### PR TITLE
Add options to set ports on weaver command line

### DIFF
--- a/router/gossip_test.go
+++ b/router/gossip_test.go
@@ -17,7 +17,7 @@ type mockChannelConnection struct {
 // Construct a "passive" Router, i.e. without any goroutines, except
 // for Routes and GossipSenders.
 func NewTestRouter(name PeerName) *Router {
-	router := NewRouter(nil, name, "", nil, 10, 1024, nil)
+	router := NewRouter(nil, name, "", nil, 10, 1024, nil, Port)
 	// need to create a dummy channel otherwise tests hang on nil
 	// channels when the Router invoked ConnectionMaker.Refresh
 	router.ConnectionMaker.actionChan = make(chan ConnectionMakerAction, ChannelSize)

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -94,7 +94,7 @@ func (peer *LocalPeer) CreateConnection(peerAddr string, acceptNewPeer bool) err
 		return err
 	}
 	// We're dialing the remote so that means connections will come from random ports
-	addrStr := NormalisePeerAddr(peerAddr)
+	addrStr := peer.Router.NormalisePeerAddr(peerAddr)
 	tcpAddr, tcpErr := net.ResolveTCPAddr("tcp4", addrStr)
 	udpAddr, udpErr := net.ResolveUDPAddr("udp4", addrStr)
 	if tcpErr != nil || udpErr != nil {

--- a/router/udp_sender.go
+++ b/router/udp_sender.go
@@ -48,7 +48,7 @@ func NewRawUDPSender(conn *LocalConnection) (*RawUDPSender, error) {
 	if err != nil {
 		return nil, err
 	}
-	udpHeader := &layers.UDP{SrcPort: layers.UDPPort(Port)}
+	udpHeader := &layers.UDP{SrcPort: layers.UDPPort(conn.Router.Port)}
 	ipBuf := gopacket.NewSerializeBuffer()
 	opts := gopacket.SerializeOptions{
 		FixLengths: true,

--- a/router/utils.go
+++ b/router/utils.go
@@ -117,13 +117,3 @@ func (lop ListOfPeers) Swap(i, j int) {
 func (lop ListOfPeers) Less(i, j int) bool {
 	return lop[i].Name < lop[j].Name
 }
-
-// given an address like '1.2.3.4:567', return the address if it has a port,
-// otherwise return the address with weave's standard port number
-func NormalisePeerAddr(peerAddr string) string {
-	_, _, err := net.SplitHostPort(peerAddr)
-	if err == nil {
-		return peerAddr
-	}
-	return fmt.Sprintf("%s:%d", peerAddr, Port)
-}


### PR DESCRIPTION
This commit adds two command line options, intended to allow multiple
instances of weave to run without container separation between them.

* -port=PORT makes weave bind to port PORT (an integer). Without the
  option, the default value (6783) is used.

* -bindjsonto=BINDSTRING makes weave bind its control interface to
  a different port. For instance "127.0.0.1:6784" can be used to
  bind to localhost only. ":6784" is the default. An empty string
  can be used to disable the control interface.

Signed-off-by: Alex Bligh <alex@alex.org.uk>