### PR TITLE
Cope with duplicate name->IP entries

### DIFF
--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -61,15 +61,12 @@ func ListenHttp(domain string, db Zone, port int) {
 			if dns.IsSubDomain(domain, name) {
 				Info.Printf("Adding %s -> %s", name, ipStr)
 				if err = db.AddRecord(ident, name, ip); err != nil {
-					if dup, ok := err.(DuplicateError); !ok {
+					if _, ok := err.(DuplicateError); !ok {
 						httpErrorAndLog(
 							Error, w, "Internal error", http.StatusInternalServerError,
 							"Unexpected error from DB: %s", err)
 						return
-					} else if dup.Ident != ident {
-						http.Error(w, err.Error(), http.StatusConflict)
-						return
-					} // else we are golden
+					} // oh, I already know this. whatever.
 				}
 			} else {
 				Info.Printf("Ignoring name %s, not in %s", name, domain)

--- a/nameserver/testing_utils.go
+++ b/nameserver/testing_utils.go
@@ -19,7 +19,7 @@ func assertStatus(t *testing.T, got int, wanted int, desc string) {
 
 func assertErrorInterface(t *testing.T, got interface{}, wanted interface{}, desc string) {
 	if got == nil {
-		t.Fatalf("Expected %s but got nil", reflect.TypeOf(wanted).Elem())
+		t.Fatalf("Expected %s but got nil (%s)", reflect.TypeOf(wanted).Elem(), desc)
 	}
 	gotT, wantedT := reflect.TypeOf(got), reflect.TypeOf(wanted).Elem()
 	if !gotT.Implements(wantedT) {
@@ -29,7 +29,7 @@ func assertErrorInterface(t *testing.T, got interface{}, wanted interface{}, des
 
 func assertErrorType(t *testing.T, got interface{}, wanted interface{}, desc string) {
 	if got == nil {
-		t.Fatalf("Expected %s but got nil", reflect.TypeOf(wanted).Elem())
+		t.Fatalf("Expected %s but got nil (%s)", reflect.TypeOf(wanted).Elem(), desc)
 	}
 	gotT, wantedT := reflect.TypeOf(got), reflect.TypeOf(wanted).Elem()
 	if gotT != wantedT {

--- a/nameserver/zone_test.go
+++ b/nameserver/zone_test.go
@@ -7,9 +7,10 @@ import (
 
 func TestZone(t *testing.T) {
 	var (
-		containerID     = "deadbeef"
-		successTestName = "test1.weave."
-		testAddr1       = "10.0.2.1/24"
+		containerID      = "deadbeef"
+		otherContainerID = "cowjuice"
+		successTestName  = "test1.weave."
+		testAddr1        = "10.0.2.1/24"
 	)
 
 	var zone = new(ZoneDb)
@@ -40,12 +41,18 @@ func TestZone(t *testing.T) {
 		t.Fatal("Unexpected result for", ip, foundName)
 	}
 
-	// Now try to add the same address again
 	err = zone.AddRecord(containerID, successTestName, ip)
 	assertErrorType(t, err, (*DuplicateError)(nil), "duplicate add")
 
-	// Now delete the record
+	err = zone.AddRecord(otherContainerID, successTestName, ip)
+	// Delete the record for the original container
 	err = zone.DeleteRecord(containerID, ip)
+	assertNoErr(t, err)
+
+	_, err = zone.LookupLocal(successTestName)
+	assertNoErr(t, err)
+
+	err = zone.DeleteRecord(otherContainerID, ip)
 	assertNoErr(t, err)
 
 	// Check that the address is not there now.
@@ -59,10 +66,10 @@ func TestZone(t *testing.T) {
 
 func TestDeleteFor(t *testing.T) {
 	var (
-		id       = "foobar"
-		name     = "foo.weave."
-		addr1    = "10.1.2.3/24"
-		addr2    = "10.2.7.8/24"
+		id    = "foobar"
+		name  = "foo.weave."
+		addr1 = "10.1.2.3/24"
+		addr2 = "10.2.7.8/24"
 	)
 	zone := new(ZoneDb)
 	for _, addr := range []string{addr1, addr2} {


### PR DESCRIPTION
The zone DB no longer considers duplicates of (IP, name); it will
reject duplicates of (IP, name, ident), but this ultimately doesn't
matter since those are all the fields it records anyway.

The HTTP interface treats these duplicates as trivial success (i.e.,
it acts as if it's idempotent, which it is).

This changes the behaviour for removals: if (IP, name) is recorded for
two different containers, removing one will leave the other extant.

Closes #249.
