### PR TITLE
Improve ipam error messages

### DIFF
--- a/ipam/allocate.go
+++ b/ipam/allocate.go
@@ -46,7 +46,7 @@ func (g *allocate) Try(alloc *Allocator) bool {
 }
 
 func (g *allocate) Cancel() {
-	g.resultChan <- allocateResult{0, fmt.Errorf("Allocate request for %s cancelled, g.ident")}
+	g.resultChan <- allocateResult{0, fmt.Errorf("Allocate request for %s cancelled", g.ident)}
 }
 
 func (g *allocate) String() string {

--- a/ipam/allocate.go
+++ b/ipam/allocate.go
@@ -46,7 +46,7 @@ func (g *allocate) Try(alloc *Allocator) bool {
 }
 
 func (g *allocate) Cancel() {
-	g.resultChan <- allocateResult{0, fmt.Errorf("Request Cancelled")}
+	g.resultChan <- allocateResult{0, fmt.Errorf("Allocate request for %s cancelled, g.ident")}
 }
 
 func (g *allocate) String() string {

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -242,7 +242,7 @@ func (alloc *Allocator) free(ident string) error {
 		found = alloc.cancelOpsFor(&alloc.pendingClaims, ident) || found
 
 		if !found {
-			errChan <- fmt.Errorf("No addresses for %s", ident)
+			errChan <- fmt.Errorf("Free: no addresses for %s", ident)
 			return
 		}
 		errChan <- nil

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -37,7 +37,11 @@ func (c *claim) Try(alloc *Allocator) bool {
 		return false
 	}
 	if owner != alloc.ourName {
-		c.resultChan <- fmt.Errorf("Address %s is owned by other peer %s", c.addr.String(), owner)
+		name, found := alloc.nicknames[owner]
+		if found {
+			name = " (" + name + ")"
+		}
+		c.resultChan <- fmt.Errorf("address %s is owned by other peer %s%s", c.addr.String(), owner, name)
 		return true
 	}
 	// We are the owner, check we haven't given it to another container
@@ -58,7 +62,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 		return true
 	}
 	// Addr already owned by container on this machine
-	c.resultChan <- fmt.Errorf("Claimed address %s is already owned by %s", c.addr.String(), existingIdent)
+	c.resultChan <- fmt.Errorf("address %s is already owned by %s", c.addr.String(), existingIdent)
 	return true
 }
 

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -12,7 +12,7 @@ import (
 
 func badRequest(w http.ResponseWriter, err error) {
 	http.Error(w, err.Error(), http.StatusBadRequest)
-	common.Warning.Println(err.Error())
+	common.Warning.Println("[allocator]:", err.Error())
 }
 
 // HandleHTTP wires up ipams HTTP endpoints to the provided mux.
@@ -26,7 +26,7 @@ func (alloc *Allocator) HandleHTTP(router *mux.Router) {
 			badRequest(w, err)
 			return
 		} else if err := alloc.Claim(ident, ip, closedChan); err != nil {
-			badRequest(w, fmt.Errorf("Unable to claim IP address %s: %s", ip, err))
+			badRequest(w, fmt.Errorf("Unable to claim: %s", err))
 			return
 		}
 


### PR DESCRIPTION
Make clear that they come from the IP allocator, and reduce repetition in the text.
Also include the nickname for other peer, if known.
Addresses #684