### PR TITLE
Add new attach command for existing containers

### DIFF
--- a/weaver/weave
+++ b/weaver/weave
@@ -5,6 +5,7 @@ usage() {
     echo "Usage:"
     echo "weave launch <ipaddr>/<subnet> [-passwd <passwd>] <peer_host> ..."
     echo "weave run    <ipaddr>/<subnet> <docker run args> ..."
+    echo "weave attach <ipaddr>/<subnet> <docker container id"
     echo "weave expose <ipaddr>/<subnet>"
     echo "weave hide   <ipaddr>/<subnet>"
     echo "weave status"
@@ -225,6 +226,15 @@ case "$COMMAND" in
         CONTAINER=$(docker run -d "$@")
         configure_container_networking $CONTAINER $IPADDR $CONTAINER_IFNAME
         echo $CONTAINER
+        ;;
+    attach)
+        [ $# -gt 0 ] || usage
+        IPADDR=$1
+        shift 1
+        CONTAINER=$1
+        shift 1
+        create_bridge
+        configure_container_networking $CONTAINER $IPADDR $CONTAINER_IFNAME
         ;;
     expose)
         [ $# -gt 0 ] || usage


### PR DESCRIPTION
Allows containers created using orchestration tools like [Clocker](clocker.io) or via the [jclouds](https://github.com/jclouds/jclouds-labs/blob/master/docker/) driver to be added to the weave network.
