### PR TITLE
always include the remote address in connection log entries

### DIFF
--- a/router/connection.go
+++ b/router/connection.go
@@ -82,7 +82,7 @@ func (conn *RemoteConnection) BreakTie(Connection) ConnectionTieBreak { return T
 func (conn *RemoteConnection) Shutdown(error)                         {}
 
 func (conn *RemoteConnection) Log(args ...interface{}) {
-	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s]:", conn.remote.FullName())), args...)...)
+	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote.FullName())), args...)...)
 }
 
 func (conn *RemoteConnection) String() string {
@@ -296,7 +296,7 @@ func (conn *LocalConnection) run(actionChan <-chan ConnectionAction, finished ch
 	if err = conn.handshake(enc, dec, acceptNewPeer); err != nil {
 		return
 	}
-	log.Printf("->[%s] completed handshake with %s\n", conn.remoteTCPAddr, conn.remote.FullName())
+	conn.Log("completed handshake")
 
 	if err = conn.initHeartbeats(); err != nil { // [1]
 		return

--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -104,9 +104,9 @@ func (cm *ConnectionMaker) String() string {
 				fmt.Fprintf(&buf, " (%s)", target.lastError)
 			}
 			if target.attempting {
-				fmt.Fprintf(&buf, " (trying since %v)\n", target.tryAfter)
+				fmt.Fprintf(&buf, " trying since %v\n", target.tryAfter)
 			} else {
-				fmt.Fprintf(&buf, " (next try at %v)\n", target.tryAfter)
+				fmt.Fprintf(&buf, " next try at %v\n", target.tryAfter)
 			}
 		}
 		resultChan <- buf.String()

--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -99,7 +99,7 @@ func (cm *ConnectionMaker) String() string {
 	cm.actionChan <- func() bool {
 		var buf bytes.Buffer
 		for address, target := range cm.targets {
-			fmt.Fprint(&buf, address)
+			fmt.Fprintf(&buf, "->[%s]", address)
 			if target.lastError != nil {
 				fmt.Fprintf(&buf, " (%s)", target.lastError)
 			}

--- a/router/peer.go
+++ b/router/peer.go
@@ -35,7 +35,7 @@ func NewPeer(name PeerName, nickName string, uid uint64, version uint64) *Peer {
 func (peer *Peer) String() string {
 	peer.RLock()
 	defer peer.RUnlock()
-	return fmt.Sprint("Peer ", peer.FullName(), " (v", peer.version, ") (UID ", peer.UID, ")")
+	return fmt.Sprint(peer.FullName(), " (v", peer.version, ") (UID ", peer.UID, ")")
 }
 
 func (peer *Peer) FullName() string {

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -67,9 +67,9 @@ ce:15:34:a9:b5:6d -> 7a:f4:56:87:76:3b(weave01) (2014-10-23 16:39:28.257103595 +
 9e:95:0c:54:8e:39 -> 7a:16:dd:5b:83:de(weave02) (2014-10-23 16:39:28.795601325 +0000 UTC)
 72:5f:a4:60:e5:ce -> 7a:16:dd:5b:83:de(weave02) (2014-10-23 16:39:29.575995255 +0000 UTC)
 Peers:
-Peer 7a:16:dd:5b:83:de(weave02) (v31) (UID 13151318985609435078)
+7a:16:dd:5b:83:de(weave02) (v31) (UID 13151318985609435078)
    -> 7a:f4:56:87:76:3b(weave01) [37.157.33.76:7195]
-Peer 7a:f4:56:87:76:3b(weave01) (v1) (UID 6913268221365110570)
+7a:f4:56:87:76:3b(weave01) (v1) (UID 6913268221365110570)
    -> 7a:16:dd:5b:83:de(weave02) [191.235.147.190:6783]
 Routes:
 unicast:
@@ -79,7 +79,7 @@ broadcast:
 7a:f4:56:87:76:3b -> [7a:16:dd:5b:83:de]
 7a:16:dd:5b:83:de -> []
 Reconnects:
-192.168.32.1:6783 (dial tcp4 192.168.32.1:6783: connection timed out) (next try at 2014-10-23 16:39:50.585932102 +0000 UTC)
+->[192.168.32.1:6783] (dial tcp4 192.168.32.1:6783: connection timed out) next try at 2014-10-23 16:39:50.585932102 +0000 UTC
 ````
 
 The terms used here are explained further at


### PR DESCRIPTION
in addition to the peer name/nick

This is handy for debugging, especially in situations when there are multiple connections in flight to the same peer.