### PR TITLE
change -passwd to -password in usage function

### DIFF
--- a/weaver/weave
+++ b/weaver/weave
@@ -3,7 +3,7 @@ set -e
 
 usage() {
     echo "Usage:"
-    echo "weave launch <ipaddr>/<subnet> [-passwd <passwd>] <peer_host> ..."
+    echo "weave launch <ipaddr>/<subnet> [-password <password>] <peer_host> ..."
     echo "weave run    <ipaddr>/<subnet> <docker run args> ..."
     echo "weave attach <ipaddr>/<subnet> <container_id>"
     echo "weave detach <ipaddr>/<subnet> <container_id>"


### PR DESCRIPTION
A tiny change to the usage output.

It was talking about -passwd but [main.go](https://github.com/binocarlos/weave/blob/master/weaver/main.go#L76) uses -password.

I was reading the output of `weave help` and getting confused why -passwd was not working :)
