### PR TITLE
eliminate route calculcation deadlock

### DIFF
--- a/router/connection.go
+++ b/router/connection.go
@@ -412,7 +412,7 @@ func (conn *LocalConnection) shutdown(err error) {
 	}
 
 	if conn.remote != nil {
-		conn.remote.DecrementLocalRefCount()
+		conn.Router.Peers.Dereference(conn.remote)
 		conn.Router.Ourself.DeleteConnection(conn)
 	}
 

--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -206,8 +206,13 @@ func (cm *ConnectionMaker) ourConnections() (PeerNameSet, map[string]struct{}, m
 
 func (cm *ConnectionMaker) addPeerTargets(ourConnectedPeers PeerNameSet, addTarget func(string)) {
 	cm.peers.ForEach(func(peer *Peer) {
-		for conn := range peer.Connections() {
-			otherPeer := conn.Remote().Name
+		if peer == cm.ourself.Peer {
+			return
+		}
+		// Modifying peer.connections requires a write lock on Peers,
+		// and since we are holding a read lock (due to the ForEach),
+		// access without locking the peer is safe.
+		for otherPeer, conn := range peer.connections {
 			if otherPeer == cm.ourself.Name {
 				continue
 			}

--- a/router/gossip_test.go
+++ b/router/gossip_test.go
@@ -79,7 +79,8 @@ func (router *Router) tp(routers ...*Router) *Peer {
 		p := NewPeer(r.Ourself.Peer.Name, "", r.Ourself.Peer.UID, r.Ourself.Peer.version)
 		connections[r.Ourself.Peer.Name] = newMockConnection(peer, p)
 	}
-	peer.SetVersionAndConnections(router.Ourself.Peer.version, connections)
+	peer.version = router.Ourself.Peer.version
+	peer.connections = connections
 	return peer
 }
 

--- a/router/gossip_test.go
+++ b/router/gossip_test.go
@@ -55,8 +55,8 @@ func (router *Router) DeleteTestChannelConnection(r *Router) {
 	fromPeer, _ := r.Peers.Fetch(fromName)
 	toPeer, _ := router.Peers.Fetch(toName)
 
-	fromPeer.DecrementLocalRefCount()
-	toPeer.DecrementLocalRefCount()
+	r.Peers.Dereference(fromPeer)
+	router.Peers.Dereference(toPeer)
 
 	conn, _ := router.Ourself.ConnectionTo(toName)
 	router.Ourself.handleDeleteConnection(conn)

--- a/router/handshake.go
+++ b/router/handshake.go
@@ -75,7 +75,7 @@ func (conn *LocalConnection) handshake(enc *gob.Encoder, dec *gob.Decoder, accep
 			return fmt.Errorf("Found unknown remote name: %s at %s", name, conn.remoteTCPAddr)
 		}
 	}
-	if existingConn, found := conn.local.ConnectionTo(name); found && existingConn.Established() {
+	if existingConn, found := conn.Router.Ourself.ConnectionTo(name); found && existingConn.Established() {
 		return fmt.Errorf("Already have connection to %s at %s", existingConn.Remote(), existingConn.RemoteTCPAddr())
 	}
 	uid, err := strconv.ParseUint(uidStr, 10, 64)

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sync"
 	"time"
 )
 
 type LocalPeer struct {
+	sync.RWMutex
 	*Peer
 	router     *Router
 	actionChan chan<- LocalPeerAction

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -75,6 +75,13 @@ func (peer *LocalPeer) RelayBroadcast(srcPeer *Peer, df bool, frame []byte, dec 
 	}
 }
 
+func (peer *LocalPeer) ConnectionTo(name PeerName) (Connection, bool) {
+	peer.RLock()
+	defer peer.RUnlock()
+	conn, found := peer.connections[name]
+	return conn, found // yes, you really can't inline that. FFS.
+}
+
 func (peer *LocalPeer) ConnectionsTo(names []PeerName) []Connection {
 	conns := make([]Connection, 0, len(names))
 	peer.RLock()

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -75,6 +75,16 @@ func (peer *LocalPeer) RelayBroadcast(srcPeer *Peer, df bool, frame []byte, dec 
 	}
 }
 
+func (peer *LocalPeer) Connections() ConnectionSet {
+	connections := make(ConnectionSet)
+	peer.RLock()
+	defer peer.RUnlock()
+	for _, conn := range peer.connections {
+		connections[conn] = void
+	}
+	return connections
+}
+
 func (peer *LocalPeer) ConnectionTo(name PeerName) (Connection, bool) {
 	peer.RLock()
 	defer peer.RUnlock()

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -75,6 +75,12 @@ func (peer *LocalPeer) RelayBroadcast(srcPeer *Peer, df bool, frame []byte, dec 
 	}
 }
 
+func (peer *LocalPeer) Info() string {
+	peer.RLock()
+	defer peer.RUnlock()
+	return peer.Peer.Info()
+}
+
 func (peer *LocalPeer) Connections() ConnectionSet {
 	connections := make(ConnectionSet)
 	peer.RLock()

--- a/router/mocks_test.go
+++ b/router/mocks_test.go
@@ -33,7 +33,7 @@ func (peers *Peers) AddTestRemoteConnection(p1, p2 *Peer) {
 func (peers *Peers) DeleteTestConnection(p *Peer) {
 	toName := p.Name
 	toPeer, _ := peers.Fetch(toName)
-	toPeer.DecrementLocalRefCount()
+	peers.Dereference(toPeer)
 	conn, _ := peers.ourself.ConnectionTo(toName)
 	peers.ourself.deleteConnection(conn)
 }

--- a/router/mocks_test.go
+++ b/router/mocks_test.go
@@ -14,7 +14,7 @@ import (
 func (peers *Peers) AddTestConnection(p *Peer) {
 	toPeer := NewPeer(p.Name, "", p.UID, 0)
 	peers.FetchWithDefault(toPeer) // Has side-effect of incrementing refcount
-	conn := newMockConnection(peers.ourself, toPeer)
+	conn := newMockConnection(peers.ourself.Peer, toPeer)
 	peers.ourself.addConnection(conn)
 	peers.ourself.connectionEstablished(conn)
 }

--- a/router/peer.go
+++ b/router/peer.go
@@ -42,12 +42,6 @@ func (peer *Peer) Info() string {
 	return fmt.Sprint(peer.String(), " (v", peer.version, ") (UID ", peer.UID, ")")
 }
 
-func (peer *Peer) Version() uint64 {
-	peer.RLock()
-	defer peer.RUnlock()
-	return peer.version
-}
-
 func (peer *Peer) Connections() ConnectionSet {
 	connections := make(ConnectionSet)
 	peer.RLock()

--- a/router/peer.go
+++ b/router/peer.go
@@ -48,13 +48,6 @@ func (peer *Peer) Version() uint64 {
 	return peer.version
 }
 
-func (peer *Peer) ConnectionTo(name PeerName) (Connection, bool) {
-	peer.RLock()
-	defer peer.RUnlock()
-	conn, found := peer.connections[name]
-	return conn, found // yes, you really can't inline that. FFS.
-}
-
 func (peer *Peer) Connections() ConnectionSet {
 	connections := make(ConnectionSet)
 	peer.RLock()

--- a/router/peer.go
+++ b/router/peer.go
@@ -42,13 +42,6 @@ func (peer *Peer) Info() string {
 	return fmt.Sprint(peer.String(), " (v", peer.version, ") (UID ", peer.UID, ")")
 }
 
-func (peer *Peer) SetVersionAndConnections(version uint64, connections map[PeerName]Connection) {
-	peer.Lock()
-	defer peer.Unlock()
-	peer.version = version
-	peer.connections = connections
-}
-
 // Calculate the routing table from this peer to all peers reachable
 // from it, returning a "next hop" map of PeerNameX -> PeerNameY,
 // which says "in order to send a message to X, the peer should send

--- a/router/peer.go
+++ b/router/peer.go
@@ -42,16 +42,6 @@ func (peer *Peer) Info() string {
 	return fmt.Sprint(peer.String(), " (v", peer.version, ") (UID ", peer.UID, ")")
 }
 
-func (peer *Peer) Connections() ConnectionSet {
-	connections := make(ConnectionSet)
-	peer.RLock()
-	defer peer.RUnlock()
-	for _, conn := range peer.connections {
-		connections[conn] = void
-	}
-	return connections
-}
-
 func (peer *Peer) SetVersionAndConnections(version uint64, connections map[PeerName]Connection) {
 	peer.Lock()
 	defer peer.Unlock()

--- a/router/peer.go
+++ b/router/peer.go
@@ -66,12 +66,6 @@ func (peer *Peer) IsLocallyReferenced() bool {
 	return peer.localRefCount != 0
 }
 
-func (peer *Peer) ConnectionCount() int {
-	peer.RLock()
-	defer peer.RUnlock()
-	return len(peer.connections)
-}
-
 func (peer *Peer) ConnectionTo(name PeerName) (Connection, bool) {
 	peer.RLock()
 	defer peer.RUnlock()
@@ -94,26 +88,6 @@ func (peer *Peer) SetVersionAndConnections(version uint64, connections map[PeerN
 	defer peer.Unlock()
 	peer.version = version
 	peer.connections = connections
-}
-
-func (peer *Peer) addConnection(conn Connection) {
-	peer.Lock()
-	defer peer.Unlock()
-	peer.connections[conn.Remote().Name] = conn
-	peer.version++
-}
-
-func (peer *Peer) deleteConnection(conn Connection) {
-	peer.Lock()
-	defer peer.Unlock()
-	delete(peer.connections, conn.Remote().Name)
-	peer.version++
-}
-
-func (peer *Peer) connectionEstablished(conn Connection) {
-	peer.Lock()
-	defer peer.Unlock()
-	peer.version++
 }
 
 // Calculate the routing table from this peer to all peers reachable

--- a/router/peer.go
+++ b/router/peer.go
@@ -37,8 +37,6 @@ func (peer *Peer) String() string {
 }
 
 func (peer *Peer) Info() string {
-	peer.RLock()
-	defer peer.RUnlock()
 	return fmt.Sprint(peer.String(), " (v", peer.version, ") (UID ", peer.UID, ")")
 }
 

--- a/router/peer.go
+++ b/router/peer.go
@@ -13,7 +13,7 @@ type Peer struct {
 	NickName      string
 	UID           uint64
 	version       uint64
-	localRefCount uint64
+	localRefCount uint64 // maintained by Peers
 	connections   map[PeerName]Connection
 }
 
@@ -46,24 +46,6 @@ func (peer *Peer) Version() uint64 {
 	peer.RLock()
 	defer peer.RUnlock()
 	return peer.version
-}
-
-func (peer *Peer) IncrementLocalRefCount() {
-	peer.Lock()
-	defer peer.Unlock()
-	peer.localRefCount++
-}
-
-func (peer *Peer) DecrementLocalRefCount() {
-	peer.Lock()
-	defer peer.Unlock()
-	peer.localRefCount--
-}
-
-func (peer *Peer) IsLocallyReferenced() bool {
-	peer.RLock()
-	defer peer.RUnlock()
-	return peer.localRefCount != 0
 }
 
 func (peer *Peer) ConnectionTo(name PeerName) (Connection, bool) {

--- a/router/peers.go
+++ b/router/peers.go
@@ -270,8 +270,8 @@ func (peers *Peers) applyUpdate(decodedUpdate []*Peer, decodedConns [][]Connecti
 		// for an update would be someone else calling
 		// router.Peers.ApplyUpdate. But ApplyUpdate takes the Lock on
 		// the router.Peers, so there can be no race here.
-		conns := makeConnsMap(peer, connSummaries, peers.table)
-		peer.SetVersionAndConnections(newPeer.version, conns)
+		peer.version = newPeer.version
+		peer.connections = makeConnsMap(peer, connSummaries, peers.table)
 		newUpdate[name] = peer
 	}
 	return newUpdate

--- a/router/peers.go
+++ b/router/peers.go
@@ -242,7 +242,7 @@ func (peers *Peers) applyUpdate(decodedUpdate []*Peer, decodedConns [][]Connecti
 		// guaranteed to find peer in the peers.table
 		peer := peers.table[name]
 		if peer != newPeer &&
-			(peer == peers.ourself.Peer || peer.Version() >= newPeer.Version()) {
+			(peer == peers.ourself.Peer || peer.version >= newPeer.version) {
 			// Nobody but us updates us. And if we know more about a
 			// peer than what's in the the update, we ignore the
 			// latter.
@@ -259,7 +259,7 @@ func (peers *Peers) applyUpdate(decodedUpdate []*Peer, decodedConns [][]Connecti
 		// router.Peers.ApplyUpdate. But ApplyUpdate takes the Lock on
 		// the router.Peers, so there can be no race here.
 		conns := makeConnsMap(peer, connSummaries, peers.table)
-		peer.SetVersionAndConnections(newPeer.Version(), conns)
+		peer.SetVersionAndConnections(newPeer.version, conns)
 		newUpdate[name] = peer
 	}
 	return newUpdate

--- a/router/peers.go
+++ b/router/peers.go
@@ -182,7 +182,9 @@ func (peers *Peers) String() string {
 
 func (peers *Peers) garbageCollect() []*Peer {
 	removed := []*Peer{}
+	peers.ourself.RLock()
 	_, reached := peers.ourself.Routes(nil, false)
+	peers.ourself.RUnlock()
 	for name, peer := range peers.table {
 		if _, found := reached[peer.Name]; !found && peer.localRefCount == 0 {
 			delete(peers.table, name)

--- a/router/peers.go
+++ b/router/peers.go
@@ -10,7 +10,7 @@ import (
 
 type Peers struct {
 	sync.RWMutex
-	ourself *Peer
+	ourself *LocalPeer
 	table   map[PeerName]*Peer
 	onGC    func(*Peer)
 }
@@ -39,7 +39,7 @@ type ConnectionSummary struct {
 	Established   bool
 }
 
-func NewPeers(ourself *Peer, onGC func(*Peer)) *Peers {
+func NewPeers(ourself *LocalPeer, onGC func(*Peer)) *Peers {
 	return &Peers{
 		ourself: ourself,
 		table:   make(map[PeerName]*Peer),
@@ -250,7 +250,7 @@ func (peers *Peers) applyUpdate(decodedUpdate []*Peer, decodedConns [][]Connecti
 		// guaranteed to find peer in the peers.table
 		peer := peers.table[name]
 		if peer != newPeer &&
-			(peer == peers.ourself || peer.Version() >= newPeer.Version()) {
+			(peer == peers.ourself.Peer || peer.Version() >= newPeer.Version()) {
 			// Nobody but us updates us. And if we know more about a
 			// peer than what's in the the update, we ignore the
 			// latter.

--- a/router/peers.go
+++ b/router/peers.go
@@ -160,12 +160,13 @@ func (peers *Peers) String() string {
 		fmt.Fprintf(&buf, "   -> %s [%v%s]\n", conn.Remote(), conn.RemoteTCPAddr(), established)
 	}
 	peers.ForEach(func(peer *Peer) {
-		fmt.Fprintln(&buf, peer.Info())
 		if peer == peers.ourself.Peer {
+			fmt.Fprintln(&buf, peers.ourself.Info())
 			for conn := range peers.ourself.Connections() {
 				printConnection(conn)
 			}
 		} else {
+			fmt.Fprintln(&buf, peer.Info())
 			// Modifying peer.connections requires a write lock on
 			// Peers, and since we are holding a read lock (due to the
 			// ForEach), access without locking the peer is safe.

--- a/router/peers_test.go
+++ b/router/peers_test.go
@@ -17,10 +17,10 @@ import (
 // - non-gc of peers that are only referenced locally
 
 func newNode(name PeerName) (*Peer, *Peers) {
-	peer := NewPeer(name, "", 0, 0)
+	peer := NewLocalPeer(name, "", nil)
 	peers := NewPeers(peer, func(*Peer) {})
-	peers.FetchWithDefault(peer)
-	return peer, peers
+	peers.FetchWithDefault(peer.Peer)
+	return peer.Peer, peers
 }
 
 // Check that ApplyUpdate copies the whole topology from peers
@@ -29,7 +29,7 @@ func checkApplyUpdate(t *testing.T, peers *Peers) {
 	// We need a new node outside of the network, with a connection
 	// into it.
 	_, testBedPeers := newNode(dummyName)
-	testBedPeers.AddTestConnection(peers.ourself)
+	testBedPeers.AddTestConnection(peers.ourself.Peer)
 	testBedPeers.ApplyUpdate(peers.EncodePeers(peers.Names()))
 
 	checkTopologyPeers(t, true, testBedPeers.allPeersExcept(dummyName), peers.allPeers()...)

--- a/router/peers_test.go
+++ b/router/peers_test.go
@@ -52,7 +52,7 @@ func TestPeersEncoding(t *testing.T) {
 		case 0:
 			from, to := rand.Intn(numNodes), rand.Intn(numNodes)
 			if from != to {
-				if _, found := peer[from].ConnectionTo(peer[to].Name); !found {
+				if _, found := peer[from].connections[peer[to].Name]; !found {
 					ps[from].AddTestConnection(peer[to])
 					conns = append(conns, struct{ from, to int }{from, to})
 					checkApplyUpdate(t, ps[from])

--- a/router/router.go
+++ b/router/router.go
@@ -66,7 +66,7 @@ func NewRouter(config RouterConfig, name PeerName, nickName string) *Router {
 	router.Macs = NewMacCache(macMaxAge, onMacExpiry)
 	router.Peers = NewPeers(router.Ourself, onPeerGC)
 	router.Peers.FetchWithDefault(router.Ourself.Peer)
-	router.Routes = NewRoutes(router.Ourself.Peer, router.Peers)
+	router.Routes = NewRoutes(router.Ourself, router.Peers)
 	router.ConnectionMaker = NewConnectionMaker(router.Ourself, router.Peers, router.Port)
 	router.TopologyGossip = router.NewGossip("topology", router)
 	return router

--- a/router/router.go
+++ b/router/router.go
@@ -64,7 +64,7 @@ func NewRouter(config RouterConfig, name PeerName, nickName string) *Router {
 	}
 	router.Ourself = NewLocalPeer(name, nickName, router)
 	router.Macs = NewMacCache(macMaxAge, onMacExpiry)
-	router.Peers = NewPeers(router.Ourself.Peer, onPeerGC)
+	router.Peers = NewPeers(router.Ourself, onPeerGC)
 	router.Peers.FetchWithDefault(router.Ourself.Peer)
 	router.Routes = NewRoutes(router.Ourself.Peer, router.Peers)
 	router.ConnectionMaker = NewConnectionMaker(router.Ourself, router.Peers, router.Port)

--- a/router/routes.go
+++ b/router/routes.go
@@ -9,7 +9,7 @@ import (
 
 type Routes struct {
 	sync.RWMutex
-	ourself      *Peer
+	ourself      *LocalPeer
 	peers        *Peers
 	unicast      map[PeerName]PeerName
 	unicastAll   map[PeerName]PeerName // [1]
@@ -21,7 +21,7 @@ type Routes struct {
 	// symmetric ones
 }
 
-func NewRoutes(ourself *Peer, peers *Peers) *Routes {
+func NewRoutes(ourself *LocalPeer, peers *Peers) *Routes {
 	routes := &Routes{
 		ourself:      ourself,
 		peers:        peers,
@@ -219,7 +219,7 @@ func (routes *Routes) calculateBroadcast(establishedAndSymmetric bool) map[PeerN
 
 	routes.peers.ForEach(func(peer *Peer) {
 		hops := []PeerName{}
-		if found, reached := peer.Routes(ourself, establishedAndSymmetric); found {
+		if found, reached := peer.Routes(ourself.Peer, establishedAndSymmetric); found {
 			// This is rather similar to the inner loop on
 			// peer.Routes(...); the main difference is in the
 			// locking.

--- a/router/routes.go
+++ b/router/routes.go
@@ -231,7 +231,11 @@ func (routes *Routes) calculateBroadcast(establishedAndSymmetric bool) map[PeerN
 				if _, found := reached[remoteName]; found {
 					continue
 				}
-				if remoteConn, found := conn.Remote().ConnectionTo(ourself.Name); !establishedAndSymmetric || (found && remoteConn.Established()) {
+				// conn.Remote() cannot by ourself. Modifying
+				// peer.connections requires a write lock on Peers,
+				// and since we are holding a read lock (due to the
+				// ForEach), access without locking the peer is safe.
+				if remoteConn, found := conn.Remote().connections[ourself.Name]; !establishedAndSymmetric || (found && remoteConn.Established()) {
 					hops = append(hops, remoteName)
 				}
 			}


### PR DESCRIPTION
The principal idea here is to maintain just a single lock - on Peers - for the entire topology information, instead of individual locks for every peer. That makes sense since there are only two sources of updates to this information: a) topology updates received from other peers, the processing of which requires the Peers lock anyway, and b) reference counting as part of local connection lifecycle, which used to *sometimes* require the Peers lock, and now always does. Furthermore, there are very few consumers of the topology information - essentially just route calculation, gossip, connection management and diagnostics.

The exception is LocalPeer, the state of which changes based on local connection lifecycle, and is consumed in quite a few places. We therefore maintain a separate lock for that.  This does result in awkwardness in a few places since we need to make sure to acquire that lock when encountering the LocalPeer as part of topology traversal. Ultimately we may want to leave the LocalPeer out of Peers.table, but that is a fiddly change which I've decided to defer for now.

The above entails an almost complete separation between Peer and LocalPeer, the bulk of which is accomplished by moving methods from the former to the latter, or inlining them in Peers code.

Fixes #643.