### PR TITLE
Silence most of the noise from smoke-tests

### DIFF
--- a/test/140_weave_local_test.sh
+++ b/test/140_weave_local_test.sh
@@ -6,13 +6,13 @@ start_suite "Run weave with --local"
 
 run_on $HOST1 sudo ./weave --local reset
 
-run_on $HOST1 sudo ./weave --local launch -iprange 10.2.5.0/24
+run_on $HOST1 sudo ./weave --local launch -iprange 10.2.5.0/24 >/dev/null
 assert_raises "docker_on $HOST1 ps | grep weave"
 
-run_on $HOST1 sudo ./weave --local run 10.2.6.5/24 -ti --name=c1 gliderlabs/alpine /bin/sh
+run_on $HOST1 sudo ./weave --local run 10.2.6.5/24 -ti --name=c1 gliderlabs/alpine /bin/sh >/dev/null
 assert_raises "exec_on $HOST1 c1 ip link show ethwe"
 
-run_on $HOST1 sudo ./weave --local run -ti --name=c2 gliderlabs/alpine /bin/sh
+run_on $HOST1 sudo ./weave --local run -ti --name=c2 gliderlabs/alpine /bin/sh >/dev/null
 assert_raises "exec_on $HOST1 c2 ifconfig | grep ethwe"
 
 end_suite

--- a/test/500_weave_multi_cidr_test.sh
+++ b/test/500_weave_multi_cidr_test.sh
@@ -11,7 +11,7 @@ assert_container_cidrs() {
     CIDRS="$@"
 
     # Assert container has attached CIDRs
-    assert_raises "weave_on $HOST ps | grep \"^$CID [^ ]* $CIDRS$\""
+    assert_raises "weave_cmd_on $HOST ps | grep \"^$CID [^ ]* $CIDRS$\""
 }
 
 # assert_zone_records <host> <cid> <fqdn> <ip> [<ip> ...]
@@ -21,11 +21,11 @@ assert_zone_records() {
     FQDN=$1; shift
 
     # Assert correct number of records exist
-    assert "weave_on $HOST status | grep \"^$CID\" | wc -l" $#
+    assert "weave_cmd_on $HOST status | grep \"^$CID\" | wc -l" $#
 
     # Assert correct records exist
     for IP; do
-        assert_raises "weave_on $HOST status | grep \"^$CID $IP $FQDN$\""
+        assert_raises "weave_cmd_on $HOST status | grep \"^$CID $IP $FQDN$\""
     done
 }
 
@@ -46,7 +46,8 @@ weave_on $HOST1 launch
 weave_on $HOST1 launch-dns 10.254.254.254/24
 
 # Run container with three cidrs
-CID=$(start_container $HOST1 10.2.1.1/24 10.2.2.1/24 10.2.3.1/24 --name=multicidr -h $NAME | cut -b 1-12)
+start_container $HOST1 10.2.1.1/24 10.2.2.1/24 10.2.3.1/24 --name=multicidr -h $NAME
+CID=$(echo $CONTAINERID | cut -b 1-12)
 assert_container_cidrs $HOST1 $CID 10.2.1.1/24 10.2.2.1/24 10.2.3.1/24
 assert_zone_records $HOST1 $CID $NAME. 10.2.1.1 10.2.2.1 10.2.3.1
 

--- a/test/sanity_check.sh
+++ b/test/sanity_check.sh
@@ -5,9 +5,9 @@
 set -e
 
 whitely echo Ping each host from the other
-run_on $HOST2 $PING $HOST1
-run_on $HOST1 $PING $HOST2
+run_on $HOST2 $PING $HOST1 >/dev/null
+run_on $HOST1 $PING $HOST2 >/dev/null
 
 whitely echo Check we can reach docker
-docker_on $HOST1 info
-docker_on $HOST2 info
+docker_on $HOST1 info >/dev/null
+docker_on $HOST2 info >/dev/null


### PR DESCRIPTION
Slight convolutions with `$CONTAINERID` and `weave_cmd_on` to minimise diffs in the individual tests.

If you prefer to see indication of progress, run test with `-v`.