### PR TITLE
Set 'Unsafe' flag on dns.Server to allow it to handle response messages

### DIFF
--- a/nameserver/mdns_client.go
+++ b/nameserver/mdns_client.go
@@ -48,7 +48,9 @@ type inflightQuery struct {
 }
 
 type MDNSClient struct {
-	server    *dns.Server
+	// note unorthodox use of 'Server' class in client logic - using it to
+	// listen on a multicast socket and call callback whenever a message comes in.
+	listener  *dns.Server
 	conn      *net.UDPConn
 	addr      *net.UDPAddr
 	inflight  map[string]*inflightQuery
@@ -85,8 +87,8 @@ func (c *MDNSClient) Start(ifi *net.Interface) error {
 		}
 	}
 
-	c.server = &dns.Server{Unsafe: true, PacketConn: multicast, Handler: dns.HandlerFunc(handleMDNS)}
-	go c.server.ActivateAndServe()
+	c.listener = &dns.Server{Unsafe: true, PacketConn: multicast, Handler: dns.HandlerFunc(handleMDNS)}
+	go c.listener.ActivateAndServe()
 
 	queryChan := make(chan *MDNSInteraction, MailboxSize)
 	c.queryChan = queryChan
@@ -177,7 +179,7 @@ func (c *MDNSClient) queryLoop(queryChan <-chan *MDNSInteraction) {
 			}
 			switch query.code {
 			case CShutdown:
-				c.server.Shutdown()
+				c.listener.Shutdown()
 				terminate = true
 			case CSendQuery:
 				c.handleSendQuery(query.payload.(mDNSQueryInfo))

--- a/nameserver/mdns_server_test.go
+++ b/nameserver/mdns_server_test.go
@@ -61,9 +61,9 @@ func TestServerSimpleQuery(t *testing.T) {
 		}
 	}
 
-	server := &dns.Server{Unsafe: true, PacketConn: multicast, Handler: dns.HandlerFunc(handleMDNS)}
-	go server.ActivateAndServe()
-	defer server.Shutdown()
+	listener := &dns.Server{Unsafe: true, PacketConn: multicast, Handler: dns.HandlerFunc(handleMDNS)}
+	go listener.ActivateAndServe()
+	defer listener.Shutdown()
 
 	time.Sleep(100 * time.Millisecond) // Allow for server to get going
 


### PR DESCRIPTION
As part of the multicast-dns client, we use a dns.Server object to listen for replies.  We need to use a new flag 'Unsafe', recently added, in order to have this carry on working. 

This is to fix #187 

(Thanks for the flag, @miekg!)
