### PR TITLE
Fix multi cidr error messages

### DIFF
--- a/weave
+++ b/weave
@@ -147,6 +147,9 @@ collect_cidr_args() {
         CIDR_COUNT=$(($CIDR_COUNT + 1))
         shift 1
     done
+    if [ $CIDR_COUNT -eq 0 ]; then
+        [ $# -gt 0 ] && validate_cidr "$1" || usage
+    fi
 }
 
 run_iptables() {

--- a/weave
+++ b/weave
@@ -802,8 +802,10 @@ case "$COMMAND" in
         ;;
     hide)
         [ $# -gt 0 ] || usage
+        collect_cidr_args "$@"
+        shift $CIDR_COUNT
         create_bridge --without-ethtool
-        for CIDR; do
+        for CIDR in $CIDR_ARGS; do
             validate_cidr $CIDR
             if ip addr show dev $BRIDGE | grep -qF $CIDR
             then

--- a/weave
+++ b/weave
@@ -751,9 +751,9 @@ case "$COMMAND" in
         echo -n $DNS_ARGS
         ;;
     start)
-        [ $# -gt 1 ] || usage
         collect_cidr_args "$@"
         shift $CIDR_COUNT
+        [ $# -eq 1 ] || usage
         CONTAINER_ID="$1"
         create_bridge
         CONTAINER=$(docker start $CONTAINER_ID)
@@ -762,24 +762,23 @@ case "$COMMAND" in
         echo $CONTAINER
         ;;
     attach)
-        [ $# -gt 1 ] || usage
         collect_cidr_args "$@"
         shift $CIDR_COUNT
+        [ $# -eq 1 ] || usage
         CONTAINER_ID="$1"
         create_bridge
         with_container_netns $CONTAINER_ID attach $CIDR_ARGS >/dev/null
         tell_dns PUT $CONTAINER_ID $CIDR_ARGS
         ;;
     detach)
-        [ $# -gt 1 ] || usage
         collect_cidr_args "$@"
         shift $CIDR_COUNT
+        [ $# -eq 1 ] || usage
         CONTAINER_ID="$1"
         with_container_netns $CONTAINER_ID detach $CIDR_ARGS >/dev/null
         tell_dns DELETE $CONTAINER_ID $CIDR_ARGS
         ;;
     expose)
-        [ $# -gt 0 ] || usage
         collect_cidr_args "$@"
         shift $CIDR_COUNT
         if [ $# -eq 0 ]; then
@@ -804,12 +803,11 @@ case "$COMMAND" in
         done
         ;;
     hide)
-        [ $# -gt 0 ] || usage
         collect_cidr_args "$@"
         shift $CIDR_COUNT
+        [ $# -eq 0 ] || usage
         create_bridge --without-ethtool
         for CIDR in $CIDR_ARGS; do
-            validate_cidr $CIDR
             if ip addr show dev $BRIDGE | grep -qF $CIDR
             then
                 ip addr del dev $BRIDGE $CIDR


### PR DESCRIPTION
Fixes #568:
````
vagrant@ubuntu-14:~/weave$ ./weave run -ti ubuntu
Invalid CIDR: -ti
CIDR must of be of form <ip_address>/<routing_prefix_length>, e.g. 10.2.1.1/24
vagrant@ubuntu-14:~/weave$ ./weave start foo bar
Invalid CIDR: foo
CIDR must of be of form <ip_address>/<routing_prefix_length>, e.g. 10.2.1.1/24
vagrant@ubuntu-14:~/weave$ ./weave attach foo bar
Invalid CIDR: foo
CIDR must of be of form <ip_address>/<routing_prefix_length>, e.g. 10.2.1.1/24
vagrant@ubuntu-14:~/weave$ ./weave detach foo bar
Invalid CIDR: foo
CIDR must of be of form <ip_address>/<routing_prefix_length>, e.g. 10.2.1.1/24
vagrant@ubuntu-14:~/weave$ ./weave expose foo
Invalid CIDR: foo
CIDR must of be of form <ip_address>/<routing_prefix_length>, e.g. 10.2.1.1/24
vagrant@ubuntu-14:~/weave$ ./weave hide foo
Invalid CIDR: foo
CIDR must of be of form <ip_address>/<routing_prefix_length>, e.g. 10.2.1.1/24
vagrant@ubuntu-14:~/weave$ ./weave hide 10.0.0.1/24 foo
Invalid CIDR: foo
CIDR must of be of form <ip_address>/<routing_prefix_length>, e.g. 10.2.1.1/24
````