### PR TITLE
Supply a --dns-search to blank the inherited resolv.conf search

### DIFF
--- a/weave
+++ b/weave
@@ -397,7 +397,17 @@ case "$COMMAND" in
         shift 1
         create_bridge
         DNS_ARG=$(docker inspect --format '--dns {{ .NetworkSettings.IPAddress }}'" --link $DNS_CONTAINER_NAME:$DNS_CONTAINER_NAME" $DNS_CONTAINER_NAME 2>/dev/null) || true
-        CONTAINER=$(docker run $DNS_ARG -d "$@" | tail -n 1)
+        DNS_SEARCH_ARG="--dns-search=."
+        for arg in $@; do
+           case $arg in
+               --dns-search=*)
+                   DNS_SEARCH_ARG=""
+                   ;;
+               *)
+                   ;;
+           esac;
+        done
+        CONTAINER=$(docker run $DNS_ARG $DNS_SEARCH_ARG -d "$@" | tail -n 1)
         with_container_netns $CONTAINER attach $CIDR >/dev/null
         tell_dns PUT $CONTAINER $CIDR
         echo $CONTAINER


### PR DESCRIPTION
In the absence of _either_ a `--dns` or `--dns-search` argument,
Docker will write a `/etc/resolv.conf` based on the host's. Since, in
general, we rely on the DNS search path being empty (so that the
resolver uses the local domain), we want to blank the
`/etc/resolv.conf` by providing `--dns-search=.` when running a
container.

However, if there's a `--dns-search=` in the remainder of the args,
Docker will append them to the dot, which breaks resolution. Not good.

So, we only "blank" the search path if there's no `--dns-search`
argument present already.
