### PR TITLE
Check if Docker using weave bridge before inserting DROP rule

### DIFF
--- a/weave
+++ b/weave
@@ -261,7 +261,10 @@ create_bridge() {
         ip link set dev v${CONTAINER_IFNAME}du master $BRIDGE
         ip link del dev v${CONTAINER_IFNAME}du
         # Drop traffic from Docker bridge to Weave; it can break subnet isolation
-        run_iptables -t filter -I FORWARD -i $DOCKER_BRIDGE -o $BRIDGE -j DROP
+        if [ ! "$DOCKER_BRIDGE" = "$BRIDGE" ] ; then
+            # Note using -I to insert ahead of Docker's bridge rules
+            run_iptables -t filter -I FORWARD -i $DOCKER_BRIDGE -o $BRIDGE -j DROP
+        fi
         # Work around the situation where there are no rules allowing traffic
         # across our bridge. E.g. ufw
         add_iptables_rule filter FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT


### PR DESCRIPTION
Addresses #723.
Also comment the use of `-I`, as noted on c5d5dd5fdc07239001cd853a9137091e6406d4c1