### PR TITLE
Route multicast packets across the weave network

### DIFF
--- a/weaver/weave
+++ b/weaver/weave
@@ -174,6 +174,10 @@ attach() {
         fi
     fi
 
+    # Route multicast packets across the weave network.  This will fail
+    # if the route is already present.
+    ip netns exec $NSPID ip route add 224.0.0.0/4 dev $CONTAINER_IFNAME >/dev/null 2>&1 || true
+
     container_netns_postamble $1
 
     return $EXITCODE


### PR DESCRIPTION
Add a route to send multicast packets to ethwe and so across the weave
network.

Without that, multicast packets get sent to the default route, i.e.
to docker's eth0 interface, rather than across the weave network.
So IP multicast doesn't work between containers on different hosts,
even though weaver supports it.
