### PR TITLE
Fixes post #612

### DIFF
--- a/site/build-and-publish.sh
+++ b/site/build-and-publish.sh
@@ -26,7 +26,7 @@ gsutil -m cp -z html,css -a public-read -R _site "gs://docs.weave.works/${OUTPUT
 
 echo "Published at http://docs.weave.works/${OUTPUT}"
 
-if [ -z "${TRAVIS_TAG}" ]; then
+if [ -z "${TRAVIS_TAG}" -a ! "${BRANCH}" = "latest_release_doc_updates" ]; then
   echo "<meta http-equiv=\"refresh\" content=\"0; url=http://docs.weave.works/${OUTPUT}\" />" \
     | gsutil \
       -h "Content-Type:text/html" \

--- a/site/build-and-publish.sh
+++ b/site/build-and-publish.sh
@@ -22,7 +22,7 @@ export BRANCH COMMIT OUTPUT
 bundle install --path=.bundle
 bundle exec jekyll build --verbose
 
-gsutil -m cp -z html,css -a public-read -R _site "gs://docs.weave.works/${OUTPUT}"
+gsutil -m rsync -d _site "gs://docs.weave.works/${OUTPUT}"
 
 echo "Published at http://docs.weave.works/${OUTPUT}"
 


### PR DESCRIPTION
Use rsync instead of cp to avoid uploading site to a subdirectory (when the directory already exists).