### PR TITLE
Move call to Topology.RebuildRoutes

### DIFF
--- a/router/connection.go
+++ b/router/connection.go
@@ -492,6 +492,7 @@ func (conn *LocalConnection) receiveTCP(decoder *gob.Decoder, usingPassword bool
 			if len(newUpdate) == 0 {
 				continue
 			}
+			conn.Router.Topology.RebuildRoutes()
 			conn.local.BroadcastTCP(Concat(ProtocolUpdateByte, newUpdate))
 		} else if msg[0] == ProtocolPMTUVerified {
 			conn.verifyPMTU <- int(binary.BigEndian.Uint16(msg[1:]))

--- a/router/peer.go
+++ b/router/peer.go
@@ -358,13 +358,13 @@ func (peer *Peer) handleConnectionEstablished(conn *LocalConnection) {
 }
 
 func (peer *Peer) handleBroadcastTCP(msg []byte) {
-	peer.Router.Topology.RebuildRoutes()
 	peer.ForEachConnection(func(_ PeerName, conn Connection) {
 		conn.(*LocalConnection).SendTCP(msg)
 	})
 }
 
 func (peer *Peer) broadcastPeerUpdate(peers ...*Peer) {
+	peer.Router.Topology.RebuildRoutes()
 	peer.handleBroadcastTCP(Concat(ProtocolUpdateByte, EncodePeers(append(peers, peer)...)))
 }
 


### PR DESCRIPTION
It doesn't belong in handleBroadcastTCP(), so I moved it up to the two places that cause that function to be called.

Closes #258
