### PR TITLE
Error if neither -iface or -name is specified

### DIFF
--- a/weaver/main.go
+++ b/weaver/main.go
@@ -92,6 +92,9 @@ func main() {
 	}
 
 	if routerName == "" {
+		if iface == nil {
+			log.Fatal("Either an interface must be specified with -iface or a name with -name")
+		}
 		routerName = iface.HardwareAddr.String()
 	}
 


### PR DESCRIPTION
This prevents a nil pointer dereference if (e.g.) weaver is
invoked with no arguments.

Signed-off-by: Alex Bligh <alex@alex.org.uk>

Before this change:

    $ weaver/weaver
    weave 2015/04/10 14:54:39.431562 Command line options: map[]
    weave 2015/04/10 14:54:39.431709 Command line peers: []
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal 0xb code=0x1 addr=0x0 pc=0x4034df]

    goroutine 1 [running]:
    runtime.panic(0x82dc60, 0xfc1a68)
    	/usr/lib/go/src/pkg/runtime/panic.c:266 +0xb6
    main.main()
    	/home/amb/weave/weave/weaver/main.go:95 +0x12df

    goroutine 3 [syscall]:
    os/signal.loop()
    	/usr/lib/go/src/pkg/os/signal/signal_unix.go:21 +0x1e
    created by os/signal.init·1

After this change:

    $ weaver/weaver
    weave 2015/04/10 14:59:11.852728 Command line options: map[]
    weave 2015/04/10 14:59:11.853156 Command line peers: []
    weave 2015/04/10 14:59:11.853164 An interface must be specified with -iface
