### PR TITLE
Drop traffic from docker0 bridge to weave bridge

### DIFF
--- a/test/130_expose_test.sh
+++ b/test/130_expose_test.sh
@@ -25,10 +25,9 @@ check_container_connectivity() {
     exec_on1 "c1 $PING $C2"
     exec_on1 "c3 $PING $C4"
     exec_on1 "c5 $PING $C6"
-    # fails due to #620
-    # exec_on1 "c3 ! $PING $C1"
-    # exec_on1 "c5 ! $PING $C1"
-    # exec_on1 "c5 ! $PING $C3"
+    exec_on1 "c3 sh -c \"! $PING $C1\""
+    exec_on1 "c5 sh -c \"! $PING $C1\""
+    exec_on1 "c5 sh -c \"! $PING $C3\""
 }
 
 start_suite "exposing weave network to host"

--- a/test/130_expose_test.sh
+++ b/test/130_expose_test.sh
@@ -21,13 +21,14 @@ exec_on1() {
     assert_raises "exec_on  $HOST1 $@"
 }
 
+# Containers in the same subnet should be able to talk; different subnet not.
 check_container_connectivity() {
     exec_on1 "c1 $PING $C2"
     exec_on1 "c3 $PING $C4"
     exec_on1 "c5 $PING $C6"
-    exec_on1 "c3 sh -c \"! $PING $C1\""
+    exec_on1 "c1 sh -c \"! $PING $C3\""
+    exec_on1 "c3 sh -c \"! $PING $C5\""
     exec_on1 "c5 sh -c \"! $PING $C1\""
-    exec_on1 "c5 sh -c \"! $PING $C3\""
 }
 
 start_suite "exposing weave network to host"

--- a/weave
+++ b/weave
@@ -260,6 +260,8 @@ create_bridge() {
         ip link add name v${CONTAINER_IFNAME}du mtu $MTU type dummy
         ip link set dev v${CONTAINER_IFNAME}du master $BRIDGE
         ip link del dev v${CONTAINER_IFNAME}du
+        # Drop traffic from Docker bridge to Weave; it can break subnet isolation
+        run_iptables -t filter -I FORWARD -i $DOCKER_BRIDGE -o $BRIDGE -j DROP
         # Work around the situation where there are no rules allowing traffic
         # across our bridge. E.g. ufw
         add_iptables_rule filter FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT
@@ -282,6 +284,7 @@ destroy_bridge() {
     if [ -d /sys/class/net/$BRIDGE ] ; then
         ip link del dev $BRIDGE
     fi
+    run_iptables -t filter -D FORWARD -i $DOCKER_BRIDGE -o $BRIDGE -j DROP 2>/dev/null || true
     run_iptables -t filter -D FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT 2>/dev/null || true
     run_iptables -t nat -F WEAVE >/dev/null 2>&1 || true
     run_iptables -t nat -D POSTROUTING -j WEAVE >/dev/null 2>&1 || true


### PR DESCRIPTION
Fixes #620, as discussed in comments there.  All smoke tests still pass.