### PR TITLE
Switched to lxc-docker (from docker.io)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 vm_ip = "172.16.0.3" # arbitrary private IP
-pkgs = "docker.io golang ethtool libpcap-dev git mercurial"
+pkgs = "lxc-docker golang ethtool libpcap-dev git mercurial"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "phusion/ubuntu-14.04-amd64"
@@ -10,6 +10,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "private_network", ip: vm_ip
 
   config.vm.synced_folder "./", "/home/vagrant/src/github.com/zettio/weave"
+
+  config.vm.provision :shell, :inline => "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+  config.vm.provision :shell, :inline => "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
 
   pkg_cmd = "apt-get update -qq; " \
   "apt-get install -q -y --force-yes --no-install-recommends "


### PR DESCRIPTION
lxc-docker is the docker-maintained package, which is rather more
current than the Ubuntu one.
