### PR TITLE
Implement weaveexec signal proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage.html
 # Project specific
 weaver/weaver
 weavedns/weavedns
+sigproxy/sigproxy
 tools/bin
 tools/build
 releases
@@ -39,4 +40,5 @@ weave.tar
 weavedns.tar
 weaveexec.tar
 weaveexec/weave
+weaveexec/sigproxy
 weaveexec/docker*.tgz

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ $(WEAVER_EXE) $(WEAVEDNS_EXE): common/*.go
 
 $(WEAVER_EXE): router/*.go weaver/main.go
 $(WEAVEDNS_EXE): nameserver/*.go weavedns/main.go
+
+# Sigproxy needs separate rule as it fails the netgo check in the main build stanza due to not importing net package 
 $(SIGPROXY_EXE): sigproxy/main.go
 	go build -o $@ ./$(shell dirname $@)
 

--- a/sigproxy/main.go
+++ b/sigproxy/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+func checkArguments() {
+	if len(os.Args) == 1 {
+		log.Fatal("USAGE: sigproxy <command> [arguments ...]")
+	}
+}
+
+func installSignalHandler() chan os.Signal {
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc, os.Interrupt)
+
+	return sc
+}
+
+func execCommand() *exec.Cmd {
+	// First argument is command to run, remainder are its arguments
+	cmd := exec.Command(os.Args[1], os.Args[2:]...)
+
+	// These conveniently default to /dev/null otherwise...
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	return cmd
+}
+
+func forwardSignals(sc chan os.Signal, cmd *exec.Cmd) {
+	// Unfortunately there's no way to convert the os.Signal type from
+	// the channel into a numeric signal number for syscall.Kill. Wait for
+	// (and discard) os.Interrupt, then deliver SIGINT to process group
+	<-sc
+	syscall.Kill(0, syscall.SIGINT)
+}
+
+func waitAndExit(cmd *exec.Cmd) {
+	if err := cmd.Wait(); err != nil {
+		// Exit status is platform specific so not readily accessible - casts
+		// required to access system-dependent exit information
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if waitStatus, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				os.Exit(waitStatus.ExitStatus())
+			} else {
+				os.Exit(1)
+			}
+		} else {
+			os.Exit(1)
+		}
+	} else {
+		os.Exit(0)
+	}
+}
+
+func main() {
+	checkArguments()
+	sc := installSignalHandler()
+	cmd := execCommand()
+	go forwardSignals(sc, cmd)
+	waitAndExit(cmd)
+}

--- a/sigproxy/main.go
+++ b/sigproxy/main.go
@@ -37,7 +37,7 @@ func execCommand() *exec.Cmd {
 	return cmd
 }
 
-func forwardSignals(sc chan os.Signal, cmd *exec.Cmd) {
+func forwardSignals(sc chan os.Signal) {
 	for {
 		// Signalling PID 0 delivers to our process group
 		syscall.Kill(0, (<-sc).(syscall.Signal))
@@ -66,6 +66,6 @@ func main() {
 	checkArguments()
 	sc := installSignalHandler()
 	cmd := execCommand()
-	go forwardSignals(sc, cmd)
+	go forwardSignals(sc)
 	waitAndExit(cmd)
 }

--- a/sigproxy/main.go
+++ b/sigproxy/main.go
@@ -8,24 +8,19 @@ import (
 	"syscall"
 )
 
-func checkArguments() {
+func main() {
 	if len(os.Args) == 1 {
 		log.Fatal("USAGE: sigproxy <command> [arguments ...]")
 	}
-}
 
-func installSignalHandler() chan os.Signal {
+	// Install signal handler as soon as possible - channel is buffered so
+	// we'll catch signals that arrive whilst child process is starting
 	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGINT)
+	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM)
 
-	return sc
-}
-
-func execCommand() *exec.Cmd {
-	// First argument is command to run, remainder are its arguments
 	cmd := exec.Command(os.Args[1], os.Args[2:]...)
 
-	// These conveniently default to /dev/null otherwise...
+	// These default to /dev/null, so set them explicitly to ours
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -34,38 +29,22 @@ func execCommand() *exec.Cmd {
 		log.Fatal(err)
 	}
 
-	return cmd
-}
+	// Only begin delivering signals after the child has started
+	go func() {
+		for {
+			// Signalling PID 0 delivers to our process group
+			syscall.Kill(0, (<-sc).(syscall.Signal))
+		}
+	}()
 
-func forwardSignals(sc chan os.Signal) {
-	for {
-		// Signalling PID 0 delivers to our process group
-		syscall.Kill(0, (<-sc).(syscall.Signal))
-	}
-}
-
-func waitAndExit(cmd *exec.Cmd) {
 	if err := cmd.Wait(); err != nil {
-		// Exit status is platform specific so not readily accessible - casts
+		// Exit status is platform specific so not directly accessible - casts
 		// required to access system-dependent exit information
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			if waitStatus, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				os.Exit(waitStatus.ExitStatus())
-			} else {
-				os.Exit(1)
-			}
-		} else {
-			os.Exit(1)
+			waitStatus := exitErr.Sys().(syscall.WaitStatus)
+			os.Exit(waitStatus.ExitStatus())
 		}
-	} else {
-		os.Exit(0)
+		os.Exit(1)
 	}
-}
-
-func main() {
-	checkArguments()
-	sc := installSignalHandler()
-	cmd := execCommand()
-	go forwardSignals(sc)
-	waitAndExit(cmd)
+	os.Exit(0)
 }

--- a/weave
+++ b/weave
@@ -52,7 +52,7 @@ DNS_IMAGE=$BASE_DNS_IMAGE:$IMAGE_VERSION
 EXEC_IMAGE=$BASE_EXEC_IMAGE:$IMAGE_VERSION
 
 exec_remote() {
-    docker run --sig-proxy=true --rm \
+    docker run --rm \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v "$PROCFS":/hostproc \
         -e VERSION \

--- a/weave
+++ b/weave
@@ -52,7 +52,7 @@ DNS_IMAGE=$BASE_DNS_IMAGE:$IMAGE_VERSION
 EXEC_IMAGE=$BASE_EXEC_IMAGE:$IMAGE_VERSION
 
 exec_remote() {
-    docker run -t --rm \
+    docker run --sig-proxy=true --rm \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v "$PROCFS":/hostproc \
         -e VERSION \

--- a/weaveexec/Dockerfile
+++ b/weaveexec/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /home/weave
 RUN ["apk", "add", "--update", "ethtool", "conntrack-tools", "curl", "iptables", "iproute2"]
 RUN ["sh", "-c", "rm -rf /var/cache/apk/*"]
 ADD ./weave /home/weave/
+ADD ./sigproxy /home/weave/
 ADD ./docker.tgz /
-ENTRYPOINT ["/home/weave/weave"]
+ENTRYPOINT ["/home/weave/sigproxy", "/home/weave/weave"]


### PR DESCRIPTION
Address #507 (`weave` and `weave --local` behave differently).

Introduce an intermediate signal proxying process that:

* Runs as PID 1 inside the weaveexec container
* Installs a SIGINT handler
* Forks and execs the weave script
* Redelivers inbound SIGINTs (received from `docker run --sig-proxy=true`) to its own process group, which includes the shell running the weave script and any subprocesses (such as `curl`) it is executing
* Waits for child to exit and then exits with child's exit status

As a consequence we can disable the problematic docker pseudoterminal allocation without losing the ability to interrupt the script running in the weaveexec container. 