### PR TITLE
allow test/run_all.sh to run specific test files

### DIFF
--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -24,7 +24,7 @@ check_test_status() {
 # Overwrite assert.sh _assert_cleanup trap with our own
 trap check_test_status EXIT
 
-TESTS=*_test.sh
+TESTS="${@:-*_test.sh}"
 
 # If running on circle, use the scheduler to work out what tests to run
 if [ -n "$CIRCLECI" ]; then


### PR DESCRIPTION
`./run_all.sh 110_encryption_test.sh`

Handles the assert_* calls better than running the test bare. If people like/use this, it would be nice to rename `run_all.sh` to something more appropriate.