### PR TITLE
lower topology periodic gossip complexity

### DIFF
--- a/router/consts.go
+++ b/router/consts.go
@@ -16,10 +16,10 @@ const (
 	UDPNonceSendAt      = 8192
 	FragTestSize        = 60001
 	PMTUDiscoverySize   = 60000
+	TCPHeartbeat        = 30 * time.Second
 	FastHeartbeat       = 500 * time.Millisecond
 	SlowHeartbeat       = 10 * time.Second
 	FragTestInterval    = 5 * time.Minute
-	ReadTimeout         = 1 * time.Minute
 	PMTUVerifyAttempts  = 8
 	PMTUVerifyTimeout   = 10 * time.Millisecond // gets doubled with every attempt
 	MaxDuration         = time.Duration(math.MaxInt64)

--- a/router/gossip.go
+++ b/router/gossip.go
@@ -105,7 +105,7 @@ func (router *Router) NewGossip(channelName string, g Gossiper) Gossip {
 
 func (router *Router) SendAllGossip() {
 	for _, channel := range router.GossipChannels {
-		channel.Send(channel.gossiper.Gossip())
+		channel.Send(router.Ourself.Name, channel.gossiper.Gossip())
 	}
 }
 
@@ -167,7 +167,7 @@ func (c *GossipChannel) deliverBroadcast(srcName PeerName, _ []byte, dec *gob.De
 	return c.relayBroadcast(srcName, data)
 }
 
-func (c *GossipChannel) deliver(_ PeerName, _ []byte, dec *gob.Decoder) error {
+func (c *GossipChannel) deliver(srcName PeerName, _ []byte, dec *gob.Decoder) error {
 	var payload []byte
 	if err := dec.Decode(&payload); err != nil {
 		return err
@@ -175,30 +175,46 @@ func (c *GossipChannel) deliver(_ PeerName, _ []byte, dec *gob.Decoder) error {
 	if data, err := c.gossiper.OnGossip(payload); err != nil {
 		return err
 	} else if data != nil {
-		c.Send(data)
+		c.Send(srcName, data)
 	}
 	return nil
 }
 
-func (c *GossipChannel) Send(data GossipData) {
-	connections := c.ourself.Connections() // do this outside the lock so they don't nest
+func (c *GossipChannel) Send(srcName PeerName, data GossipData) {
+	// do this outside the lock below so we avoid lock nesting
+	c.ourself.Router.Routes.EnsureRecalculated()
+	selectedConnections := make(ConnectionSet)
+	for name := range c.ourself.Router.Routes.RandomNeighbours(srcName) {
+		if conn, found := c.ourself.ConnectionTo(name); found {
+			selectedConnections[conn] = void
+		}
+	}
+	if len(selectedConnections) == 0 {
+		return
+	}
+	connections := c.ourself.Connections()
 	c.Lock()
 	defer c.Unlock()
 	// GC - randomly (courtesy of go's map iterator) pick some
 	// existing entries and stop&remove them if the associated
 	// connection is no longer active.  We stop as soon as we
 	// encounter a valid entry; the idea being that when there is
-	// little or no garbage then this executes close to O(1), whereas
-	// when there is lots of garbage we remove it quickly.
+	// little or no garbage then this executes close to O(1)[1],
+	// whereas when there is lots of garbage we remove it quickly.
+	//
+	// [1] TODO Unfortunately, due to the desire to avoid nested
+	// locks, instead of simply invoking Peer.ConnectionTo(name)
+	// below, we have that Peer.Connections() invocation above. That
+	// is O(n_our_connections) at best.
 	for conn, sender := range c.senders {
-		if foundConn, found := c.ourself.ConnectionTo(conn.Remote().Name); !found || foundConn != conn {
+		if _, found := connections[conn]; !found {
 			delete(c.senders, conn)
 			sender.Stop()
 		} else {
 			break
 		}
 	}
-	for conn := range connections {
+	for conn := range selectedConnections {
 		c.sendDown(conn, data)
 	}
 }

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -8,7 +8,8 @@ const (
 type ProtocolTag byte
 
 const (
-	ProtocolConnectionEstablished ProtocolTag = iota
+	ProtocolHeartbeat ProtocolTag = iota
+	ProtocolConnectionEstablished
 	ProtocolFragmentationReceived
 	ProtocolStartFragmentationTest
 	ProtocolNonce


### PR DESCRIPTION
Instead of gossiping to all neighbours, we select up to log(n_peers) neighbours at random, based on a probability distribution that takes into account the topology, i.e. favours neighbours at the end of "bottleneck" links. The distribution is determined from the unicast topology.

Closes #517.