### PR TITLE
Clean up network on failure

### DIFF
--- a/weaver/weave
+++ b/weaver/weave
@@ -121,6 +121,7 @@ configure_container_networking() {
     LOCAL_IFNAME="v${CONTAINER_IFNAME}pl${NSPID}"
     GUEST_IFNAME="v${CONTAINER_IFNAME}pg${NSPID}"
     IP_TMPFILE=/tmp/weave_ip_output_$$
+    rm -f $IP_TMPFILE
     if ip link add name $LOCAL_IFNAME mtu $MTU type veth peer name $GUEST_IFNAME mtu $MTU >$IP_TMPFILE 2>&1 ; then
         if  (ip link set $LOCAL_IFNAME master $BRIDGE &&
             ip link set $LOCAL_IFNAME up &&


### PR DESCRIPTION
Remove veth and/or netns symlink if interface configuration fails part-way through.
One common cause of such failures is that the container itself has exited, as described in #61.

The change consists of using either 'if' or '&&' to avoid 'set -e' terminating the script on first failure, then carrying the real success/failure status in EXITCODE.

Once we have managed to attach the veth interface to the container's netns, it will go away when the container exits, so at that point we don't need to clean it up ourselves.
