### PR TITLE
Support for multiple responses in mDNS

### DIFF
--- a/nameserver/addrs.go
+++ b/nameserver/addrs.go
@@ -87,7 +87,7 @@ func addrToIPv4(addr string) (IPv4, error) {
 // Parse a reverse address (eg, "11.12.13.10.in-addr.arpa.") and return the corresponding IPv4 (eg, "10.13.12.11")
 func raddrToIPv4(addr string) (IPv4, error) {
 	l := len(addr)
-	if l < rdnsDomainLen + 1 {
+	if l < rdnsDomainLen+1 {
 		return IPv4{}, &net.ParseError{"too short reverse IP address", addr}
 	}
 

--- a/nameserver/addrs.go
+++ b/nameserver/addrs.go
@@ -1,0 +1,107 @@
+package nameserver
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+)
+
+// A zone record
+// Note: we will try to keep all the zone records information is concentrated here. Maybe not all queries will
+//       use things like priorities or weights, but we do not want to create a hierarchy for dealing with all
+//       possible queries...
+type ZoneRecord interface {
+	Name() string  // The name for this IP
+	IP() net.IP    // The IP (v4) address
+	Priority() int // The priority
+	Weight() int   // The weight
+}
+
+type ZoneLookup interface {
+	// Lookup for a name
+	LookupName(name string) ([]ZoneRecord, error)
+	// Lookup for an address
+	LookupInaddr(inaddr string) ([]ZoneRecord, error)
+}
+
+type ZoneObserver interface {
+	// Observe anything that affects a particular name in the zone
+	ObserveName(name string, observer ZoneRecordObserver) error
+	// Observe anything that affects a particular IP in the zone
+	ObserveInaddr(inaddr string, observer ZoneRecordObserver) error
+}
+
+type ZoneRecordObserver func(ZoneRecord)
+
+/////////////////////////////////////////////////////////////
+
+// A basic record struct (satisfying the ZoneRecord interface)
+type Record struct {
+	name     string
+	ip       net.IP
+	priority int
+	weight   int
+}
+
+func (r Record) Name() string  { return r.name }
+func (r Record) IP() net.IP    { return r.ip }
+func (r Record) Priority() int { return r.priority }
+func (r Record) Weight() int   { return r.weight }
+
+func (i Record) String() string {
+	var buf bytes.Buffer
+	if len(i.Name()) > 0 {
+		buf.WriteString(fmt.Sprintf("%s", i.Name()))
+	}
+	if !i.IP().IsUnspecified() {
+		buf.WriteString(fmt.Sprintf("[%s]", i.IP()))
+	}
+	if i.Priority() > 0 {
+		buf.WriteString(fmt.Sprintf("/P:%d", i.Priority()))
+	}
+	if i.Weight() > 0 {
+		buf.WriteString(fmt.Sprintf("/W:%d", i.Weight()))
+	}
+
+	return buf.String()
+}
+
+/////////////////////////////////////////////////////////////
+
+// simple IPv4 type that can be used as a key in a map (in contrast with net.IP), used for sets of IPs, etc...
+type IPv4 [4]byte
+
+func (ip IPv4) toNetIP() net.IP { return net.IPv4(ip[0], ip[1], ip[2], ip[3]) }
+func (ip IPv4) String() string  { return ip.toNetIP().String() }
+func ipToIPv4(nip net.IP) IPv4  { ip := nip.To4(); return IPv4([4]byte{ip[0], ip[1], ip[2], ip[3]}) }
+
+// Parse an address (eg, "10.13.12.11") and return the corresponding IPv4 (eg, "10.13.12.11")
+func addrToIPv4(addr string) (IPv4, error) {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return IPv4{}, &net.ParseError{"IP address", addr}
+	}
+	return ipToIPv4(ip), nil
+}
+
+// Parse a reverse address (eg, "11.12.13.10.in-addr.arpa.") and return the corresponding IPv4 (eg, "10.13.12.11")
+func raddrToIPv4(addr string) (IPv4, error) {
+	l := len(addr)
+	if l < rdnsDomainLen + 1 {
+		return IPv4{}, &net.ParseError{"too short reverse IP address", addr}
+	}
+
+	suffixLen := l - rdnsDomainLen
+	suffix := addr[suffixLen+1:]
+	if suffix != RDNSDomain {
+		return IPv4{}, &net.ParseError{"suffix of reverse IP address", addr}
+	}
+	ipStr := addr[:suffixLen]
+	revIP := net.ParseIP(ipStr)
+	if revIP == nil {
+		return IPv4{}, &net.ParseError{"reverse IP address", addr}
+	}
+
+	revIP4 := revIP.To4()
+	return IPv4([4]byte{revIP4[3], revIP4[2], revIP4[1], revIP4[0]}), nil
+}

--- a/nameserver/addrs_test.go
+++ b/nameserver/addrs_test.go
@@ -1,0 +1,30 @@
+package nameserver
+
+import (
+    . "github.com/weaveworks/weave/common"
+    wt "github.com/weaveworks/weave/testing"
+    "net"
+    "testing"
+)
+
+func TestAddrs(t *testing.T) {
+    InitDefaultLogging(testing.Verbose())
+
+    ip, err := addrToIPv4("10.13.12.11")
+    wt.AssertNoErr(t, err)
+    wt.AssertTrue(t, net.ParseIP("10.13.12.11").Equal(ip.toNetIP()), "IP")
+
+    ip, err = raddrToIPv4("11.12.13.10.in-addr.arpa.")
+    wt.AssertNoErr(t, err)
+    wt.AssertTrue(t, net.ParseIP("10.13.12.11").Equal(ip.toNetIP()), "IP")
+
+    // some malformed addresses
+    ip, err = addrToIPv4("10.13.12")
+    wt.AssertTrue(t, err != nil, "when parsing malformed address")
+    ip, err = addrToIPv4("10.13.AA.12")
+    wt.AssertTrue(t, err != nil, "when parsing malformed address")
+    ip, err = raddrToIPv4("11.12.13.10.in-axxx.arpa.")
+    wt.AssertTrue(t, err != nil, "when parsing malformed address")
+    ip, err = raddrToIPv4("11.12.13.10.in-addr")
+    wt.AssertTrue(t, err != nil, "when parsing malformed address")
+}

--- a/nameserver/addrs_test.go
+++ b/nameserver/addrs_test.go
@@ -1,30 +1,30 @@
 package nameserver
 
 import (
-    . "github.com/weaveworks/weave/common"
-    wt "github.com/weaveworks/weave/testing"
-    "net"
-    "testing"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
+	"net"
+	"testing"
 )
 
 func TestAddrs(t *testing.T) {
-    InitDefaultLogging(testing.Verbose())
+	InitDefaultLogging(testing.Verbose())
 
-    ip, err := addrToIPv4("10.13.12.11")
-    wt.AssertNoErr(t, err)
-    wt.AssertTrue(t, net.ParseIP("10.13.12.11").Equal(ip.toNetIP()), "IP")
+	ip, err := addrToIPv4("10.13.12.11")
+	wt.AssertNoErr(t, err)
+	wt.AssertTrue(t, net.ParseIP("10.13.12.11").Equal(ip.toNetIP()), "IP")
 
-    ip, err = raddrToIPv4("11.12.13.10.in-addr.arpa.")
-    wt.AssertNoErr(t, err)
-    wt.AssertTrue(t, net.ParseIP("10.13.12.11").Equal(ip.toNetIP()), "IP")
+	ip, err = raddrToIPv4("11.12.13.10.in-addr.arpa.")
+	wt.AssertNoErr(t, err)
+	wt.AssertTrue(t, net.ParseIP("10.13.12.11").Equal(ip.toNetIP()), "IP")
 
-    // some malformed addresses
-    ip, err = addrToIPv4("10.13.12")
-    wt.AssertTrue(t, err != nil, "when parsing malformed address")
-    ip, err = addrToIPv4("10.13.AA.12")
-    wt.AssertTrue(t, err != nil, "when parsing malformed address")
-    ip, err = raddrToIPv4("11.12.13.10.in-axxx.arpa.")
-    wt.AssertTrue(t, err != nil, "when parsing malformed address")
-    ip, err = raddrToIPv4("11.12.13.10.in-addr")
-    wt.AssertTrue(t, err != nil, "when parsing malformed address")
+	// some malformed addresses
+	ip, err = addrToIPv4("10.13.12")
+	wt.AssertTrue(t, err != nil, "when parsing malformed address")
+	ip, err = addrToIPv4("10.13.AA.12")
+	wt.AssertTrue(t, err != nil, "when parsing malformed address")
+	ip, err = raddrToIPv4("11.12.13.10.in-axxx.arpa.")
+	wt.AssertTrue(t, err != nil, "when parsing malformed address")
+	ip, err = raddrToIPv4("11.12.13.10.in-addr")
+	wt.AssertTrue(t, err != nil, "when parsing malformed address")
 }

--- a/nameserver/cache.go
+++ b/nameserver/cache.go
@@ -247,6 +247,7 @@ func (c *Cache) Purge(now time.Time) {
 }
 
 // Add adds a reply to the cache.
+// When `ttl` is equal to `nullTTL`, the cache entry will be valid until the closest TTL in the `reply`
 func (c *Cache) Put(request *dns.Msg, reply *dns.Msg, ttl int, flags uint8, now time.Time) int {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -274,8 +275,7 @@ func (c *Cache) Put(request *dns.Msg, reply *dns.Msg, ttl int, flags uint8, now 
 }
 
 // Look up for a question's reply from the cache.
-// If no reply is stored in the cache, it returns a `nil` reply and no error. The caller can then `Wait()`
-// for another goroutine `Put`ing a reply in the cache.
+// If no reply is stored in the cache, it returns a `nil` reply and no error.
 func (c *Cache) Get(request *dns.Msg, maxLen int, now time.Time) (reply *dns.Msg, err error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -307,6 +307,7 @@ func (c *Cache) Remove(question *dns.Question) {
 
 	key := cacheKey(*question)
 	if entry, found := c.entries[key]; found {
+		Debug.Printf("[cache] removing %s-response for '%s'", dns.TypeToString[question.Qtype], question.Name)
 		if entry.index > 0 {
 			heap.Remove(&c.entriesH, entry.index)
 		}

--- a/nameserver/mdns_client.go
+++ b/nameserver/mdns_client.go
@@ -51,9 +51,9 @@ func (r Response) Equal(r2 *Response) bool {
 }
 
 type responseInfo struct {
-	timeout    time.Time // if no answer by this time, give up
-	insistent  bool      // insistent queries are not removed on the first reply
-	ch         chan<- *Response
+	timeout   time.Time // if no answer by this time, give up
+	insistent bool      // insistent queries are not removed on the first reply
+	ch        chan<- *Response
 }
 
 // Represents one query that we have sent for one name.
@@ -161,9 +161,9 @@ func (c *MDNSClient) SendQuery(name string, querytype uint16, insistent bool, re
 			c.inflight[name] = query
 		}
 		info := &responseInfo{
-			ch:         responseCh,
-			timeout:    time.Now().Add(mDNSTimeout),
-			insistent:  insistent,
+			ch:        responseCh,
+			timeout:   time.Now().Add(mDNSTimeout),
+			insistent: insistent,
 		}
 		// Invariant on responseInfos: they are in ascending order of
 		// timeout.  Since we use a fixed interval from Now(), this

--- a/nameserver/mdns_client.go
+++ b/nameserver/mdns_client.go
@@ -27,14 +27,33 @@ var (
 )
 
 type Response struct {
-	Name string
-	Addr net.IP
-	Err  error
+	name string
+	addr net.IP
+	err  error
+}
+
+func (r Response) Name() string  { return r.name }
+func (r Response) IP() net.IP    { return r.addr }
+func (r Response) Priority() int { return 0 }
+func (r Response) Weight() int   { return 0 }
+
+func (r Response) Equal(r2 *Response) bool {
+	if r.name != r2.name {
+		return false
+	}
+	if !r.addr.Equal(r2.addr) {
+		return false
+	}
+	if r.err != r2.err {
+		return false
+	}
+	return true
 }
 
 type responseInfo struct {
-	timeout time.Time // if no answer by this time, give up
-	ch      chan<- *Response
+	timeout    time.Time // if no answer by this time, give up
+	insistent  bool      // insistent queries are not removed on the first reply
+	ch         chan<- *Response
 }
 
 // Represents one query that we have sent for one name.
@@ -55,6 +74,7 @@ type MDNSClient struct {
 	addr       *net.UDPAddr
 	inflight   map[string]*inflightQuery
 	actionChan chan<- MDNSAction
+	running    bool
 }
 
 type mDNSQueryInfo struct {
@@ -64,17 +84,21 @@ type mDNSQueryInfo struct {
 }
 
 func NewMDNSClient() (*MDNSClient, error) {
-	if conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0}); err != nil {
-		return nil, err
-	} else {
-		return &MDNSClient{
-			conn:     conn,
-			addr:     ipv4Addr,
-			inflight: make(map[string]*inflightQuery)}, nil
-	}
+	return &MDNSClient{
+		addr:     ipv4Addr,
+		running:  false,
+		inflight: make(map[string]*inflightQuery)}, nil
 }
 
-func (c *MDNSClient) Start(ifi *net.Interface) error {
+func (c *MDNSClient) Start(ifi *net.Interface) (err error) {
+	if c.running {
+		return nil
+	}
+
+	if c.conn, err = net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0}); err != nil {
+		return err
+	}
+
 	multicast, err := LinkLocalMulticastListener(ifi)
 	if err != nil {
 		return err
@@ -93,7 +117,13 @@ func (c *MDNSClient) Start(ifi *net.Interface) error {
 	actionChan := make(chan MDNSAction, MailboxSize)
 	c.actionChan = actionChan
 	go c.actorLoop(actionChan)
+	return nil
+}
 
+func (c *MDNSClient) Stop() error {
+	if c.running {
+		c.actionChan <- nil
+	}
 	return nil
 }
 
@@ -106,7 +136,7 @@ func LinkLocalMulticastListener(ifi *net.Interface) (net.PacketConn, error) {
 type MDNSAction func()
 
 // Async
-func (c *MDNSClient) SendQuery(name string, querytype uint16, responseCh chan<- *Response) {
+func (c *MDNSClient) SendQuery(name string, querytype uint16, insistent bool, responseCh chan<- *Response) {
 	c.actionChan <- func() {
 		query, found := c.inflight[name]
 		if !found {
@@ -115,7 +145,7 @@ func (c *MDNSClient) SendQuery(name string, querytype uint16, responseCh chan<- 
 			m.RecursionDesired = false
 			buf, err := m.Pack()
 			if err != nil {
-				responseCh <- &Response{Err: err}
+				responseCh <- &Response{err: err}
 				close(responseCh)
 				return
 			}
@@ -124,15 +154,16 @@ func (c *MDNSClient) SendQuery(name string, querytype uint16, responseCh chan<- 
 				id:   m.Id,
 			}
 			if _, err = c.conn.WriteTo(buf, c.addr); err != nil {
-				responseCh <- &Response{Err: err}
+				responseCh <- &Response{err: err}
 				close(responseCh)
 				return
 			}
 			c.inflight[name] = query
 		}
 		info := &responseInfo{
-			ch:      responseCh,
-			timeout: time.Now().Add(mDNSTimeout),
+			ch:         responseCh,
+			timeout:    time.Now().Add(mDNSTimeout),
+			insistent:  insistent,
 		}
 		// Invariant on responseInfos: they are in ascending order of
 		// timeout.  Since we use a fixed interval from Now(), this
@@ -151,20 +182,30 @@ func (c *MDNSClient) ResponseCallback(r *dns.Msg) {
 			switch rr := answer.(type) {
 			case *dns.A:
 				name = rr.Hdr.Name
-				res = &Response{Addr: rr.A}
+				res = &Response{addr: rr.A}
 			case *dns.PTR:
 				name = rr.Hdr.Name
-				res = &Response{Name: rr.Ptr}
+				res = &Response{name: rr.Ptr}
 			default:
 				return
 			}
 
 			if query, found := c.inflight[name]; found {
+				newResponseInfos := make([]*responseInfo, 0)
 				for _, resp := range query.responseInfos {
 					resp.ch <- res
-					close(resp.ch)
+					// insistent queries are not removed on the first reply, but on the timeout
+					if resp.insistent {
+						newResponseInfos = append(newResponseInfos, resp)
+					} else {
+						close(resp.ch)
+					}
 				}
-				delete(c.inflight, name)
+				if len(newResponseInfos) == 0 {
+					delete(c.inflight, name)
+				} else {
+					query.responseInfos = newResponseInfos
+				}
 			} else {
 				// We've received a response that didn't match a query
 				// Do we want to cache it?
@@ -207,13 +248,13 @@ func (c *MDNSClient) checkInFlightQueries() time.Duration {
 func (c *MDNSClient) actorLoop(actionChan <-chan MDNSAction) {
 	timer := time.NewTimer(MaxDuration)
 	run := func() { timer.Reset(c.checkInFlightQueries()) }
-	terminate := false
-	for !terminate {
+	c.running = true
+	for c.running {
 		select {
 		case action := <-actionChan:
 			if action == nil {
 				c.listener.Shutdown()
-				terminate = true
+				c.running = false
 			} else {
 				action()
 				run()

--- a/nameserver/mdns_lookup.go
+++ b/nameserver/mdns_lookup.go
@@ -3,37 +3,69 @@ package nameserver
 import (
 	"github.com/miekg/dns"
 	. "github.com/weaveworks/weave/common"
-	"net"
 )
 
-func mdnsLookup(client *MDNSClient, name string, qtype uint16) (*Response, error) {
+func mdnsLookup(client *MDNSClient, name string, qtype uint16, insistent bool) ([]ZoneRecord, error) {
+	responses := make([]*Response, 0)
 	channel := make(chan *Response)
-	client.SendQuery(name, qtype, channel)
+	client.SendQuery(name, qtype, insistent, channel)
+
 	for resp := range channel {
-		if err := resp.Err; err != nil {
-			Debug.Printf("[mdns] Error for query type %s name %s: %s",
-				dns.TypeToString[qtype], name, err)
+		if err := resp.err; err != nil {
+			Debug.Printf("[mdns] Error for query type %s name %s: %s", dns.TypeToString[qtype], name, err)
 			return nil, err
 		}
-		Debug.Printf("[mdns] Got response name for query type %s name %s: name %s, addr %s",
-			dns.TypeToString[qtype], name, resp.Name, resp.Addr)
-		return resp, nil
+		Debug.Printf("[mdns] Got response name for %s-query about name '%s': name '%s', addr '%s'",
+			dns.TypeToString[qtype], name, resp.name, resp.addr)
+
+		if !insistent {
+			return []ZoneRecord{resp}, nil // non-background queries return the first response...
+		}
+
+		// add the response, avoiding duplicates
+		// TODO: replace this linear search by something better... (not a big deal as we don't expect long responses)
+		duplicate := false
+		for _, r := range responses {
+			if r.Equal(resp) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			responses = append(responses, resp)
+		}
 	}
-	return nil, LookupError(name)
+
+	if len(responses) == 0 {
+		return nil, LookupError(name)
+	}
+
+	// convert []Response to []ZoneRecord
+	res := make([]ZoneRecord, len(responses))
+	for i, rr := range responses {
+		res[i] = ZoneRecord(rr)
+	}
+	return res, nil
 }
 
-func (client *MDNSClient) LookupName(name string) (net.IP, error) {
-	if r, e := mdnsLookup(client, name, dns.TypeA); r != nil {
-		return r.Addr, nil
-	} else {
-		return nil, e
-	}
+// Perform a lookup for a name, returning either an IP address or an error
+func (client *MDNSClient) LookupName(name string) ([]ZoneRecord, error) {
+	return mdnsLookup(client, name, dns.TypeA, false)
 }
 
-func (client *MDNSClient) LookupInaddr(inaddr string) (string, error) {
-	if r, e := mdnsLookup(client, inaddr, dns.TypePTR); r != nil {
-		return r.Name, nil
-	} else {
-		return "", e
-	}
+// Perform a lookup for an IP address, returning either a name or an error
+func (client *MDNSClient) LookupInaddr(inaddr string) ([]ZoneRecord, error) {
+	return mdnsLookup(client, inaddr, dns.TypePTR, false)
+}
+
+// Perform lookup for a name, returning either a list of IP addresses or an error
+// Insistent queries will wait up to `mDNSTimeout` milliseconds for responses
+func (client *MDNSClient) InsistentLookupName(name string) ([]ZoneRecord, error) {
+	return mdnsLookup(client, name, dns.TypeA, true)
+}
+
+// Perform an insistent lookup for an IP address, returning either a list of names or an error
+// Insistent queries will wait up to `mDNSTimeout` milliseconds for responses
+func (client *MDNSClient) InsistentLookupInaddr(inaddr string) ([]ZoneRecord, error) {
+	return mdnsLookup(client, inaddr, dns.TypePTR, true)
 }

--- a/nameserver/mdns_server.go
+++ b/nameserver/mdns_server.go
@@ -97,7 +97,6 @@ func (s *MDNSServer) Stop() error {
 	return s.srv.Shutdown()
 }
 
-
 func (s *MDNSServer) Zone() Zone {
 	return s.zone
 }

--- a/nameserver/mdns_server.go
+++ b/nameserver/mdns_server.go
@@ -11,15 +11,13 @@ type MDNSServer struct {
 	sendconn   *net.UDPConn
 	srv        *dns.Server
 	zone       Zone
+	running    bool
 }
 
+// Create a new mDNS server
+// Nothing will be done (including port bindings) until you `Start()` the server
 func NewMDNSServer(zone Zone) (*MDNSServer, error) {
-	// This is a bit of a kludge - per the RFC we should send responses from 5353, but that doesn't seem to work
-	sendconn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
-	if err != nil {
-		return nil, err
-	}
-	return &MDNSServer{sendconn: sendconn, zone: zone}, nil
+	return &MDNSServer{zone: zone}, nil
 }
 
 // Return true if testaddr is a UDP address with IP matching my local i/f
@@ -36,7 +34,19 @@ func (s *MDNSServer) addrIsLocal(testaddr net.Addr) bool {
 	return false
 }
 
-func (s *MDNSServer) Start(ifi *net.Interface, localDomain string) error {
+// Start the mDNS server
+func (s *MDNSServer) Start(ifi *net.Interface) (err error) {
+	// skip double initialization
+	if s.running {
+		return nil
+	}
+
+	// This is a bit of a kludge - per the RFC we should send responses from 5353, but that doesn't seem to work
+	s.sendconn, err = net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		return err
+	}
+
 	conn, err := LinkLocalMulticastListener(ifi)
 	if err != nil {
 		return err
@@ -52,23 +62,23 @@ func (s *MDNSServer) Start(ifi *net.Interface, localDomain string) error {
 	}
 
 	handleLocal := s.makeHandler(dns.TypeA,
-		func(zone Lookup, r *dns.Msg, q *dns.Question) *dns.Msg {
-			if ip, err := zone.LookupName(q.Name); err == nil {
-				return makeAddressReply(r, q, []net.IP{ip})
+		func(zone ZoneLookup, r *dns.Msg, q *dns.Question) *dns.Msg {
+			if ips, err := zone.LookupName(q.Name); err == nil {
+				return makeAddressReply(r, q, ips)
 			}
 			return nil
 		})
 
 	handleReverse := s.makeHandler(dns.TypePTR,
-		func(zone Lookup, r *dns.Msg, q *dns.Question) *dns.Msg {
-			if name, err := zone.LookupInaddr(q.Name); err == nil {
-				return makePTRReply(r, q, []string{name})
+		func(zone ZoneLookup, r *dns.Msg, q *dns.Question) *dns.Msg {
+			if names, err := zone.LookupInaddr(q.Name); err == nil {
+				return makePTRReply(r, q, names)
 			}
 			return nil
 		})
 
 	mux := dns.NewServeMux()
-	mux.HandleFunc(localDomain, handleLocal)
+	mux.HandleFunc(s.zone.Domain(), handleLocal)
 	mux.HandleFunc(RDNSDomain, handleReverse)
 
 	s.srv = &dns.Server{
@@ -77,17 +87,25 @@ func (s *MDNSServer) Start(ifi *net.Interface, localDomain string) error {
 		Handler:    mux,
 	}
 	go s.srv.ActivateAndServe()
+	s.running = true
 	return err
 }
 
+// Stop the mDNS server
 func (s *MDNSServer) Stop() error {
+	s.running = false
 	return s.srv.Shutdown()
 }
 
-type LookupFunc func(Lookup, *dns.Msg, *dns.Question) *dns.Msg
+
+func (s *MDNSServer) Zone() Zone {
+	return s.zone
+}
+
+type LookupFunc func(ZoneLookup, *dns.Msg, *dns.Question) *dns.Msg
 
 func (s *MDNSServer) makeHandler(qtype uint16, lookup LookupFunc) dns.HandlerFunc {
-	return func(_ dns.ResponseWriter, r *dns.Msg) {
+	return func(rw dns.ResponseWriter, r *dns.Msg) {
 		// Handle only questions, ignore answers. We might also ignore
 		// questions that arise locally (i.e., that come from an IP we
 		// think is local), but in the interest of avoiding
@@ -95,18 +113,20 @@ func (s *MDNSServer) makeHandler(qtype uint16, lookup LookupFunc) dns.HandlerFun
 		// assumption that the client wouldn't ask if it already knew
 		// the answer, and if it does ask, it'll be happy to get an
 		// answer.
+		// TODO: use any Answer in the query for adding records in the Zone database...
 		if len(r.Answer) == 0 && len(r.Question) > 0 {
 			q := &r.Question[0]
 			if q.Qtype == qtype {
+				Debug.Printf("[mdns msgid %d] Trying to answer to mDNS query '%s'", r.MsgHdr.Id, q.Name)
 				if m := lookup(s.zone, r, q); m != nil {
-					Debug.Printf("[mdns msgid %d] Found local answer to mDNS query %s",
-						r.MsgHdr.Id, q.Name)
+					Debug.Printf("[mdns msgid %d] - found local answer to mDNS query '%s'", r.MsgHdr.Id, q.Name)
 					if err := s.sendResponse(m); err != nil {
-						Warning.Printf("[mdns msgid %d] Error writing to %v",
-							r.MsgHdr.Id, s.sendconn)
+						Warning.Printf("[mdns msgid %d] - error writing to %v", r.MsgHdr.Id, s.sendconn)
+					} else {
+						Debug.Printf("[mdns msgid %d] - response sent: %d answers", r.MsgHdr.Id, len(m.Answer))
 					}
 				} else {
-					Debug.Printf("[mdns msgid %d] No local answer for mDNS query %s",
+					Debug.Printf("[mdns msgid %d] - no local answer for mDNS query '%s'",
 						r.MsgHdr.Id, q.Name)
 				}
 			}

--- a/nameserver/mdns_server_test.go
+++ b/nameserver/mdns_server_test.go
@@ -2,87 +2,81 @@ package nameserver
 
 import (
 	"github.com/miekg/dns"
-	"github.com/weaveworks/weave/common"
+	. "github.com/weaveworks/weave/common"
 	wt "github.com/weaveworks/weave/testing"
-	"log"
 	"net"
 	"testing"
 	"time"
 )
 
-var (
-	containerID = "deadbeef"
-	testName    = "test.weave.local."
-	testAddr1   = "10.2.2.1/24"
-	testInAddr1 = "1.2.2.10.in-addr.arpa."
-)
-
-func sendQuery(name string, querytype uint16) error {
-	m := new(dns.Msg)
-	m.SetQuestion(name, querytype)
-	m.RecursionDesired = false
-	buf, err := m.Pack()
-	if err != nil {
-		return err
-	}
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
-	if err != nil {
-		return err
-	}
-	_, err = conn.WriteTo(buf, ipv4Addr)
-	return err
-}
-
 func TestServerSimpleQuery(t *testing.T) {
-	// The ff can be handy for debugging (obvs)
-	common.InitDefaultLogging(true)
+	InitDefaultLogging(testing.Verbose())
 
-	log.Println("TestServerSimpleQuery starting")
-	var zone = new(ZoneDb)
-	ip, _, _ := net.ParseCIDR(testAddr1)
-	zone.AddRecord(containerID, testName, ip)
+	var (
+		testRecord1 = Record{"test.weave.local.", net.ParseIP("10.20.20.10"), 0, 0}
+		testInAddr1 = "10.20.20.10.in-addr.arpa."
+	)
+
+	mzone := NewMockedZone(testRecord1)
+	mdnsServer, err := NewMDNSServer(mzone)
+	wt.AssertNoErr(t, err)
+	err = mdnsServer.Start(nil)
+	wt.AssertNoErr(t, err)
+	defer mdnsServer.Stop()
 
 	var receivedAddr net.IP
 	var receivedName string
 	var recvChan chan interface{}
 	receivedCount := 0
 
-	reset := func() {
-		receivedAddr = nil
-		receivedName = ""
-		receivedCount = 0
-		recvChan = make(chan interface{})
-	}
-
-	wait := func() {
-		select {
-		case <-recvChan:
-			return
-		case <-time.After(100 * time.Millisecond):
-			return
-		}
-	}
-
 	// Implement a minimal listener for responses
 	multicast, err := LinkLocalMulticastListener(nil)
-	if err != nil {
-		t.Fatalf("Unable to run test server: %s. No default multicast interface?", err)
-	}
+	wt.AssertNoErr(t, err)
 
 	handleMDNS := func(w dns.ResponseWriter, r *dns.Msg) {
 		// Only handle responses here
 		if len(r.Answer) > 0 {
+			t.Logf("Received %d answer(s)", len(r.Answer))
 			for _, answer := range r.Answer {
 				switch rr := answer.(type) {
 				case *dns.A:
+					t.Logf("... A:\n%+v", rr)
 					receivedAddr = rr.A
 					receivedCount++
 				case *dns.PTR:
+					t.Logf("... PTR:\n%+v", rr)
 					receivedName = rr.Ptr
 					receivedCount++
 				}
 			}
 			recvChan <- "ok"
+		}
+	}
+
+	sendQuery := func(name string, querytype uint16) {
+		receivedAddr = nil
+		receivedName = ""
+		receivedCount = 0
+		recvChan = make(chan interface{})
+
+		m := new(dns.Msg)
+		m.SetQuestion(name, querytype)
+		m.RecursionDesired = false
+		buf, err := m.Pack()
+		wt.AssertNoErr(t, err)
+		conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+		wt.AssertNoErr(t, err)
+		Debug.Printf("Sending UDP packet to %s", ipv4Addr)
+		_, err = conn.WriteTo(buf, ipv4Addr)
+		wt.AssertNoErr(t, err)
+
+		Debug.Printf("Waiting for response")
+		select {
+		case <-recvChan:
+			return
+		case <-time.After(100 * time.Millisecond):
+			Debug.Printf("Timeout while waiting for response")
+			return
 		}
 	}
 
@@ -94,39 +88,28 @@ func TestServerSimpleQuery(t *testing.T) {
 	go listener.ActivateAndServe()
 	defer listener.Shutdown()
 
-	mdnsServer, err := NewMDNSServer(zone)
-	wt.AssertNoErr(t, err)
-	err = mdnsServer.Start(nil, DefaultLocalDomain)
-	wt.AssertNoErr(t, err)
-
 	time.Sleep(100 * time.Millisecond) // Allow for server to get going
 
-	reset()
-	sendQuery(testName, dns.TypeA)
-	wait()
-
+	Debug.Printf("Query: %s dns.TypeA", testRecord1.Name())
+	sendQuery(testRecord1.Name(), dns.TypeA)
 	if receivedCount != 1 {
-		t.Fatalf("Unexpected result count %d for %s", receivedCount, testName)
+		t.Fatalf("Unexpected result count %d for %s", receivedCount, testRecord1.Name())
 	}
-	if !receivedAddr.Equal(ip) {
-		t.Fatalf("Unexpected result %s for %s", receivedAddr, testName)
+	if !receivedAddr.Equal(testRecord1.IP()) {
+		t.Fatalf("Unexpected result %s for %s", receivedAddr, testRecord1.Name())
 	}
 
-	reset()
+	Debug.Printf("Query: testfail.weave. dns.TypeA")
 	sendQuery("testfail.weave.", dns.TypeA)
-	wait()
-
 	if receivedCount != 0 {
 		t.Fatalf("Unexpected result count %d for testfail.weave", receivedCount)
 	}
 
-	reset()
+	Debug.Printf("Query: %s dns.TypePTR", testInAddr1)
 	sendQuery(testInAddr1, dns.TypePTR)
-	wait()
-
 	if receivedCount != 1 {
 		t.Fatalf("Expected an answer to %s, got %d answers", testInAddr1, receivedCount)
-	} else if !(testName == receivedName) {
-		t.Fatalf("Expected answer %s to query for %s, got %s", testName, testInAddr1, receivedName)
+	} else if !(testRecord1.Name() == receivedName) {
+		t.Fatalf("Expected answer %s to query for %s, got %s", testRecord1.Name(), testInAddr1, receivedName)
 	}
 }

--- a/nameserver/mocks_test.go
+++ b/nameserver/mocks_test.go
@@ -1,0 +1,54 @@
+package nameserver
+
+import (
+	. "github.com/weaveworks/weave/common"
+	"net"
+)
+
+// Warn about some methods that some day should be implemented...
+func notImplWarn() { Warning.Printf("Mocked method. Not implemented.") }
+
+// A mocked Zone that always returns the same record
+type mockedZone struct {
+	record ZoneRecord
+
+	// Statistics
+	NumLookupsName   int
+	NumLookupsInaddr int
+}
+
+func NewMockedZone(zr ZoneRecord) *mockedZone { return &mockedZone{record: zr} }
+func (mz mockedZone) Domain() string         { return DefaultLocalDomain }
+func (mz mockedZone) LookupName(name string) ([]ZoneRecord, error) {
+	Debug.Printf("[mocked zone]: LookupName: returning record %s", mz.record)
+	mz.NumLookupsName += 1
+	return []ZoneRecord{mz.record}, nil
+}
+func (mz mockedZone) LookupInaddr(inaddr string) ([]ZoneRecord, error) {
+	Debug.Printf("[mocked zone]: LookupInaddr: returning record %s", mz.record)
+	mz.NumLookupsInaddr += 1
+	return []ZoneRecord{mz.record}, nil
+}
+
+// the following methods are not currently needed...
+func (mz mockedZone) Status() string                                       { notImplWarn(); return "nothing" }
+func (mz mockedZone) AddRecord(ident string, name string, ip net.IP) error { notImplWarn(); return nil }
+func (mz mockedZone) DeleteRecord(ident string, ip net.IP) error           { notImplWarn(); return nil }
+func (mz mockedZone) DeleteRecordsFor(ident string) error                  { notImplWarn(); return nil }
+func (mz mockedZone) DomainLookupName(name string) ([]ZoneRecord, error) {
+	notImplWarn()
+	return nil, nil
+}
+func (mz mockedZone) DomainLookupInaddr(inaddr string) ([]ZoneRecord, error) {
+	notImplWarn()
+	return nil, nil
+}
+func (mz mockedZone) ObserveName(name string, observer ZoneRecordObserver) error {
+	notImplWarn()
+	return nil
+}
+func (mz mockedZone) ObserveInaddr(inaddr string, observer ZoneRecordObserver) error {
+	notImplWarn()
+	return nil
+}
+

--- a/nameserver/mocks_test.go
+++ b/nameserver/mocks_test.go
@@ -18,7 +18,7 @@ type mockedZone struct {
 }
 
 func NewMockedZone(zr ZoneRecord) *mockedZone { return &mockedZone{record: zr} }
-func (mz mockedZone) Domain() string         { return DefaultLocalDomain }
+func (mz mockedZone) Domain() string          { return DefaultLocalDomain }
 func (mz mockedZone) LookupName(name string) ([]ZoneRecord, error) {
 	Debug.Printf("[mocked zone]: LookupName: returning record %s", mz.record)
 	mz.NumLookupsName += 1
@@ -51,4 +51,3 @@ func (mz mockedZone) ObserveInaddr(inaddr string, observer ZoneRecordObserver) e
 	notImplWarn()
 	return nil
 }
-

--- a/nameserver/server_test.go
+++ b/nameserver/server_test.go
@@ -36,6 +36,7 @@ func setupForTest(t *testing.T) {
 func TestUDPDNSServer(t *testing.T) {
 	setupForTest(t)
 	const (
+		containerID     = "foobar"
 		successTestName = "test1.weave.local."
 		failTestName    = "test2.weave.local."
 		nonLocalName    = "weave.works."
@@ -44,7 +45,7 @@ func TestUDPDNSServer(t *testing.T) {
 	testCIDR1 := testAddr1 + "/24"
 
 	InitDefaultLogging(true)
-	var zone = new(ZoneDb)
+	var zone = NewZoneDb(DefaultLocalDomain)
 	ip, _, _ := net.ParseCIDR(testCIDR1)
 	zone.AddRecord(containerID, successTestName, ip)
 
@@ -125,14 +126,14 @@ func TestTCPDNSServer(t *testing.T) {
 	dnsAddr := fmt.Sprintf("localhost:%d", testPort)
 
 	InitDefaultLogging(true)
-	var zone = new(ZoneDb)
+	var zone = NewZoneDb(DefaultLocalDomain)
 
 	// generate a list of `numAnswers` IP addresses
-	var addrs []net.IP
+	var addrs []ZoneRecord
 	bs := make([]byte, 4)
 	for i := 0; i < numAnswers; i++ {
 		binary.LittleEndian.PutUint32(bs, uint32(i))
-		addrs = append(addrs, net.IPv4(bs[0], bs[1], bs[2], bs[3]))
+		addrs = append(addrs, Record{"", net.IPv4(bs[0], bs[1], bs[2], bs[3]), 0, 0})
 	}
 
 	// handler for the fallback server: it will just return a very long response

--- a/nameserver/zone_test.go
+++ b/nameserver/zone_test.go
@@ -14,7 +14,7 @@ func TestZone(t *testing.T) {
 		testAddr1        = "10.2.2.1/24"
 	)
 
-	var zone = new(ZoneDb)
+	var zone = NewZoneDb(DefaultLocalDomain)
 
 	ip, _, _ := net.ParseCIDR(testAddr1)
 	err := zone.AddRecord(containerID, successTestName, ip)
@@ -30,7 +30,7 @@ func TestZone(t *testing.T) {
 	foundIP, err := zone.LookupName(successTestName)
 	wt.AssertNoErr(t, err)
 
-	if !foundIP.Equal(ip) {
+	if !foundIP[0].IP().Equal(ip) {
 		t.Fatal("Unexpected result for", successTestName, foundIP)
 	}
 
@@ -38,7 +38,7 @@ func TestZone(t *testing.T) {
 	foundName, err := zone.LookupInaddr("1.2.2.10.in-addr.arpa.")
 	wt.AssertNoErr(t, err)
 
-	if foundName != successTestName {
+	if foundName[0].Name() != successTestName {
 		t.Fatal("Unexpected result for", ip, foundName)
 	}
 
@@ -72,7 +72,7 @@ func TestDeleteFor(t *testing.T) {
 		addr1 = "10.2.2.3/24"
 		addr2 = "10.2.7.8/24"
 	)
-	zone := new(ZoneDb)
+	zone := NewZoneDb(DefaultLocalDomain)
 	for _, addr := range []string{addr1, addr2} {
 		ip, _, _ := net.ParseCIDR(addr)
 		err := zone.AddRecord(id, name, ip)

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -55,7 +55,7 @@ func main() {
 	InitDefaultLogging(debug)
 	Info.Printf("WeaveDNS version %s\n", version) // first thing in log: the version
 
-	var zone = weavedns.NewZoneDb(localDomain)
+	var zone = weavedns.NewZoneDb(domain)
 
 	if watch {
 		err := updater.Start(apiPath, zone)

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -55,7 +55,7 @@ func main() {
 	InitDefaultLogging(debug)
 	Info.Printf("WeaveDNS version %s\n", version) // first thing in log: the version
 
-	var zone = new(weavedns.ZoneDb)
+	var zone = weavedns.NewZoneDb(localDomain)
 
 	if watch {
 		err := updater.Start(apiPath, zone)


### PR DESCRIPTION
This pull request is the stepping stone for full support of multiple responses in WeaveDNS. It focuses in the mDNS client and server, where it provides

* support for "insistent" `Lookups` (maybe not the best name): mDNS queries that try to obtain as many responses as possible for up to 500ms (and, in consequence, they block for that period of time). This will be used in the next PR by a "updater" process that will _refresh_ the ZoneDb information by sending periodic queries to peers...
* support for multiple responses from all the `Lookup*()` methods
* a common `ZoneRecord` interface for many structs that contain names and IPs (used in `Lookup` methods, but also in the future database records)
* support for multiple records when building packets with `make*()` methods
* improved unit tests for mDNS

