### PR TITLE
Attempt re-connection immediately when notified of a broken connection

### DIFF
--- a/connection_maker.go
+++ b/connection_maker.go
@@ -78,6 +78,7 @@ func (cm *ConnectionMaker) queryLoop(queryChan <-chan *ConnectionMakerInteractio
 					target.tryAfter, target.tryInterval = tryAfter(target.tryInterval)
 				}
 				cm.checkStateAndAttemptConnections(time.Now())
+				maybeTick()
 			default:
 				log.Fatal("Unexpected connection maker query:", query)
 			}


### PR DESCRIPTION
Jump straight into the routine that looks to see what can be re-tried, instead of waiting for a tick.
Addresses #28 
