### PR TITLE
Improve the "Generic error" message when compiled against old libpcap

### DIFF
--- a/router/pcap.go
+++ b/router/pcap.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"code.google.com/p/gopacket/pcap"
+	"fmt"
 )
 
 type PcapIO struct {
@@ -44,6 +45,17 @@ func newPcapIO(ifName string, promisc bool, snaplen int, bufSz int) (handle *Pca
 		return
 	}
 	if err = inactive.SetImmediateMode(true); err != nil {
+		// If gopacket is compiled against an older pcap.h
+		// that doesn't have pcap_set_immediate_mode, it
+		// supplies a dummy definition that always returns
+		// PCAP_ERROR.  That becomes "Generic error", which is
+		// not very helpful.  The real pcap_set_set_immediate
+		// never returns PCAP_ERROR, so this turns it into a
+		// more informative message.
+		if fmt.Sprint(err) == "Generic error" {
+			err = fmt.Errorf("compiled against an old version of libpcap; please compile against libpcap-1.5.0 or later")
+		}
+
 		return
 	}
 	if err = inactive.SetBufferSize(bufSz); err != nil {


### PR DESCRIPTION
If gopacket is compiled against an older pcap.h that doesn't have pcap_set_immediate_mode, it supplies a dummy definition that  always returns PCAP_ERROR.  That becomes "Generic error", which is not very helpful.  The real pcap_set_set_immediate never returns PCAP_ERROR, so this turns it into a more informative message.

Fixes #623 