### PR TITLE
Check that 'iptables -w' is supported before using it

### DIFF
--- a/weaver/weave
+++ b/weaver/weave
@@ -49,9 +49,16 @@ create_bridge() {
 }
 
 add_nat_rule() {
-    if ! iptables -w -t nat -C $1 >/dev/null 2>&1
+    if [ -z "$CHECKED_IPTABLES_W" ] ; then
+        if iptables -S -w >/dev/null 2>&1 ; then
+            IPTABLES_W=-w
+        fi
+        CHECKED_IPTABLES_W=1
+    fi
+
+    if ! iptables $IPTABLES_W -t nat -C $1 >/dev/null 2>&1
     then
-        iptables -w -t nat -A $1 >/dev/null
+        iptables $IPTABLES_W -t nat -A $1 >/dev/null
     fi
 }
 


### PR DESCRIPTION
To fix #24:

'-w' was only introduced in a recent version of iptables.  It means
"Wait for the xtables lock", so it seems reasonable to proceed without
it for older versions.
