### PR TITLE
Route multicast packets across the weave network

### DIFF
--- a/weaver/weave
+++ b/weaver/weave
@@ -102,6 +102,7 @@ stop_masquerading() {
     run_iptables -t nat -X WEAVE >/dev/null 2>&1 || true
 }
 
+# the following borrows from https://github.com/jpetazzo/pipework
 with_container_netns () {
     CONTAINER="$2"
     CONTAINER_PID=$(docker inspect --format='{{ .State.Pid }}' $CONTAINER)


### PR DESCRIPTION
 Add a route to send multicast packets to ethwe and so across the weave
network.

Without that, multicast packets get sent to the default route, i.e.
to docker's eth0 interface, rather than across the weave network.
So IP multicast doesn't work between containers on different hosts,
even though weaver supports it.
