### PR TITLE
Improvements to circle ci integration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+general:
+  branches:
+    ignore:
+      - gh-pages
+
 machine:
   services:
     - docker
@@ -6,18 +11,26 @@ machine:
     SRCDIR: /home/ubuntu/src/github.com/weaveworks/weave
     PATH: $PATH:$HOME/.local/bin:$HOME/google-cloud-sdk/bin/
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    WEAVE_BUILD: $HOME/docker/weave-build.tar
 
 dependencies:
+  cache_directories:
+    - "~/docker"
+  override:
+      - if [[ -e "$WEAVE_BUILD" ]]; then
+          docker load -i $WEAVE_BUILD;
+        else
+          docker pull weaveworks/weave-build;
+          mkdir -p $(dirname "$WEAVE_BUILD");
+          docker save weaveworks/weave-build >$WEAVE_BUILD;
+        fi
   post:
-    - docker build -t weaveworks/weave-build build
-    - pip install --user --upgrade gcloud gsutil
     - curl https://sdk.cloud.google.com | bash
     - bin/setup-circleci-secrets "$SECRET_PASSWORD"
-
-test:
-  pre:
     - mkdir -p $(dirname $SRCDIR)
     - cp -r $(pwd)/ $SRCDIR
+
+test:
   override:
     - docker run -v /var/run/docker.sock:/run/docker.sock -v /home/ubuntu:/home/go weaveworks/weave-build
     - cd $SRCDIR/test; ./gce.sh setup


### PR DESCRIPTION
- Don't need gsutil on circle
- Use a prebuild weave-build image and cache it locally.
- Name VMs after change I'm building, so I can do multiple concurrently
- Don't build gh-pages branch