### PR TITLE
Populate DNS when starting the weaveDNS container

### DIFF
--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/miekg/dns"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -26,6 +27,15 @@ func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,
 }
 
 func ListenHttp(domain string, db Zone, port int) {
+
+	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		} else {
+			io.WriteString(w, "ok")
+		}
+	})
+
 	http.HandleFunc("/name/", func(w http.ResponseWriter, r *http.Request) {
 
 		reqError := func(msg string, logmsg string, logargs ...interface{}) {

--- a/weave
+++ b/weave
@@ -317,6 +317,17 @@ tell_dns() {
 # Tell the newly-started weaveDNS about existing weave IPs
 populate_dns() {
     DNS_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $DNS_CONTAINER_NAME)
+    WAIT_TIME=1
+    while ! http_call_ip $DNS_IP $DNS_HTTP_PORT GET /status >/dev/null && [ $WAIT_TIME -lt 4 ]; do
+        echo "Waiting for weaveDNS container to start" >&2
+        sleep $WAIT_TIME
+        WAIT_TIME=$((WAIT_TIME+1))
+    done
+    if [ $WAIT_TIME = 4 ]; then
+        echo "Timed out waiting for weaveDNS container to start." >&2
+        echo "If running, it will not be pre-populated." >&2
+    fi
+
     for CONTAINER in $(docker ps -q); do
         MORE_ARGS=$(docker inspect --format '--data-urlencode local_ip={{ .NetworkSettings.IPAddress }} --data-urlencode fqdn={{ .Config.Hostname }}.{{ .Config.Domainname }}.' $CONTAINER 2>/dev/null) && true
         if CONTAINER_ADDRS=$(with_container_netns $CONTAINER container_weave_addrs 2>&1) ; then


### PR DESCRIPTION
This changes `./weave` so that when the weaveDNS container is started, the script looks for all the containers with weave addresses, and tells the weaveDNS about them. This means weaveDNS can be (re)started after other containers and still resolve their names.

I decided it would be simpler to use the existing HTTP endpoint rather than add a bulk-update endpoint, because the latter would require some encoding of the container IDs, hostnames and IPs, and that would be a terrible pain to do in shell script. We might want to revisit that if we ever rewrite `./weave`.
