### PR TITLE
Include weave exposed addresses in ps output

### DIFF
--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -129,6 +129,7 @@ is waiting for a while before connecting again.
 Produces a list of all the containers running on this host that are
 connected to the weave network, like this:
 
+    weave:expose 7a:c4:8b:a1:e6:ad 10.2.5.2/24
     b07565b06c53 ae:e3:07:9c:8c:d4
     5245643870f1 ce:15:34:a9:b5:6d 10.2.5.1/24
     e32a7d37a93a 7a:61:a2:49:4b:91 10.2.8.3/24
@@ -137,7 +138,9 @@ connected to the weave network, like this:
 On each line are the container ID, its MAC address, then the list of
 IP address/routing prefix length ([CIDR
 notation](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing))
-assigned on the weave network.
+assigned on the weave network. The special container name `weave:expose`
+displays the weave bridge MAC and any IP addresses added to it via the
+`weave expose` command.
 
 You can also supply a list of container IDs/names to `weave ps`, like this:
 

--- a/weave
+++ b/weave
@@ -676,9 +676,14 @@ case "$COMMAND" in
         http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT GET /status 2>/dev/null || true
         ;;
     ps)
-        [ $# -eq 0 ] && CONTAINERS="$(docker ps -q)" || CONTAINERS="$@"
+        [ $# -eq 0 ] && CONTAINERS="weave:expose $(docker ps -q)" || CONTAINERS="$@"
         for CONTAINER_ID in $CONTAINERS ; do
-            if CONTAINER_ADDRS=$(with_container_netns $CONTAINER_ID container_weave_addrs 2>&1) ; then
+            if [ "$CONTAINER_ID" = "weave:expose" ]; then
+                ADDRS_CMD="ip addr show dev $BRIDGE"
+            else
+                ADDRS_CMD="with_container_netns $CONTAINER_ID container_weave_addrs"
+            fi
+            if CONTAINER_ADDRS=$($ADDRS_CMD 2>&1) ; then
                 CONTAINER_MAC=$(echo "$CONTAINER_ADDRS" | grep -o 'link/ether .*' | cut -d ' ' -f 2)
                 CONTAINER_IPS=$(echo "$CONTAINER_ADDRS" | grep -o 'inet .*'       | cut -d ' ' -f 2)
                 echo $CONTAINER_ID $CONTAINER_MAC $CONTAINER_IPS


### PR DESCRIPTION
Fixes #385. Sample output:
````
$ sudo ./weave ps
e8f979801cd7 ae:50:e8:95:f6:03 10.0.0.1/24
2e25b47b08fe 6a:95:45:20:14:56
weave 7a:c4:8b:a1:e6:ad 10.0.0.2/24
````
The final entry uses `$BRIDGE` in place of the container name, for lack of anything better - thoughts @rade @bboreham ?