### PR TITLE
Extra check for duplicate connection

### DIFF
--- a/router/connection.go
+++ b/router/connection.go
@@ -345,10 +345,8 @@ func (conn *LocalConnection) handshake(acceptNewPeer bool) error {
 			return fmt.Errorf("Found unknown remote name: %s at %s", name, conn.remoteTCPAddr)
 		}
 	}
-	if existingConn, found := conn.local.ConnectionTo(name); found {
-		if existingConn.Established() {
-			return fmt.Errorf("Already have connection to %s at %s", name, existingConn.RemoteTCPAddr())
-		}
+	if existingConn, found := conn.local.ConnectionTo(name); found && existingConn.Established() {
+		return fmt.Errorf("Already have connection to %s at %s", name, existingConn.RemoteTCPAddr())
 	}
 
 	uidStr, err := checkHandshakeStringField("UID", "", handshakeRecv)


### PR DESCRIPTION
Add check during initial connection handshake to see whether we already have an established connection to this peer, and reject the new connection if so.

Concern: is it possible that two peers, connecting at the same time, will each consider the other connection to be established, and thus drop both?  No, since 'established' is not set until after a heartbeat has passed in one direction and a ProtocolConnectionEstablished message passed in the other, which cannot happen if the connection is rejected during handshake.

It is possible that neither side rejects the new connection during handshake, in which case the duplicate will be detected in Peer.AddConnection(), and that test has a tie-breaker so both sides will make the same choice.
