### PR TITLE
return NXDOMAIN instead of NOTIMP

### DIFF
--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -74,14 +74,6 @@ func makeDNSFailResponse(r *dns.Msg) *dns.Msg {
 	return m
 }
 
-func makeDNSNotImplResponse(r *dns.Msg) *dns.Msg {
-	m := new(dns.Msg)
-	m.SetReply(r)
-	m.RecursionAvailable = true
-	m.Rcode = dns.RcodeNotImplemented
-	return m
-}
-
 // get the maximum UDP-reply length
 func getMaxReplyLen(r *dns.Msg, proto dnsProtocol) int {
 	maxLen := minUDPSize

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -277,7 +277,7 @@ func (s *DNSServer) commonQueryHandler(proto dnsProtocol, kind string, qtype uin
 		// catch unsupported queries
 		if q.Qtype != qtype {
 			Debug.Printf("[dns msgid %d] Unsupported query type %s", r.MsgHdr.Id, dns.TypeToString[q.Qtype])
-			m := makeDNSNotImplResponse(r)
+			m := makeDNSFailResponse(r)
 			s.cache.Put(r, m, negLocalTTL, 0)
 			w.WriteMsg(m)
 			return

--- a/nameserver/server_test.go
+++ b/nameserver/server_test.go
@@ -101,8 +101,8 @@ func TestUDPDNSServer(t *testing.T) {
 
 	assertExchange(t, testRDNSfail, dns.TypePTR, 0, 0, dns.RcodeNameError)
 
-	// This should fail because we don't handle MX records
-	assertExchange(t, successTestName, dns.TypeMX, 0, 0, dns.RcodeNotImplemented)
+	// This should fail because we don't have information about MX records
+	assertExchange(t, successTestName, dns.TypeMX, 0, 0, dns.RcodeNameError)
 
 	// This non-local query for an MX record should succeed by being
 	// passed on to the fallback server

--- a/test/200_dns_test.sh
+++ b/test/200_dns_test.sh
@@ -15,4 +15,7 @@ weave_on $HOST1 run --with-dns $C1/24 -t --name=c1 aanand/docker-dnsutils /bin/s
 
 assert_dns_record $HOST1 c1 $NAME $C2
 
+assert_dns_status $HOST1 c1 "MX   seetwo.weave.local" NXDOMAIN
+assert_dns_status $HOST1 c1 "AAAA seetwo.weave.local" NXDOMAIN
+
 end_suite

--- a/test/config.sh
+++ b/test/config.sh
@@ -88,6 +88,18 @@ exec_on() {
     docker -H tcp://$host:2375 exec $container "$@"
 }
 
+dig_on() {
+    host=$1
+    cont=$2
+    query=$3
+    docker -H tcp://$host:2375 exec $cont sh -c "dig $query"
+}
+
+# assert_dns_status <host> <container> <name> <query> <status>
+assert_dns_status() {
+    assert_raises "dig_on \"$1\" \"$2\" \"$3\" | grep -q \"status: $4\""
+}
+
 # assert_dns_record <host> <container> <name> <ip>
 assert_dns_record() {
     assert "exec_on $1 $2 getent hosts $3 | tr -s ' '" "$4 $3"


### PR DESCRIPTION
Fixes #588 by returning NOTIMP for some unimplemented query types, NXDOMAIN otherwise