### PR TITLE
tag published image with git revision

### DIFF
--- a/weaver/Makefile
+++ b/weaver/Makefile
@@ -14,7 +14,7 @@ docker-image: /tmp/weave.tar
 	sudo docker save zettio/weave > /tmp/weave.tar
 
 publish: docker-image
-	sudo docker tag zettio/weave:latest zettio/weave:git-`git rev-parse --short=12 HEAD`
+	sudo docker tag zettio/weave zettio/weave:git-`git rev-parse --short=12 HEAD`
 	sudo docker push zettio/weave
 
 clean:


### PR DESCRIPTION
Pending a process to assign major/minor version numbers, this is implemented by having the makefile embed the build date.  Addresses #10
This change also puts the version info and command-line arguments used to start the router at the top of its logfile, which will be useful when trying to understand what happened on someone else's system.
