### PR TITLE
Make weaveDNS use the docker bridge IP instead of its own

### DIFF
--- a/weave
+++ b/weave
@@ -46,6 +46,7 @@ MTU=65535
 PORT=6783
 HTTP_PORT=6784
 DNS_HTTP_PORT=6785
+DOCKER_BRIDGE=${DOCKER_BRIDGE:-docker0}
 
 COMMAND=$1
 
@@ -137,6 +138,11 @@ destroy_bridge() {
     run_iptables -t nat -F WEAVE >/dev/null 2>&1 || true
     run_iptables -t nat -D POSTROUTING -j WEAVE >/dev/null 2>&1 || true
     run_iptables -t nat -X WEAVE >/dev/null 2>&1 || true
+}
+
+docker_bridge_ip() {
+    DOCKER_BRIDGE_IP=$(ip -4 addr show dev $DOCKER_BRIDGE | grep -m1 -o 'inet [.0-9]*')
+    DOCKER_BRIDGE_IP=${DOCKER_BRIDGE_IP#inet }
 }
 
 # the following borrows from https://github.com/jpetazzo/pipework
@@ -372,7 +378,8 @@ case "$COMMAND" in
         shift 1
         check_not_running $DNS_CONTAINER_NAME $DNS_IMAGE
         create_bridge
-        CONTAINER=$(docker run --privileged -d --name=$DNS_CONTAINER_NAME -v /var/run/docker.sock:/var/run/docker.sock $DNS_IMAGE "$@" | tail -n 1)
+        docker_bridge_ip
+        CONTAINER=$(docker run --privileged -d --name=$DNS_CONTAINER_NAME -p $DOCKER_BRIDGE_IP:53:53/udp -v /var/run/docker.sock:/var/run/docker.sock $DNS_IMAGE "$@" | tail -n 1)
         with_container_netns $CONTAINER attach $CIDR >/dev/null
         echo $CONTAINER
         ;;
@@ -408,7 +415,8 @@ case "$COMMAND" in
         [ $# -gt 0 ] || usage
         if [ "$1" = "--with-dns" ] ; then
             shift 1
-            DNS_ARG=$(docker inspect --format '--dns {{ .NetworkSettings.IPAddress }}'" --link $DNS_CONTAINER_NAME:$DNS_CONTAINER_NAME" $DNS_CONTAINER_NAME 2>/dev/null) || true
+            docker_bridge_ip
+            DNS_ARG="--dns $DOCKER_BRIDGE_IP"
             DNS_SEARCH_ARG="--dns-search=."
             for arg in $@; do
                 case $arg in

--- a/weavedns/README.md
+++ b/weavedns/README.md
@@ -24,9 +24,9 @@ $ docker attach $shell1
 ...
 ```
 
-The IP address supplied to `weave launch-dns` must not be used by any
-other container, and the supplied network must contain all application
-networks.
+The weave IP address supplied to `weave launch-dns` must not be used
+by any other container, and the supplied network must contain all
+application networks.
 
 ## Domain search paths
 
@@ -51,23 +51,45 @@ supply the DNS server address to the new container. And both
 container against the given weave network IP address.
 
 In some circumstances, you may not want to use the `weave`
-command. You can still take advantage of a running weaveDNS, using the
-HTTP API.
+command. You can still take advantage of a running weaveDNS, with some
+extra manual steps.
+
+### Using a different docker bridge
+
+So that containers can connect to a stable and always routable IP
+address, weaveDNS publishes its port 53 to the Docker bridge device,
+which is assumed to be `docker0`.
+
+Some configurations will use a different Docker bridge device. To
+supply a different bridge device, use the environment variable
+`DOCKER_BRIDGE`, e.g.,
+
+```bash
+$ sudo DOCKER_BRIDGE=someother weave launch-dns 10.0.1.2/16
+```
 
 ### Supplying the DNS server
 
 If you want to start containers with `docker run` rather than `weave
-run`, you can supply the weaveDNS IP as the `--dns` option to make it
-use weaveDNS:
+run`, you can supply the docker bridge IP as the `--dns` option to
+make it use weaveDNS:
 
 ```bash
-$ dns_ip=$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' weavedns)
-$ shell2=$(docker run --dns=$dns_ip -ti ubuntu)
+$ docker_ip=$(docker inspect --format='{{ .NetworkSettings.Gateway }}' weavedns)
+$ shell2=$(docker run --dns=$docker_ip -ti ubuntu)
 $ weave attach 10.1.1.27/24 $shell2
 ```
 
 This isn't very useful unless the container is also attached to the
 weave network (as in the last line above).
+
+Also note that this means of finding the Docker bridge's IP address
+requires a running container (any one would do); another way to find
+it is:
+
+```bash
+$ docker_ip=$(ip -4 addr show dev docker0 | grep -o 'inet [0-9.]*' | cut -d ' ' -f 2)
+```
 
 ### Supplying the domain search path
 


### PR DESCRIPTION
This means the `--dns` setting for containers will work even if the weavedns container is restarted (and assigned a new docker network IP).

_NB_ this is only used if the `--with-dns` argument is given to `weave run`.
