### PR TITLE
Only subtree merge into gh-pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,9 +1,9 @@
 ---
-title: Weave, the Docker network
+title: weave, the Docker network
 layout: default
 ---
 
-# Weave documentation
+# weave documentation
 
  * [Introduction and example (in README)](https://github.com/zettio/weave#readme)
  * [Features](features.html)


### PR DESCRIPTION
Along with PR #180, this moves the site sources to master branch. A script for doing the subtree merge from master back into gh-pages (to be published on Github pages), is supplied in `bin/update-gh-pages` and described in the `README.md`.
