### PR TITLE
Ensure `make` stops on error from `go test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,14 +69,18 @@ $(DOCKER_DISTRIB):
 
 tests:
 	echo "mode: count" > profile.cov
+	fail=0 ;                                                                              \
 	for dir in $$(find . -type f -name '*_test.go' | xargs -n1 dirname | sort -u); do     \
-	    output=$$(mktemp cover.XXXXXXXXXX);                                               \
-	    go test -tags netgo -covermode=count -coverprofile=$$output $$dir;                \
+	    output=$$(mktemp cover.XXXXXXXXXX) ;                                              \
+	    if ! go test -tags netgo -covermode=count -coverprofile=$$output $$dir ; then     \
+            fail=1 ;                                                                      \
+        fi ;                                                                              \
 	    if [ -f $$output ]; then                                                          \
 	        tail -n +2 <$$output >>profile.cov;                                           \
 	        rm $$output;                                                                  \
 	    fi                                                                                \
-	done
+	done ;                                                                                \
+	exit $$fail
 	go tool cover -html=profile.cov -o=coverage.html
 
 $(PUBLISH): publish_%:


### PR DESCRIPTION
Changed command separator from `;` to `&&`.

In the absence of this (or something like `set -e`), `make` will carry on and report the exit status from the next command, which is generally 0 i.e. success.