### PR TITLE
Allow container names to be supplied to `weave ps`

### DIFF
--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -146,6 +146,12 @@ IP address/routing prefix length ([CIDR
 notation](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing))
 assigned on the weave network.
 
+You can also supply a list of container IDs/names to `weave ps`, like this:
+
+    $ sudo weave ps able baker
+    able ce:15:34:a9:b5:6d 10.2.5.1/24
+    baker 7a:61:a2:49:4b:91 10.2.8.3/24
+
 ### Reboots
 
 When a host reboots, docker's default behaviour is to restart any

--- a/weave
+++ b/weave
@@ -25,7 +25,7 @@ usage() {
     echo "weave detach     <cidr> [<cidr> ...] <container_id>"
     echo "weave expose     <cidr>"
     echo "weave hide       <cidr>"
-    echo "weave ps"
+    echo "weave ps         [<container_id> ...]"
     echo "weave status"
     echo "weave version"
     echo "weave stop"
@@ -675,8 +675,8 @@ case "$COMMAND" in
         http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status 2>/dev/null || true
         ;;
     ps)
-        [ $# -eq 0 ] || usage
-        for CONTAINER_ID in $(docker ps -q) ; do
+        [ $# -eq 0 ] && CONTAINERS="$(docker ps -q)" || CONTAINERS="$@"
+        for CONTAINER_ID in $CONTAINERS ; do
             if CONTAINER_ADDRS=$(with_container_netns $CONTAINER_ID container_weave_addrs 2>&1) ; then
                 CONTAINER_MAC=$(echo "$CONTAINER_ADDRS" | grep -o 'link/ether .*' | cut -d ' ' -f 2)
                 CONTAINER_IPS=$(echo "$CONTAINER_ADDRS" | grep -o 'inet .*'       | cut -d ' ' -f 2)


### PR DESCRIPTION
So, `weave ps` will still show you all containers, but `weave ps mycontainer` will just show you that one.

If you give a nonexistent name you get no output, which is consistent with Unix `ps`.