### PR TITLE
do not log password

### DIFF
--- a/weaver/main.go
+++ b/weaver/main.go
@@ -22,7 +22,6 @@ func main() {
 
 	log.SetPrefix(weave.Protocol + " ")
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
-	log.Println(os.Args)
 
 	procs := runtime.NumCPU()
 	// packet sniffing can block an OS thread, so we need one thread
@@ -54,6 +53,17 @@ func main() {
 	flag.IntVar(&bufSz, "bufsz", 8, "capture buffer size in MB (defaults to 8MB)")
 	flag.Parse()
 	peers = flag.Args()
+
+	options := make(map[string]string)
+	flag.Visit(func (f *flag.Flag) {
+		value := f.Value.String()
+		if f.Name == "password" {
+			value = "<elided>"
+		}
+		options[f.Name] = value
+	})
+	log.Println("Command line options:", options)
+	log.Println("Command line peers:", peers)
 
 	if ifaceName == "" {
 		fmt.Println("Missing required parameter 'iface'")


### PR DESCRIPTION
This is trickier than it may first appear. We can't just filter the
password from os.Args, since that would require recreating the flag
parsing logic, which allows flags to be specified in a wide variety of
formats. And there is no API for calling that logic either.

So instead we log the results of the flag parsing, eliding the
password, and using a straight golang map for formatting (so we don't
have to get creative).

Closes #275.
