### PR TITLE
Add attach command to weave.

### DIFF
--- a/weaver/weave
+++ b/weaver/weave
@@ -5,6 +5,7 @@ usage() {
     echo "Usage:"
     echo "weave launch <ipaddr>/<subnet> [-passwd <passwd>] <peer_host> ..."
     echo "weave run    <ipaddr>/<subnet> <docker run args> ..."
+    echo "weave attach <ipaddr>/<subnet> <container_id>"
     echo "weave expose <ipaddr>/<subnet>"
     echo "weave hide   <ipaddr>/<subnet>"
     echo "weave status"
@@ -129,6 +130,13 @@ case "$COMMAND" in
         create_bridge
         CONTAINER=$(docker run -d "$@")
         echo $CONTAINER
+        IFACE=$CONTAINER_IFNAME
+        ;;
+    attach)
+        [ $# -gt 1 ] || usage
+        IPADDR=$1
+        create_bridge
+        CONTAINER=$2
         IFACE=$CONTAINER_IFNAME
         ;;
     expose)


### PR DESCRIPTION
Sometimes containers are created by remote api calls. And `weave run` doesn't cover all the cases to create a container. It will be useful to attach an ip to an existing container.

This PL added an attach command to weave. The patch is quite simple. Just reuse existing code by set ip address and container id to the arguments from the cli.
