### PR TITLE
Detach of unattached container succeeds silently

### DIFF
--- a/weave
+++ b/weave
@@ -392,6 +392,8 @@ attach() {
 }
 
 detach() {
+    netnsenter ip link show $CONTAINER_IFNAME >/dev/null 2>&1 || return 0
+
     for ADDR; do
         if ! netnsenter ip addr show dev $CONTAINER_IFNAME | grep -F $ADDR >/dev/null ; then
             # address is not there, leave the device alone


### PR DESCRIPTION
Fixes #596.
````
vagrant@vagrant-ubuntu-utopic-64:~/weave$ ./weave launch
a4eba9d1b0a3dd0fd12ac3ce032387e1528b51641f286cf446182168c7983625
vagrant@vagrant-ubuntu-utopic-64:~/weave$ C=$(docker run -d -ti ubuntu)
vagrant@vagrant-ubuntu-utopic-64:~/weave$ ./weave detach 10.2.0.1/24 $C
vagrant@vagrant-ubuntu-utopic-64:~/weave$ echo $?
0
vagrant@vagrant-ubuntu-utopic-64:~/weave$ sudo ./weave --local detach 10.2.0.1/24 $C
vagrant@vagrant-ubuntu-utopic-64:~/weave$ echo $?
0
````