### PR TITLE
align script and image versions

### DIFF
--- a/weave
+++ b/weave
@@ -41,8 +41,10 @@ fi
 
 IMAGE_VERSION=${VERSION:-$IMAGE_VERSION}
 
-IMAGE=zettio/weave:$IMAGE_VERSION
-DNS_IMAGE=zettio/weavedns:$IMAGE_VERSION
+BASE_IMAGE=zettio/weave
+BASE_DNS_IMAGE=zettio/weavedns
+IMAGE=$BASE_IMAGE:$IMAGE_VERSION
+DNS_IMAGE=$BASE_DNS_IMAGE:$IMAGE_VERSION
 CONTAINER_NAME=weave
 DNS_CONTAINER_NAME=weavedns
 BRIDGE=weave
@@ -366,7 +368,14 @@ check_not_running() {
             echo "$1 is already running." >&2
             exit 1
             ;;
+        "true $2:"*)
+            echo "$1 is already running." >&2
+            exit 1
+            ;;
         "false $2")
+            docker rm $1 >/dev/null
+            ;;
+        "false $2:"*)
             docker rm $1 >/dev/null
             ;;
         true*)
@@ -437,7 +446,7 @@ DOCKER_VERSION_PATCH=$(echo "$DOCKER_VERSION" | cut -d. -f 3)
 
 case "$COMMAND" in
     launch)
-        check_not_running $CONTAINER_NAME $IMAGE
+        check_not_running $CONTAINER_NAME $BASE_IMAGE
         create_bridge
         # We set the router name to the bridge mac since that is
         # stable across re-creations of the containers.
@@ -474,7 +483,7 @@ case "$COMMAND" in
         [ $# -gt 0 ] || usage
         CIDR=$1
         shift 1
-        check_not_running $DNS_CONTAINER_NAME $DNS_IMAGE
+        check_not_running $DNS_CONTAINER_NAME $BASE_DNS_IMAGE
         create_bridge
         docker_bridge_ip
         DNS_CONTAINER=$(docker run --privileged -d --name=$DNS_CONTAINER_NAME \


### PR DESCRIPTION
- released weave scripts run their corresponding image versions
- unreleased weave scripts run the 'latest'-tagged image versions

Released versions of the script will always download the corresponding image if it does not exist locally yet, thus preventing version mismatches.

The image version to run can also be specified explicitly by setting
VERSION. Useful for testing, mainly.

Closes #34. Also closes #255.
