### PR TITLE
stop on 'docker run' errors

### DIFF
--- a/weave
+++ b/weave
@@ -385,7 +385,7 @@ uname -s -r | sed -n 's|^\([^ ]*\) \([0-9]\+\)\.\([0-9]\+\).*|\1 \2 \3|p' | {
     fi
 }
 
-if ! DOCKER_VERSION=$(docker --version | sed -n 's|^Docker version \([0-9]\+\.[0-9]\+.[0-9]\+\),.*|\1|p') || [ -z "$DOCKER_VERSION" ] ; then
+if ! DOCKER_VERSION=$(docker -v | sed -n 's|^Docker version \([0-9]\+\.[0-9]\+.[0-9]\+\),.*|\1|p') || [ -z "$DOCKER_VERSION" ] ; then
     echo "ERROR: Unable to parse docker version" >&2
     exit 1
 fi


### PR DESCRIPTION
This broke due to our workaround for
https://github.com/docker/docker/issues/8632, which affects Docker
version 1.3.0 only, so now we refuse to run with that.

Fixes #233.
