### PR TITLE
A Vagrant file for developing on other-than-Linux

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,3 +21,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, :inline => "sudo go install -a -tags netgo std"
 
 end
+
+begin
+  load 'Vagrantfile.local'
+rescue LoadError
+end


### PR DESCRIPTION
This makes an Ubuntu-based vagrant image that has
- docker installed
- go tools installed
- weave dependencies installed
- $GOPATH set to ~
- the local working directory mapped as a synced folder into the
  right place in $GOPATH

So one should be able to

```
macosx:weave$ vagrant up
macosx:weave$ vagrant ssh
vagrant:~$ cd src/github.com/zettio/weave
vagrant:weave$ make -C weaver
```

In addition there's a hook for local config (create a file called `Vagrant.local` in the same place), which I use to also share the weavedns repo.
