### PR TITLE
use grep in /sys to verify ethwe is up in tests

### DIFF
--- a/test/140_weave_local_test.sh
+++ b/test/140_weave_local_test.sh
@@ -10,9 +10,9 @@ run_on $HOST1 sudo ./weave --local launch -iprange 10.2.5.0/24
 assert_raises "docker_on $HOST1 ps | grep weave"
 
 run_on $HOST1 sudo ./weave --local run 10.2.6.5/24 -ti --name=c1 gliderlabs/alpine /bin/sh
-assert_raises "exec_on $HOST1 c1 ip link show ethwe"
+assert_raises "exec_on $HOST1 c1 $CHECK_ETHWE_UP"
 
 run_on $HOST1 sudo ./weave --local run -ti --name=c2 gliderlabs/alpine /bin/sh
-assert_raises "exec_on $HOST1 c2 ifconfig | grep ethwe"
+assert_raises "exec_on $HOST1 c2 $CHECK_ETHWE_UP"
 
 end_suite

--- a/test/610_proxy_wait_for_weave_test.sh
+++ b/test/610_proxy_wait_for_weave_test.sh
@@ -10,6 +10,6 @@ if (docker_on $HOST1 images $BASE_IMAGE | grep $BASE_IMAGE); then
   docker_on $HOST1 rmi $BASE_IMAGE
 fi
 
-assert_raises "docker_proxy_on $HOST1 run -e 'WEAVE_CIDR=10.2.1.1/24' $BASE_IMAGE ip link show ethwe | grep 'state UP'"
+assert_raises "docker_proxy_on $HOST1 run -e 'WEAVE_CIDR=10.2.1.1/24' $BASE_IMAGE $CHECK_ETHWE_UP"
 
 end_suite

--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -14,7 +14,7 @@ docker_proxy_on $HOST1 run -e WEAVE_CIDR=$C2/24 -dt --name=c2 -h $NAME gliderlab
 docker_proxy_on $HOST1 run -e WEAVE_CIDR=$C1/24 -dt --name=c1 aanand/docker-dnsutils /bin/sh
 
 docker_proxy_on $HOST1 restart c2
-assert_raises "proxy_exec_on $HOST1 c2 ip link show ethwe | grep 'state \\(UP\\|UNKNOWN\\)'"
+assert_raises "proxy_exec_on $HOST1 c2 $CHECK_ETHWE_UP"
 assert_dns_record $HOST1 c1 $NAME $C2
 
 end_suite

--- a/test/config.sh
+++ b/test/config.sh
@@ -30,6 +30,7 @@ HOST2=$(echo $HOSTS | cut -f 2 -d ' ')
 SSH=${SSH:-ssh -l vagrant -i ./insecure_private_key -o UserKnownHostsFile=./.ssh_known_hosts -o CheckHostIP=no -o StrictHostKeyChecking=no}
 
 PING="ping -nq -W 1 -c 1"
+CHECK_ETHWE_UP="grep ^1$ /sys/class/net/ethwe/carrier"
 
 remote() {
     rem=$1


### PR DESCRIPTION
Closes #707. `ip link show` seems to "lag" the real state. In tests
checking the physical link state is good enough.