### PR TITLE
proxy needs to add weavewait to execs as well

### DIFF
--- a/proxy/common.go
+++ b/proxy/common.go
@@ -8,6 +8,10 @@ import (
 	. "github.com/weaveworks/weave/common"
 )
 
+var (
+	weaveWaitEntrypoint = []string{"/home/weavewait/weavewait"}
+)
+
 func callWeave(args ...string) ([]byte, error) {
 	args = append([]string{"--local"}, args...)
 	Debug.Print("Calling weave", args)

--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -75,7 +75,7 @@ func (i *createContainerInterceptor) setWeaveWaitEntrypoint(container *docker.Co
 		command = image.Cmd
 	}
 
-	container.Entrypoint = []string{"/home/weavewait/weavewait"}
+	container.Entrypoint = weaveWaitEntrypoint
 	container.Cmd = append(entry, command...)
 	return nil
 }

--- a/proxy/create_exec_interceptor.go
+++ b/proxy/create_exec_interceptor.go
@@ -1,0 +1,65 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/weaveworks/weave/common"
+)
+
+type createExecInterceptor struct {
+	client *docker.Client
+}
+
+type createExecRequestBody struct {
+	*docker.Config
+	HostConfig *docker.HostConfig `json:"HostConfig,omitempty" yaml:"HostConfig,omitempty"`
+	MacAddress string             `json:"MacAddress,omitempty" yaml:"MacAddress,omitempty"`
+}
+
+func (i *createExecInterceptor) InterceptRequest(r *http.Request) error {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+	Info.Println("CreateExecInterceptor Intercepting: ", string(body))
+
+	options := docker.CreateExecOptions{}
+	if err := json.Unmarshal(body, &options); err != nil {
+		return err
+	}
+
+	subs := containerIDRegexp.FindStringSubmatch(r.URL.Path)
+	if subs == nil {
+		Warning.Printf("No container id found in request with path %s", r.URL.Path)
+		return nil
+	}
+	containerID := subs[1]
+
+	container, err := i.client.InspectContainer(containerID)
+	if err != nil {
+		Warning.Printf("Error inspecting container %s: %v", containerID, err)
+		return nil
+	}
+
+	if _, ok := weaveCIDRsFromConfig(container.Config); ok {
+		options.Cmd = append(weaveWaitEntrypoint, options.Cmd...)
+	}
+
+	newBody, err := json.Marshal(options)
+	if err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
+	r.ContentLength = int64(len(newBody))
+
+	return nil
+}
+
+func (i *createExecInterceptor) InterceptResponse(r *http.Response) error {
+	return nil
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -14,6 +14,7 @@ import (
 var (
 	containerCreateRegexp = regexp.MustCompile("/v[0-9\\.]*/containers/create")
 	containerStartRegexp  = regexp.MustCompile("^/v[0-9\\.]*/containers/[^/]*/(re)?start$")
+	execCreateRegexp      = regexp.MustCompile("^/v[0-9\\.]*/containers/[^/]*/exec$")
 )
 
 type Proxy struct {
@@ -68,6 +69,8 @@ func (proxy *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		proxy.serveWithInterceptor(&createContainerInterceptor{proxy.client, proxy.withDNS, proxy.dockerBridgeIP}, w, r)
 	case containerStartRegexp.MatchString(path):
 		proxy.serveWithInterceptor(&startContainerInterceptor{proxy.client, proxy.withDNS}, w, r)
+	case execCreateRegexp.MatchString(path):
+		proxy.serveWithInterceptor(&createExecInterceptor{proxy.client}, w, r)
 	case strings.HasPrefix(path, "/weave"):
 		w.WriteHeader(http.StatusOK)
 	default:

--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -14,7 +14,7 @@ docker_proxy_on $HOST1 run -e WEAVE_CIDR=$C2/24 -dt --name=c2 -h $NAME gliderlab
 docker_proxy_on $HOST1 run -e WEAVE_CIDR=$C1/24 -dt --name=c1 aanand/docker-dnsutils /bin/sh
 
 docker_proxy_on $HOST1 restart c2
-assert_raises "exec_on $HOST1 c2 ip link show ethwe | grep 'state UP'"
+assert_raises "proxy_exec_on $HOST1 c2 ip link show ethwe | grep 'state \\(UP\\|UNKNOWN\\)'"
 assert_dns_record $HOST1 c1 $NAME $C2
 
 end_suite

--- a/test/config.sh
+++ b/test/config.sh
@@ -97,6 +97,14 @@ exec_on() {
     docker -H tcp://$host:2375 exec $container "$@"
 }
 
+proxy_exec_on() {
+    host=$1
+    container=$2
+    shift 2
+    docker -H tcp://$host:12375 exec $container "$@"
+}
+
+
 start_container() {
     host=$1
     shift 1


### PR DESCRIPTION
Bug came up in a test where we are restarting and doing an exec checking
a network interface right away. weavewait is only added if the container
has a WEAVE_CIDR var set, the same as at container creation.