### PR TITLE
Add optional hostname argument to weave expose

### DIFF
--- a/site/features.md
+++ b/site/features.md
@@ -190,6 +190,11 @@ invocation:
     host2# weave expose 10.2.1.102/24 10.2.2.102/24
     host2# weave hide 10.2.1.102/24 10.2.2.102/24
 
+Finally, exposed addresses can be added to weaveDNS by supplying a
+hostname:
+
+    host2# weave expose 10.2.1.102/24 -h exposed.weave.local
+
 ### <a name="service-export"></a>Service export
 
 Services running in containers on a weave network can be made

--- a/weave
+++ b/weave
@@ -23,7 +23,7 @@ usage() {
     echo "weave start      <cidr> [<cidr> ...] <container_id>"
     echo "weave attach     <cidr> [<cidr> ...] <container_id>"
     echo "weave detach     <cidr> [<cidr> ...] <container_id>"
-    echo "weave expose     <cidr>"
+    echo "weave expose     <cidr> [-h <hostname>]"
     echo "weave hide       <cidr>"
     echo "weave ps         [<container_id> ...]"
     echo "weave status"
@@ -760,7 +760,15 @@ case "$COMMAND" in
         ;;
     expose)
         [ $# -gt 0 ] || usage
-        for CIDR; do
+        collect_cidr_args "$@"
+        shift $CIDR_COUNT
+        if [ $# -eq 0 ]; then
+            FQDN=""
+        else
+            [ $# -eq 2 -a "$1" = "-h" ] || usage
+            FQDN="$2"
+        fi
+        for CIDR in $CIDR_ARGS; do
             validate_cidr $CIDR
             create_bridge --without-ethtool
             if ! ip addr show dev $BRIDGE | grep -qF $CIDR
@@ -769,6 +777,9 @@ case "$COMMAND" in
                 arp_update $BRIDGE $CIDR
                 add_iptables_rule nat WEAVE -o $BRIDGE ! -s $CIDR -j MASQUERADE
                 add_iptables_rule nat WEAVE -s $CIDR ! -o $BRIDGE -j MASQUERADE
+                if [ "$FQDN" ]; then
+                    http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT PUT /name/weave:expose/${CIDR%/*} --data-urlencode "fqdn=$FQDN" 2>/dev/null || true
+                fi
             fi
         done
         ;;
@@ -782,6 +793,7 @@ case "$COMMAND" in
                 ip addr del dev $BRIDGE $CIDR
                 delete_iptables_rule nat WEAVE -o $BRIDGE ! -s $CIDR -j MASQUERADE
                 delete_iptables_rule nat WEAVE -s $CIDR ! -o $BRIDGE -j MASQUERADE
+                http_call $DNS_CONTAINER_NAME $DNS_HTTP_PORT DELETE /name/weave:expose/${CIDR%/*} 2>/dev/null || true
             fi
         done
         ;;


### PR DESCRIPTION
Fix #375:
````
vagrant@ubuntu-14:~/weave$ ./weave expose 10.1.1.1/24 -h myservice.weave.local
vagrant@ubuntu-14:~/weave$ ./weave status
weave router git-59ae50eb4ef9
Encryption off
Our name is 7a:c5:c4:15:be:33(ubuntu-14)
Sniffing traffic on &{10 65535 ethwe 16:3d:0b:8a:66:e4 up|broadcast|multicast}
MACs:
7a:c5:c4:15:be:33 -> 7a:c5:c4:15:be:33(ubuntu-14) (2015-04-16 09:23:30.45427506 +0000 UTC)
6a:0a:da:89:30:de -> 7a:c5:c4:15:be:33(ubuntu-14) (2015-04-16 09:22:13.804277587 +0000 UTC)
16:3d:0b:8a:66:e4 -> 7a:c5:c4:15:be:33(ubuntu-14) (2015-04-16 09:22:03.786283726 +0000 UTC)
32:dd:63:79:54:df -> 7a:c5:c4:15:be:33(ubuntu-14) (2015-04-16 09:22:04.374157935 +0000 UTC)
Peers:
Peer 7a:c5:c4:15:be:33(ubuntu-14) (v0) (UID 5547860031843093274)
Routes:
unicast:
7a:c5:c4:15:be:33 -> 00:00:00:00:00:00
broadcast:
7a:c5:c4:15:be:33 -> []
Reconnects:


weave DNS git-59ae50eb4ef9
Local domain weave.local.
Listen address :53
mDNS interface &{14 65535 ethwe 6a:0a:da:89:30:de up|broadcast|multicast}
Fallback DNS config &{[66.28.0.45 8.8.8.8] [] 53 1 5 2}
Zone database:
weave:expose 10.1.1.1 myservice.weave.local.
````

There are however a number of caveats as compared to the behaviour of `-h` as used in conjunction with run:

* `weave hide` cannot remove the DNS entries in the same way that `weave detach` does as there is no container in which to persist the metadata 
* We have to use the synthetic container ID of `weave:expose` when we interact with the DNS REST API (@inercia can you foresee any problems with this?)