### PR TITLE
Support detaching on containers created in container networking mode.

### DIFF
--- a/weave
+++ b/weave
@@ -270,7 +270,7 @@ detach() {
     fi
 
     # Deleting the interface will delete the multicast route we set up
-    ip link del $LOCAL_IFNAME type veth
+    ip netns exec $NETNS ip link del $CONTAINER_IFNAME type veth
 }
 
 # Call url $4 with http verb $3 on container $1 at port $2


### PR DESCRIPTION
Related to #302, #303. When the containers are started with `--net=container:...`, weave will get confused when detaching too. Rather than deleting the local interface on the host end, we delete the expected interface inside the container. 
