### PR TITLE
more discriminate connectivity

### DIFF
--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -93,10 +93,8 @@ func (peer *LocalPeer) CreateConnection(peerAddr string, acceptNewPeer bool) err
 	if err := peer.checkConnectionLimit(); err != nil {
 		return err
 	}
-	// We're dialing the remote so that means connections will come from random ports
-	addrStr := peer.router.NormalisePeerAddr(peerAddr)
-	tcpAddr, tcpErr := net.ResolveTCPAddr("tcp4", addrStr)
-	udpAddr, udpErr := net.ResolveUDPAddr("udp4", addrStr)
+	tcpAddr, tcpErr := net.ResolveTCPAddr("tcp4", peerAddr)
+	udpAddr, udpErr := net.ResolveUDPAddr("udp4", peerAddr)
 	if tcpErr != nil || udpErr != nil {
 		// they really should have the same value, but just in case...
 		if tcpErr == nil {

--- a/router/router.go
+++ b/router/router.go
@@ -67,7 +67,7 @@ func NewRouter(config RouterConfig, name PeerName, nickName string) *Router {
 	router.Peers = NewPeers(router.Ourself.Peer, onPeerGC)
 	router.Peers.FetchWithDefault(router.Ourself.Peer)
 	router.Routes = NewRoutes(router.Ourself.Peer, router.Peers)
-	router.ConnectionMaker = NewConnectionMaker(router.Ourself, router.Peers, router.NormalisePeerAddr)
+	router.ConnectionMaker = NewConnectionMaker(router.Ourself, router.Peers, router.Port)
 	router.TopologyGossip = router.NewGossip("topology", router)
 	return router
 }

--- a/router/router.go
+++ b/router/router.go
@@ -417,13 +417,3 @@ func (router *Router) applyTopologyUpdate(update []byte) (PeerNameSet, PeerNameS
 	}
 	return origUpdate, newUpdate, nil
 }
-
-// given an address like '1.2.3.4:567', return the address if it has a port,
-// otherwise return the address with the default port number for the router
-func (router *Router) NormalisePeerAddr(peerAddr string) string {
-	_, _, err := net.SplitHostPort(peerAddr)
-	if err == nil {
-		return peerAddr
-	}
-	return fmt.Sprintf("%s:%d", peerAddr, router.Port)
-}


### PR DESCRIPTION
If a peer was specified on the command line w/o a port, then do not connect to it if we have inbound connections from that IP.

This eliminates unnecessary (and ultimately failing0 connection attempts in the common scenario of several peers having been told about each other on their command lines.

Closes #478.