### PR TITLE
remove explicit multicast detection

### DIFF
--- a/router/ethernet_decoder.go
+++ b/router/ethernet_decoder.go
@@ -67,22 +67,12 @@ func (dec *EthernetDecoder) formICMPMTUPacket(mtu int) ([]byte, error) {
 
 var (
 	// see http://en.wikipedia.org/wiki/Multicast_address#Ethernet
-	broadcastMAC, _        = net.ParseMAC("ff:ff:ff:ff:ff:ff")
-	zeroMAC, _             = net.ParseMAC("00:00:00:00:00:00")
-	stpMACPrefix           = []byte{0x01, 0x80, 0xC2, 0x00, 0x00}
-	ipv4MulticastMACPrefix = []byte{0x01, 0x00, 0x5E}
-	ipv6MulticastMACPrefix = []byte{0x33, 0x33}
+	stpMACPrefix = []byte{0x01, 0x80, 0xC2, 0x00, 0x00}
+	zeroMAC, _   = net.ParseMAC("00:00:00:00:00:00")
 )
 
 func (dec *EthernetDecoder) DropFrame() bool {
 	return bytes.Equal(stpMACPrefix, dec.eth.DstMAC[:len(stpMACPrefix)])
-}
-
-func (dec *EthernetDecoder) BroadcastFrame() bool {
-	return bytes.Equal(broadcastMAC, dec.eth.DstMAC) ||
-		// treat multicast frames as broadcast
-		bytes.Equal(ipv4MulticastMACPrefix, dec.eth.DstMAC[:len(ipv4MulticastMACPrefix)]) ||
-		bytes.Equal(ipv6MulticastMACPrefix, dec.eth.DstMAC[:len(ipv6MulticastMACPrefix)])
 }
 
 func (dec *EthernetDecoder) IsPMTUVerify() bool {

--- a/router/router.go
+++ b/router/router.go
@@ -124,7 +124,8 @@ func (router *Router) handleCapturedPacket(frameData []byte, dec *EthernetDecode
 	frameLen := len(frameData)
 	frameCopy := make([]byte, frameLen, frameLen)
 	copy(frameCopy, frameData)
-	if !found || dec.BroadcastFrame() {
+
+	if !found {
 		return checkFrameTooBig(router.Ourself.Broadcast(df, frameCopy, dec))
 	} else {
 		return checkFrameTooBig(router.Ourself.Forward(dstPeer, df, frameCopy, dec))
@@ -287,7 +288,7 @@ func (router *Router) handleUDPPacketFunc(dec *EthernetDecoder, po PacketSink) F
 		checkWarn(po.WritePacket(frame))
 
 		dstPeer, found = router.Macs.Lookup(dec.eth.DstMAC)
-		if !found || dec.BroadcastFrame() || dstPeer != router.Ourself {
+		if !found || dstPeer != router.Ourself {
 			return checkFrameTooBig(router.Ourself.RelayBroadcast(srcPeer, df, frame, dec), srcPeer)
 		}
 


### PR DESCRIPTION
We don't need. Multicast addresses never appear as sources and hence
never end up in the peer_cache. And the router always broadcasts
frames with destination addresses that aren't in the peer cache.
