### PR TITLE
Fix in WeaveDNS: do not modify cache when getting a reply

### DIFF
--- a/nameserver/cache.go
+++ b/nameserver/cache.go
@@ -131,6 +131,9 @@ func (e cacheEntry) hasExpired(now time.Time) bool {
 func (e *cacheEntry) setReply(reply *dns.Msg, ttl int, flags uint8, now time.Time) bool {
 	var prevValidUntil time.Time
 	if e.Status == stResolved {
+		if reply != nil {
+			Debug.Printf("[cache msgid %d] replacing response in cache", reply.MsgHdr.Id)
+		}
 		prevValidUntil = e.validUntil
 	}
 

--- a/nameserver/cache.go
+++ b/nameserver/cache.go
@@ -22,6 +22,8 @@ const (
 	defPendingTimeout int = 5 // timeout for a resolution
 )
 
+const nullTTL = 0	// a null TTL
+
 type entryStatus uint8
 
 const (
@@ -61,24 +63,15 @@ type cacheEntry struct {
 	validUntil time.Time // obtained from the reply and stored here for convenience/speed
 	putTime    time.Time
 
-	waitChan chan struct{}
-
 	index int // for fast lookups in the heap
 }
 
-func newCacheEntry(question *dns.Question, reply *dns.Msg, status entryStatus, flags uint8, now time.Time) *cacheEntry {
+func newCacheEntry(question *dns.Question, now time.Time) *cacheEntry {
 	e := &cacheEntry{
-		Status:   status,
-		Flags:    flags,
-		question: *question,
-		index:    -1,
-	}
-
-	if e.Status == stPending {
-		e.validUntil = now.Add(time.Duration(defPendingTimeout) * time.Second)
-		e.waitChan = make(chan struct{})
-	} else {
-		e.setReply(reply, flags, now)
+		Status:     stPending,
+		validUntil: now.Add(time.Second * time.Duration(defPendingTimeout)),
+		question:   *question,
+		index:      -1,
 	}
 
 	return e
@@ -133,9 +126,7 @@ func (e cacheEntry) hasExpired(now time.Time) bool {
 
 // set the reply for the entry
 // returns True if the entry has changed the validUntil time
-func (e *cacheEntry) setReply(reply *dns.Msg, flags uint8, now time.Time) bool {
-	shouldNotify := (e.Status == stPending)
-
+func (e *cacheEntry) setReply(reply *dns.Msg, ttl int, flags uint8, now time.Time) bool {
 	var prevValidUntil time.Time
 	if e.Status == stResolved {
 		prevValidUntil = e.validUntil
@@ -145,10 +136,9 @@ func (e *cacheEntry) setReply(reply *dns.Msg, flags uint8, now time.Time) bool {
 	e.Flags = flags
 	e.putTime = now
 
-	if e.Flags&CacheNoLocalReplies != 0 {
-		// use a fixed timeout for negative local resolutions
-		e.validUntil = now.Add(time.Second * time.Duration(negLocalTTL))
-	} else {
+	if ttl != nullTTL {
+		e.validUntil = now.Add(time.Second * time.Duration(ttl))
+	} else if reply != nil {
 		// calculate the validUntil from the reply TTL
 		var minTTL uint32 = math.MaxUint32
 		for _, rr := range reply.Answer {
@@ -165,35 +155,7 @@ func (e *cacheEntry) setReply(reply *dns.Msg, flags uint8, now time.Time) bool {
 		e.ReplyLen = reply.Len()
 	}
 
-	if shouldNotify {
-		close(e.waitChan) // notify all the waiters by closing the channel
-	}
-
 	return (prevValidUntil != e.validUntil)
-}
-
-// wait until a valid reply is set in the cache
-func (e *cacheEntry) waitReply(request *dns.Msg, timeout time.Duration, maxLen int, now time.Time) (*dns.Msg, error) {
-	if e.Status == stResolved {
-		return e.getReply(request, maxLen, now)
-	}
-
-	if timeout > 0 {
-		select {
-		case <-e.waitChan:
-			return e.getReply(request, maxLen, now)
-		case <-time.After(time.Second * timeout):
-			return nil, errTimeout
-		}
-	}
-
-	return nil, errCouldNotResolve
-}
-
-func (e *cacheEntry) close() {
-	if e.Status == stPending {
-		close(e.waitChan)
-	}
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -280,7 +242,7 @@ func (c *Cache) Purge(now time.Time) {
 }
 
 // Add adds a reply to the cache.
-func (c *Cache) Put(request *dns.Msg, reply *dns.Msg, flags uint8, now time.Time) int {
+func (c *Cache) Put(request *dns.Msg, reply *dns.Msg, ttl int, flags uint8, now time.Time) int {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -288,8 +250,7 @@ func (c *Cache) Put(request *dns.Msg, reply *dns.Msg, flags uint8, now time.Time
 	key := cacheKey(question)
 	ent, found := c.entries[key]
 	if found {
-		Debug.Printf("[cache msgid %d] replacing response in cache", request.MsgHdr.Id)
-		updated := ent.setReply(reply, flags, now)
+		updated := ent.setReply(reply, ttl, flags, now)
 		if updated {
 			heap.Fix(&c.entriesH, ent.index)
 		}
@@ -297,10 +258,10 @@ func (c *Cache) Put(request *dns.Msg, reply *dns.Msg, flags uint8, now time.Time
 		// If we will add a new item and the capacity has been exceeded, make some room...
 		if len(c.entriesH) >= c.Capacity {
 			lowestEntry := heap.Pop(&c.entriesH).(*cacheEntry)
-			lowestEntry.close()
 			delete(c.entries, cacheKey(lowestEntry.question))
 		}
-		ent = newCacheEntry(&question, reply, stResolved, flags, now)
+		ent = newCacheEntry(&question, now)
+		ent.setReply(reply, ttl, flags, now)
 		heap.Push(&c.entriesH, ent)
 		c.entries[key] = ent
 	}
@@ -329,20 +290,7 @@ func (c *Cache) Get(request *dns.Msg, maxLen int, now time.Time) (reply *dns.Msg
 	} else {
 		// we are the first asking for this name: create an entry with no reply... the caller must wait
 		Debug.Printf("[cache msgid %d] addind in pending state", request.MsgHdr.Id)
-		c.entries[key] = newCacheEntry(&question, nil, stPending, 0, now)
-	}
-	return
-}
-
-// Wait for a reply for a question in the cache
-// Notice that the caller could Get() and then Wait() for a question, but the corresponding cache
-// entry could have been removed in between. In that case, the caller should retry the query (and
-// the user should increase the cache size!)
-func (c *Cache) Wait(request *dns.Msg, timeout time.Duration, maxLen int, now time.Time) (reply *dns.Msg, err error) {
-	// do not try to lock the cache: otherwise, no one else could `Put()` the reply
-	question := request.Question[0]
-	if entry, found := c.entries[cacheKey(question)]; found {
-		reply, err = entry.waitReply(request, timeout, maxLen, now)
+		c.entries[key] = newCacheEntry(&question, now)
 	}
 	return
 }

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -18,7 +18,6 @@ const (
 	DefaultCacheLen      = 8192               // default cache capacity
 	DefaultResolvWorkers = 8                  // default number of resolution workers
 	DefaultTimeout       = 5                  // default timeout for DNS resolutions
-	DefaultResolvTries   = 3                  // max # of times a worker tries to resolve a query
 )
 
 type DNSServerConfig struct {
@@ -264,7 +263,7 @@ func (s *DNSServer) queryHandler(proto dnsProtocol) dns.HandlerFunc {
 			now = time.Now()
 		}
 
-		Info.Printf("[dns msgid %d] No results for type %s query %s",
+		Info.Printf("[dns msgid %d] No results for type %s query %s [caching no-local]",
 			r.MsgHdr.Id, dns.TypeToString[q.Qtype], q.Name)
 		s.cache.Put(r, nil, negLocalTTL, CacheNoLocalReplies, now)
 		w.WriteMsg(makeDNSFailResponse(r))
@@ -360,8 +359,7 @@ func (s *DNSServer) notUsHandler(proto dnsProtocol) dns.HandlerFunc {
 			w.WriteMsg(reply)
 			return
 		}
-		Warning.Printf("[dns msgid %d] Failed lookup for external name %s",
-			r.MsgHdr.Id, q.Name)
+		Warning.Printf("[dns msgid %d] Failed lookup for external name %s", r.MsgHdr.Id, q.Name)
 		w.WriteMsg(makeDNSFailResponse(r))
 	}
 }

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -253,6 +253,7 @@ func (s *DNSServer) queryHandler(proto dnsProtocol) dns.HandlerFunc {
 		for _, lookup := range lookups {
 			if ip, err := lookup.LookupName(q.Name); err == nil {
 				m := makeAddressReply(r, &q, []net.IP{ip})
+				m.Authoritative = true
 
 				Debug.Printf("[dns msgid %d] Caching response for %s-query for \"%s\": %s [code:%s]",
 					m.MsgHdr.Id, dns.TypeToString[q.Qtype], q.Name, ip, dns.RcodeToString[m.Rcode])
@@ -310,6 +311,8 @@ func (s *DNSServer) rdnsHandler(proto dnsProtocol) dns.HandlerFunc {
 		for _, lookup := range lookups {
 			if name, err := lookup.LookupInaddr(q.Name); err == nil {
 				m := makePTRReply(r, &q, []string{name})
+				m.Authoritative = true
+
 				Debug.Printf("[dns msgid %d] Caching response for %s-query for \"%s\": %s [code:%s]",
 					m.MsgHdr.Id, dns.TypeToString[q.Qtype], q.Name, name, dns.RcodeToString[m.Rcode])
 				s.cache.Put(r, m, nullTTL, 0, now)

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -140,8 +140,8 @@ func NewDNSServer(config DNSServerConfig, zone Zone, iface *net.Interface) (s *D
 	// (we use the same protocol for asking upstream servers)
 	mux := func(proto dnsProtocol) *dns.ServeMux {
 		m := dns.NewServeMux()
-		m.HandleFunc(s.Domain, s.queryHandler([]Lookup{s.Zone, s.mdnsCli}, proto))
-		m.HandleFunc(RDNSDomain, s.rdnsHandler([]Lookup{s.Zone, s.mdnsCli}, proto))
+		m.HandleFunc(s.Domain, s.queryHandler(proto))
+		m.HandleFunc(RDNSDomain, s.rdnsHandler(proto))
 		m.HandleFunc(".", s.notUsHandler(proto))
 		return m
 	}
@@ -215,26 +215,32 @@ func (s *DNSServer) Stop() error {
 	return nil
 }
 
-func (s *DNSServer) queryHandler(lookups []Lookup, proto dnsProtocol) dns.HandlerFunc {
+func (s *DNSServer) queryHandler(proto dnsProtocol) dns.HandlerFunc {
 	return func(w dns.ResponseWriter, r *dns.Msg) {
 		now := time.Now()
 		q := r.Question[0]
 		maxLen := getMaxReplyLen(r, proto)
+		lookups := []Lookup{s.Zone, s.mdnsCli}
 		Debug.Printf("Query: %+v", q)
 
 		if q.Qtype != dns.TypeA {
 			Debug.Printf("[dns msgid %d] Unsuported query type %s", r.MsgHdr.Id, dns.TypeToString[q.Qtype])
 			m := makeDNSNotImplResponse(r)
-			s.cache.Put(r, m, 0, now)
+			s.cache.Put(r, m, negLocalTTL, 0, now)
 			w.WriteMsg(m)
 			return
 		}
 
 		reply, err := s.cache.Get(r, maxLen, time.Now())
 		if err != nil {
-			Debug.Printf("[dns msgid %d] Error from cache: %s", r.MsgHdr.Id, err)
-			w.WriteMsg(makeDNSFailResponse(r))
-			return
+			if err == errNoLocalReplies {
+				Debug.Printf("[dns msgid %d] Cached 'no local replies' - skipping local lookup", r.MsgHdr.Id)
+				lookups = []Lookup{s.Zone}
+			} else {
+				Debug.Printf("[dns msgid %d] Error from cache: %s", r.MsgHdr.Id, err)
+				w.WriteMsg(makeDNSFailResponse(r))
+				return
+			}
 		}
 		if reply != nil {
 			Debug.Printf("[dns msgid %d] Returning reply from cache: %s/%d answers",
@@ -248,7 +254,7 @@ func (s *DNSServer) queryHandler(lookups []Lookup, proto dnsProtocol) dns.Handle
 
 				Debug.Printf("[dns msgid %d] Caching response for %s-query for \"%s\": %s [code:%s]",
 					m.MsgHdr.Id, dns.TypeToString[q.Qtype], q.Name, ip, dns.RcodeToString[m.Rcode])
-				s.cache.Put(r, m, 0, now)
+				s.cache.Put(r, m, nullTTL, 0, now)
 				w.WriteMsg(m)
 				return
 			}
@@ -257,17 +263,17 @@ func (s *DNSServer) queryHandler(lookups []Lookup, proto dnsProtocol) dns.Handle
 
 		Info.Printf("[dns msgid %d] No results for type %s query %s",
 			r.MsgHdr.Id, dns.TypeToString[q.Qtype], q.Name)
-		m := makeDNSFailResponse(r)
-		s.cache.Put(r, m, 0, now)
-		w.WriteMsg(m)
+		s.cache.Put(r, nil, negLocalTTL, CacheNoLocalReplies, now)
+		w.WriteMsg(makeDNSFailResponse(r))
 	}
 }
 
-func (s *DNSServer) rdnsHandler(lookups []Lookup, proto dnsProtocol) dns.HandlerFunc {
+func (s *DNSServer) rdnsHandler(proto dnsProtocol) dns.HandlerFunc {
 	fallback := s.notUsHandler(proto)
 	return func(w dns.ResponseWriter, r *dns.Msg) {
 		now := time.Now()
 		q := r.Question[0]
+		lookups := []Lookup{s.Zone, s.mdnsCli}
 		maxLen := getMaxReplyLen(r, proto)
 		Debug.Printf("Reverse query: %+v", q)
 
@@ -275,7 +281,7 @@ func (s *DNSServer) rdnsHandler(lookups []Lookup, proto dnsProtocol) dns.Handler
 			Warning.Printf("[dns msgid %d] Unexpected reverse query type %s: %+v",
 				r.MsgHdr.Id, dns.TypeToString[q.Qtype], q)
 			m := makeDNSNotImplResponse(r)
-			s.cache.Put(r, m, 0, now)
+			s.cache.Put(r, m, negLocalTTL, 0, now)
 			w.WriteMsg(m)
 			return
 		}
@@ -284,12 +290,12 @@ func (s *DNSServer) rdnsHandler(lookups []Lookup, proto dnsProtocol) dns.Handler
 		if err != nil {
 			if err == errNoLocalReplies {
 				Debug.Printf("[dns msgid %d] Cached 'no local replies' - skipping local lookup", r.MsgHdr.Id)
-				fallback(w, r)
+				lookups = []Lookup{s.Zone}
 			} else {
 				Debug.Printf("[dns msgid %d] Error from cache: %s", r.MsgHdr.Id, err)
 				w.WriteMsg(makeDNSFailResponse(r))
+				return
 			}
-			return
 		}
 		if reply != nil {
 			Debug.Printf("[dns msgid %d] Returning reply from cache: %s/%d answers",
@@ -302,14 +308,16 @@ func (s *DNSServer) rdnsHandler(lookups []Lookup, proto dnsProtocol) dns.Handler
 				m := makePTRReply(r, &q, []string{name})
 				Debug.Printf("[dns msgid %d] Caching response for %s-query for \"%s\": %s [code:%s]",
 					m.MsgHdr.Id, dns.TypeToString[q.Qtype], q.Name, name, dns.RcodeToString[m.Rcode])
-				s.cache.Put(r, m, 0, now)
+				s.cache.Put(r, m, nullTTL, 0, now)
 				w.WriteMsg(m)
 				return
 			}
 			now = time.Now()
 		}
 
-		s.cache.Put(r, nil, CacheNoLocalReplies, now)
+		Info.Printf("[dns msgid %d] No results for %s-query about '%s' [caching no-local] -> sending to fallback server",
+			r.MsgHdr.Id, dns.TypeToString[q.Qtype], q.Name)
+		s.cache.Put(r, nil, negLocalTTL, CacheNoLocalReplies, now)
 		fallback(w, r)
 	}
 }

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -54,6 +54,7 @@ func main() {
 	}
 
 	InitDefaultLogging(debug)
+	Info.Printf("WeaveDNS version %s\n", version)	// first thing in log: the version
 
 	var zone = new(weavedns.ZoneDb)
 


### PR DESCRIPTION
Changes in this PR:

* do not modify the TTL in the reply stored when `Get`ting from the cache
* set all responses obtained with mDNS as authoritative
* minor improvements in the logs

Note: this PR depends on #501 
