### PR TITLE
make DNS work when docker is running with --icc=false

### DIFF
--- a/weave
+++ b/weave
@@ -358,7 +358,7 @@ case "$COMMAND" in
         shift 1
         check_not_running $DNS_CONTAINER_NAME $DNS_IMAGE
         create_bridge
-        CONTAINER=$(docker run --privileged -d --name=$DNS_CONTAINER_NAME -v /var/run/docker.sock:/var/run/docker.sock $DNS_IMAGE "$@" | tail -n 1)
+        CONTAINER=$(docker run --privileged -d --name=$DNS_CONTAINER_NAME --expose=53/udp -v /var/run/docker.sock:/var/run/docker.sock $DNS_IMAGE "$@" | tail -n 1)
         with_container_netns $CONTAINER attach $CIDR >/dev/null
         echo $CONTAINER
         ;;
@@ -396,7 +396,7 @@ case "$COMMAND" in
         CIDR=$1
         shift 1
         create_bridge
-        DNS_ARG=$(docker inspect --format '--dns {{ .NetworkSettings.IPAddress }}' $DNS_CONTAINER_NAME 2>/dev/null) || true
+        DNS_ARG=$(docker inspect --format '--dns {{ .NetworkSettings.IPAddress }}'" --link $DNS_CONTAINER_NAME:$DNS_CONTAINER_NAME" $DNS_CONTAINER_NAME 2>/dev/null) || true
         CONTAINER=$(docker run $DNS_ARG -d "$@" | tail -n 1)
         with_container_netns $CONTAINER attach $CIDR >/dev/null
         tell_dns PUT $CONTAINER $CIDR


### PR DESCRIPTION
1) expose the DNS port from the weavedns container
2) link all application containers to the weavedns container

Fixes #141
