### PR TITLE
Background updates for names in the Zone database

### DIFF
--- a/nameserver/addrs.go
+++ b/nameserver/addrs.go
@@ -32,6 +32,7 @@ type ZoneObservable interface {
 	ObserveInaddr(inaddr string, observer ZoneRecordObserver) error
 }
 
+type ZoneObserverFunc func(string, ZoneRecordObserver) error
 type ZoneRecordObserver func()
 
 /////////////////////////////////////////////////////////////

--- a/nameserver/addrs.go
+++ b/nameserver/addrs.go
@@ -25,6 +25,8 @@ type ZoneLookup interface {
 	LookupInaddr(inaddr string) ([]ZoneRecord, error)
 }
 
+type ZoneLookupFunc func(target string) ([]ZoneRecord, error)
+
 type ZoneObservable interface {
 	// Observe anything that affects a particular name in the zone
 	ObserveName(name string, observer ZoneRecordObserver) error

--- a/nameserver/addrs.go
+++ b/nameserver/addrs.go
@@ -25,7 +25,7 @@ type ZoneLookup interface {
 	LookupInaddr(inaddr string) ([]ZoneRecord, error)
 }
 
-type ZoneObserver interface {
+type ZoneObservable interface {
 	// Observe anything that affects a particular name in the zone
 	ObserveName(name string, observer ZoneRecordObserver) error
 	// Observe anything that affects a particular IP in the zone

--- a/nameserver/addrs_test.go
+++ b/nameserver/addrs_test.go
@@ -1,10 +1,11 @@
 package nameserver
 
 import (
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"testing"
+
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 func TestAddrs(t *testing.T) {

--- a/nameserver/cache.go
+++ b/nameserver/cache.go
@@ -5,12 +5,13 @@ import (
 	"container/heap"
 	"errors"
 	"fmt"
-	"github.com/benbjohnson/clock"
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
 	"math"
 	"sync"
 	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
 )
 
 var (

--- a/nameserver/cache.go
+++ b/nameserver/cache.go
@@ -9,7 +9,6 @@ import (
 	"github.com/miekg/dns"
 	. "github.com/weaveworks/weave/common"
 	"math"
-	"math/rand"
 	"sync"
 	"time"
 )
@@ -42,21 +41,6 @@ var statusToString = map[entryStatus]string{
 const (
 	CacheNoLocalReplies uint8 = 1 << iota // not found in local network (stored in the cache so we skip another local lookup or some time)
 )
-
-// shuffleAnswers reorders answers for very basic load balancing
-func shuffleAnswers(answers []dns.RR) []dns.RR {
-	n := len(answers)
-	if n > 1 {
-		rand.Seed(time.Now().UTC().UnixNano())
-
-		for i := 0; i < n; i++ {
-			r := i + rand.Intn(n-i)
-			answers[r], answers[i] = answers[i], answers[r]
-		}
-	}
-
-	return answers
-}
 
 // a cache entry
 type cacheEntry struct {
@@ -123,9 +107,6 @@ func (e *cacheEntry) getReply(request *dns.Msg, maxLen int, now time.Time) (*dns
 
 	reply.Rcode = e.reply.Rcode
 	reply.Authoritative = true
-
-	// shuffle the values, etc...
-	reply.Answer = shuffleAnswers(reply.Answer)
 
 	return reply, nil
 }

--- a/nameserver/cache_test.go
+++ b/nameserver/cache_test.go
@@ -2,13 +2,14 @@ package nameserver
 
 import (
 	"fmt"
+	"net"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	"github.com/miekg/dns"
 	. "github.com/weaveworks/weave/common"
 	wt "github.com/weaveworks/weave/testing"
-	"net"
-	"testing"
-	"time"
 )
 
 // Check that the cache keeps its intended capacity constant
@@ -201,7 +202,7 @@ func TestCacheEntries(t *testing.T) {
 	wt.AssertNotNil(t, err, "Get() error with CacheNoLocalReplies")
 
 	clk.Add(time.Second * time.Duration(negLocalTTL+1))
-	t.Logf("Checking that we get an expired response after %f seconds", negLocalTTL)
+	t.Logf("Checking that we get an expired response after %d seconds", negLocalTTL)
 	resp, err = l.Get(questionMsg3, minUDPSize)
 	wt.AssertNil(t, resp, "expired Get() response with CacheNoLocalReplies")
 	wt.AssertNil(t, err, "expired Get() error with CacheNoLocalReplies")

--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -2,6 +2,8 @@ package nameserver
 
 import (
 	"github.com/miekg/dns"
+	"math/rand"
+	"time"
 )
 
 const (
@@ -85,4 +87,21 @@ func getMaxReplyLen(r *dns.Msg, proto dnsProtocol) int {
 		maxLen = int(opt.UDPSize())
 	}
 	return maxLen
+}
+
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+// shuffleAnswers reorders answers for very basic load balancing
+func shuffleAnswers(answers []dns.RR) []dns.RR {
+	if len(answers) > 1 {
+		for i := range answers {
+			j := rand.Intn(i + 1)
+			answers[i], answers[j] = answers[j], answers[i]
+		}
+	}
+
+	return answers
 }

--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -89,7 +89,6 @@ func getMaxReplyLen(r *dns.Msg, proto dnsProtocol) int {
 	return maxLen
 }
 
-
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
 }
@@ -103,5 +102,14 @@ func shuffleAnswers(answers []dns.RR) []dns.RR {
 		}
 	}
 
+	return answers
+}
+
+// only take the first `num` answers
+func pruneAnswers(answers []dns.RR, num int) []dns.RR {
+	if num > 0 && len(answers) > num {
+		// TODO: we should have some prefer locally-introduced answers, etc...
+		return answers[:num]
+	}
 	return answers
 }

--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -1,9 +1,10 @@
 package nameserver
 
 import (
-	"github.com/miekg/dns"
 	"math/rand"
 	"time"
+
+	"github.com/miekg/dns"
 )
 
 const (

--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -33,6 +33,8 @@ func makeTruncatedReply(r *dns.Msg) *dns.Msg {
 	return reply
 }
 
+type DNSResponseBuilder func(r *dns.Msg, q *dns.Question, addrs []ZoneRecord) *dns.Msg
+
 func makeAddressReply(r *dns.Msg, q *dns.Question, addrs []ZoneRecord) *dns.Msg {
 	answers := make([]dns.RR, len(addrs))
 	header := makeHeader(r, q)

--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -1,0 +1,38 @@
+package nameserver
+
+import (
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
+	"net"
+	"testing"
+)
+
+// Check that we can prune an answer
+func TestPrune(t *testing.T) {
+	InitDefaultLogging(testing.Verbose())
+	Info.Println("TestPrune starting")
+
+	questionMsg := new(dns.Msg)
+	questionMsg.SetQuestion("name", dns.TypeA)
+	questionMsg.RecursionDesired = true
+	question := &questionMsg.Question[0]
+	records := []ZoneRecord{
+		Record{"name", net.ParseIP("10.0.1.1"), 0, 0, 0},
+		Record{"name", net.ParseIP("10.0.1.2"), 0, 0, 0},
+		Record{"name", net.ParseIP("10.0.1.3"), 0, 0, 0},
+		Record{"name", net.ParseIP("10.0.1.4"), 0, 0, 0},
+	}
+
+	reply := makeAddressReply(questionMsg, question, records)
+	reply.Answer[0].Header().Ttl = localTTL
+
+	pruned := pruneAnswers(reply.Answer, 1)
+	wt.AssertEqualInt(t, len(pruned), 1, "wrong number of answers")
+
+	pruned = pruneAnswers(reply.Answer, 2)
+	wt.AssertEqualInt(t, len(pruned), 2, "wrong number of answers")
+
+	pruned = pruneAnswers(reply.Answer, 0)
+	wt.AssertEqualInt(t, len(pruned), len(records), "wrong number of answers")
+}

--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -1,11 +1,12 @@
 package nameserver
 
 import (
+	"net"
+	"testing"
+
 	"github.com/miekg/dns"
 	. "github.com/weaveworks/weave/common"
 	wt "github.com/weaveworks/weave/testing"
-	"net"
-	"testing"
 )
 
 // Check that we can prune an answer

--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -23,6 +23,7 @@ func ListenHTTP(version string, server *DNSServer, domain string, db Zone, port 
 	muxRouter.Methods("GET").Path("/status").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "weave DNS", version)
 		fmt.Fprintln(w, server.Status())
+		fmt.Fprintln(w, db.Status())
 	})
 
 	muxRouter.Methods("PUT").Path("/name/{id:.+}/{ip:.+}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/nameserver/http.go
+++ b/nameserver/http.go
@@ -2,12 +2,13 @@ package nameserver
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
 	"log"
 	"net"
 	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
 )
 
 func httpErrorAndLog(level *log.Logger, w http.ResponseWriter, msg string,

--- a/nameserver/http_test.go
+++ b/nameserver/http_test.go
@@ -2,7 +2,6 @@ package nameserver
 
 import (
 	"fmt"
-	wt "github.com/weaveworks/weave/testing"
 	"math/rand"
 	"net"
 	"net/http"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	wt "github.com/weaveworks/weave/testing"
 )
 
 func genForm(method string, url string, data url.Values) (resp *http.Response, err error) {

--- a/nameserver/http_test.go
+++ b/nameserver/http_test.go
@@ -27,7 +27,11 @@ func TestHttp(t *testing.T) {
 		dockerIP        = "9.8.7.6"
 	)
 
-	zone := NewZoneDb(DefaultLocalDomain)
+	zone, err := NewZoneDb(ZoneConfig{})
+	wt.AssertNoErr(t, err)
+	err = zone.Start()
+	wt.AssertNoErr(t, err)
+	defer zone.Stop()
 
 	port := rand.Intn(10000) + 32768
 	fmt.Println("Http test on port", port)

--- a/nameserver/http_test.go
+++ b/nameserver/http_test.go
@@ -24,6 +24,7 @@ func TestHttp(t *testing.T) {
 		testDomain      = "weave.local."
 		successTestName = "test1." + testDomain
 		testAddr1       = "10.2.2.1/24"
+		testAddr2       = "10.2.2.2/24"
 		dockerIP        = "9.8.7.6"
 	)
 
@@ -69,6 +70,31 @@ func TestHttp(t *testing.T) {
 	wt.AssertNoErr(t, err)
 	wt.AssertStatus(t, resp.StatusCode, http.StatusOK, "http response")
 
+	// Adding a new IP for the same name should be OK
+	addrParts2 := strings.Split(testAddr2, "/")
+	addrURL2 := fmt.Sprintf("http://localhost:%d/name/%s/%s", port, containerID, addrParts2[0])
+	resp, err = genForm("PUT", addrURL2,
+		url.Values{"fqdn": {successTestName}, "local_ip": {dockerIP}, "routing_prefix": {addrParts2[1]}})
+	wt.AssertNoErr(t, err)
+	wt.AssertStatus(t, resp.StatusCode, http.StatusOK, "http success response for second IP")
+
+	// Check that we can get two IPs for that name
+	ip2, _, _ := net.ParseCIDR(testAddr2)
+	foundIP, err = zone.LookupName(successTestName)
+	wt.AssertNoErr(t, err)
+	if len(foundIP) != 2 {
+		t.Logf("IPs found: %s", foundIP)
+		t.Fatalf("Unexpected result length: received %d responses", len(foundIP))
+	}
+	if !(foundIP[0].IP().Equal(ip) || foundIP[0].IP().Equal(ip2)) {
+		t.Logf("IPs found: %s", foundIP)
+		t.Fatalf("Unexpected result for %s: received %s, expected %s", successTestName, foundIP, ip)
+	}
+	if !(foundIP[1].IP().Equal(ip) || foundIP[1].IP().Equal(ip2)) {
+		t.Logf("IPs found: %s", foundIP)
+		t.Fatalf("Unexpected result for %s: received %s, expected %s", successTestName, foundIP, ip)
+	}
+
 	// Delete the address
 	resp, err = genForm("DELETE", addrURL, nil)
 	wt.AssertNoErr(t, err)
@@ -81,6 +107,11 @@ func TestHttp(t *testing.T) {
 
 	// Delete the address record mentioning the other container
 	resp, err = genForm("DELETE", otherURL, nil)
+	wt.AssertNoErr(t, err)
+	wt.AssertStatus(t, resp.StatusCode, http.StatusOK, "http response")
+
+	// Delete the second IP
+	resp, err = genForm("DELETE", addrURL2, nil)
 	wt.AssertNoErr(t, err)
 	wt.AssertStatus(t, resp.StatusCode, http.StatusOK, "http response")
 

--- a/nameserver/mdns.go
+++ b/nameserver/mdns.go
@@ -1,0 +1,28 @@
+package nameserver
+
+import "net"
+
+// A basic mDNS service
+type ZoneMDNS interface {
+	// Start the service
+	Start(*net.Interface) error
+	// Stop the service
+	Stop() error
+}
+
+// A mDNS server
+type ZoneMDNSServer interface {
+	ZoneMDNS
+	// Return the Zone database used by the server
+	Zone() Zone
+}
+
+// A mDNS client interface
+type ZoneMDNSClient interface {
+	ZoneMDNS
+	ZoneLookup
+	// Perform an insistent lookup for a name
+	InsistentLookupName(name string) ([]ZoneRecord, error)
+	// Perform an insistent lookup for a reverse address
+	InsistentLookupInaddr(inaddr string) ([]ZoneRecord, error)
+}

--- a/nameserver/mdns_client.go
+++ b/nameserver/mdns_client.go
@@ -3,10 +3,11 @@ package nameserver
 import (
 	"bytes"
 	"fmt"
-	"github.com/miekg/dns"
 	"math"
 	"net"
 	"time"
+
+	"github.com/miekg/dns"
 )
 
 // Portions of this code taken from github.com/armon/mdns

--- a/nameserver/mdns_client_test.go
+++ b/nameserver/mdns_client_test.go
@@ -1,13 +1,14 @@
 package nameserver
 
 import (
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"log"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 var (

--- a/nameserver/mdns_server.go
+++ b/nameserver/mdns_server.go
@@ -1,9 +1,10 @@
 package nameserver
 
 import (
+	"net"
+
 	"github.com/miekg/dns"
 	. "github.com/weaveworks/weave/common"
-	"net"
 )
 
 type MDNSServer struct {

--- a/nameserver/mdns_server_test.go
+++ b/nameserver/mdns_server_test.go
@@ -1,12 +1,13 @@
 package nameserver
 
 import (
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 func TestServerSimpleQuery(t *testing.T) {

--- a/nameserver/mdns_server_test.go
+++ b/nameserver/mdns_server_test.go
@@ -20,7 +20,7 @@ func TestServerSimpleQuery(t *testing.T) {
 	Info.Println("TestServerSimpleQuery starting")
 
 	mzone := newMockedZoneWithRecords([]ZoneRecord{testRecord1, testRecord2})
-	mdnsServer, err := NewMDNSServer(mzone)
+	mdnsServer, err := NewMDNSServer(mzone, true)
 	wt.AssertNoErr(t, err)
 	err = mdnsServer.Start(nil)
 	wt.AssertNoErr(t, err)

--- a/nameserver/mdns_test.go
+++ b/nameserver/mdns_test.go
@@ -1,12 +1,13 @@
 package nameserver
 
 import (
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 // Check that we can use a regular mDNS server with a regular mDNS client

--- a/nameserver/mdns_test.go
+++ b/nameserver/mdns_test.go
@@ -1,0 +1,169 @@
+package nameserver
+
+import (
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
+	"net"
+	"testing"
+	"time"
+)
+
+// Check that we can use a regular mDNS server with a regular mDNS client
+func TestClientServerSimpleQuery(t *testing.T) {
+	InitDefaultLogging(testing.Verbose())
+
+	testRecord1 := Record{"test.weave.local.", net.ParseIP("10.2.2.1"), 0, 0, 0}
+	testInAddr1 := "1.2.2.10.in-addr.arpa."
+
+	mzone := newMockedZoneWithRecords([]ZoneRecord{testRecord1})
+	mdnsServer, err := NewMDNSServer(mzone, true)
+	wt.AssertNoErr(t, err)
+	err = mdnsServer.Start(nil)
+	wt.AssertNoErr(t, err)
+	defer mdnsServer.Stop()
+
+	var receivedAddr net.IP
+	var receivedName string
+	receivedCount := 0
+
+	mdnsCli, err := NewMDNSClient()
+	wt.AssertNoErr(t, err)
+	err = mdnsCli.Start(nil)
+	wt.AssertNoErr(t, err)
+
+	sendQuery := func(name string, querytype uint16) {
+		receivedAddr = nil
+		receivedName = ""
+		receivedCount = 0
+		Debug.Printf("Sending query...")
+		switch querytype {
+		case dns.TypeA:
+			r, err := mdnsCli.LookupName(name)
+			if len(r) > 0 {
+				receivedAddr = r[0].IP()
+				if err == nil {
+					receivedCount++
+				}
+			}
+		case dns.TypePTR:
+			r, err := mdnsCli.LookupInaddr(name)
+			if len(r) > 0 {
+				receivedName = r[0].Name()
+				if err == nil {
+					receivedCount++
+				}
+			}
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond) // Allow for server to get going
+
+	Debug.Printf("Query: %s dns.TypeA", testRecord1.Name())
+	sendQuery(testRecord1.Name(), dns.TypeA)
+	if receivedCount != 1 {
+		t.Fatalf("Unexpected result count %d for %s", receivedCount, testRecord1.Name())
+	}
+	if !receivedAddr.Equal(testRecord1.IP()) {
+		t.Fatalf("Unexpected result %s for %s", receivedAddr, testRecord1.Name())
+	}
+
+	Debug.Printf("Query: testfail.weave. dns.TypeA")
+	sendQuery("testfail.weave.", dns.TypeA)
+	if receivedCount != 0 {
+		t.Fatalf("Unexpected result count %d for testfail.weave", receivedCount)
+	}
+
+	Debug.Printf("Query: %s dns.TypePTR", testInAddr1)
+	sendQuery(testInAddr1, dns.TypePTR)
+	if receivedCount != 1 {
+		t.Fatalf("Expected an answer to %s, got %d answers", testInAddr1, receivedCount)
+	} else if !(testRecord1.Name() == receivedName) {
+		t.Fatalf("Expected answer %s to query for %s, got %s", testRecord1.Name(), testInAddr1, receivedName)
+	}
+}
+
+// Check that we can use a use "insistent" queries
+func TestClientServerInsistentQuery(t *testing.T) {
+	InitDefaultLogging(testing.Verbose())
+
+	testRecord1 := Record{"test.weave.local.", net.ParseIP("10.2.2.1"), 0, 0, 0}
+	testInAddr1 := "1.2.2.10.in-addr.arpa."
+	testRecord2 := Record{"test.weave.local.", net.ParseIP("10.2.2.2"), 0, 0, 0}
+	testInAddr2 := "2.2.2.10.in-addr.arpa."
+
+	mzone1 := newMockedZoneWithRecords([]ZoneRecord{testRecord1})
+	mdnsServer1, err := NewMDNSServer(mzone1, true)
+	wt.AssertNoErr(t, err)
+	err = mdnsServer1.Start(nil)
+	wt.AssertNoErr(t, err)
+	defer mdnsServer1.Stop()
+
+	mzone2 := newMockedZoneWithRecords([]ZoneRecord{testRecord2})
+	mdnsServer2, err := NewMDNSServer(mzone2, true)
+	wt.AssertNoErr(t, err)
+	err = mdnsServer2.Start(nil)
+	wt.AssertNoErr(t, err)
+	defer mdnsServer2.Stop()
+
+	// create a third server with exactly the same info as the second server (so we can test duplicates removals)
+	mdnsServer3, err := NewMDNSServer(mzone2, true)
+	wt.AssertNoErr(t, err)
+	err = mdnsServer3.Start(nil)
+	wt.AssertNoErr(t, err)
+	defer mdnsServer3.Stop()
+
+	var receivedAddrs []ZoneRecord
+	var receivedNames []ZoneRecord
+	receivedCount := 0
+
+	mdnsCli, err := NewMDNSClient()
+	wt.AssertNoErr(t, err)
+	err = mdnsCli.Start(nil)
+	wt.AssertNoErr(t, err)
+
+	sendQuery := func(name string, querytype uint16) {
+		receivedAddrs = nil
+		receivedNames = nil
+		receivedCount = 0
+		Debug.Printf("Sending query...")
+		switch querytype {
+		case dns.TypeA:
+			receivedAddrs, err = mdnsCli.InsistentLookupName(name)
+			if err == nil {
+				receivedCount = len(receivedAddrs)
+			}
+		case dns.TypePTR:
+			receivedNames, err = mdnsCli.InsistentLookupInaddr(name)
+			if err == nil {
+				receivedCount = len(receivedNames)
+			}
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond) // Allow for server to get going
+
+	Debug.Printf("Query: %s dns.TypeA", testRecord1.Name())
+	sendQuery(testRecord1.Name(), dns.TypeA)
+	if receivedCount != 2 {
+		t.Fatalf("Unexpected result count %d for %s", receivedCount, testRecord1.Name())
+	}
+
+	Debug.Printf("Query: testfail.weave. dns.TypeA")
+	sendQuery("testfail.weave.", dns.TypeA)
+	if receivedCount != 0 {
+		t.Fatalf("Unexpected result count %d for testfail.weave", receivedCount)
+	}
+
+	Debug.Printf("Query: %s dns.TypePTR", testInAddr1)
+	sendQuery(testInAddr1, dns.TypePTR)
+	if receivedCount != 1 {
+		t.Fatalf("Expected an answer to %s, got %d answers", testInAddr1, receivedCount)
+	}
+
+	Debug.Printf("Query: %s dns.TypePTR", testInAddr2)
+	sendQuery(testInAddr2, dns.TypePTR)
+	if receivedCount != 1 {
+		t.Fatalf("Expected an answer to %s, got %d answers", testInAddr2, receivedCount)
+	}
+}

--- a/nameserver/mocks_test.go
+++ b/nameserver/mocks_test.go
@@ -1,9 +1,15 @@
 package nameserver
 
 import (
+	"fmt"
+	"github.com/miekg/dns"
 	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 	"net"
+	"strconv"
 	"sync"
+	"testing"
+	"time"
 )
 
 const (
@@ -88,4 +94,388 @@ func (mz *mockedZoneWithRecords) ObserveName(name string, observer ZoneRecordObs
 func (mz *mockedZoneWithRecords) ObserveInaddr(inaddr string, observer ZoneRecordObserver) error {
 	notImplWarn()
 	return nil
+}
+
+//////////////////////////////////////////////////////////////////
+
+// A mocked mDNS server
+type mockedMDNSServer struct {
+	zone Zone
+}
+
+func newMockedMDNSServer(z Zone) *mockedMDNSServer        { return &mockedMDNSServer{zone: z} }
+func (ms *mockedMDNSServer) Start(_ *net.Interface) error { return nil }
+func (ms *mockedMDNSServer) Stop() error                  { return nil }
+func (ms *mockedMDNSServer) Zone() Zone                   { return ms.zone }
+
+// a useful mix of NewMockedZone and NewMockedMDNSServer
+func newMockedMDNSServerWithRecord(zr ZoneRecord) *mockedMDNSServer {
+	return newMockedMDNSServer(newMockedZoneWithRecords([]ZoneRecord{zr}))
+}
+func newMockedMDNSServerWithRecords(zrs []ZoneRecord) *mockedMDNSServer {
+	return newMockedMDNSServer(newMockedZoneWithRecords(zrs))
+}
+
+//////////////////////////////////////////////////////////////////
+
+// A mocked mDNS client.
+// This mock asks a group of (potentially mocked) mDNS servers
+type mockedMDNSClient struct {
+	sync.RWMutex
+
+	servers map[ZoneMDNSServer]ZoneMDNSServer
+
+	// Statistics
+	NumLookupsName      int
+	NumLookupsInaddr    int
+	NumInsLookupsName   int
+	NumInsLookupsInaddr int
+}
+
+func newMockedMDNSClient(srvrs []*mockedMDNSServer) *mockedMDNSClient {
+	r := mockedMDNSClient{
+		servers: make(map[ZoneMDNSServer]ZoneMDNSServer),
+	}
+	if srvrs != nil {
+		for _, server := range srvrs {
+			r.servers[server] = server
+		}
+	}
+	return &r
+}
+
+func (mc *mockedMDNSClient) Start(ifi *net.Interface) error { return nil }
+func (mc *mockedMDNSClient) Stop() error                    { return nil }
+func (mc *mockedMDNSClient) Domain() string                 { return DefaultLocalDomain }
+func (mc *mockedMDNSClient) LookupName(name string) ([]ZoneRecord, error) {
+	mc.Lock()
+	defer mc.Unlock()
+
+	// get a random result
+	mc.NumLookupsName += 1
+	for _, server := range mc.servers {
+		r, err := server.Zone().LookupName(name)
+		if err == nil {
+			return r, nil // return the first answer
+		}
+	}
+	return nil, LookupError(name)
+}
+
+func (mc *mockedMDNSClient) LookupInaddr(inaddr string) ([]ZoneRecord, error) {
+	mc.Lock()
+	defer mc.Unlock()
+
+	// get a random result
+	mc.NumLookupsInaddr += 1
+	for _, server := range mc.servers {
+		r, err := server.Zone().LookupInaddr(inaddr)
+		if err == nil {
+			return r, nil // return the first answer
+		}
+	}
+	return nil, LookupError(inaddr)
+}
+
+func (mc *mockedMDNSClient) InsistentLookupName(name string) ([]ZoneRecord, error) {
+	mc.Lock()
+	defer mc.Unlock()
+
+	res := make([]ZoneRecord, 0)
+	mc.NumInsLookupsName += 1
+	for _, server := range mc.servers {
+		r, err := server.Zone().LookupName(name)
+		if err == nil {
+			res = append(res, r...)
+		}
+	}
+	if len(res) == 0 {
+		return nil, LookupError(name)
+	}
+	return res, nil
+}
+
+func (mc *mockedMDNSClient) InsistentLookupInaddr(inaddr string) ([]ZoneRecord, error) {
+	mc.Lock()
+	defer mc.Unlock()
+
+	res := make([]ZoneRecord, 0)
+	mc.NumInsLookupsInaddr += 1
+	for _, server := range mc.servers {
+		r, err := server.Zone().LookupInaddr(inaddr)
+		if err == nil {
+			res = append(res, r...)
+		}
+	}
+	if len(res) == 0 {
+		return nil, LookupError(inaddr)
+	}
+	return res, nil
+}
+
+func (mc *mockedMDNSClient) AddServer(srv ZoneMDNSServer) {
+	mc.Lock()
+	defer mc.Unlock()
+	mc.servers[srv] = srv
+}
+
+func (mc *mockedMDNSClient) RemoveServer(srv ZoneMDNSServer) {
+	mc.Lock()
+	defer mc.Unlock()
+	delete(mc.servers, srv)
+}
+
+//////////////////////////////////////////////////////////////////
+
+type zbmEntry struct {
+	Server *mockedMDNSServer
+	Client *mockedMDNSClient
+	Zone   *zoneDb
+}
+type zoneDbsWithMockedMDns []*zbmEntry
+
+// Creates a group of (real) zone databases linked through mocked mDNS servers and clients
+// This effectively creates a cluster of WeaveDNS peers
+func newZoneDbsWithMockedMDns(num int, config ZoneConfig) zoneDbsWithMockedMDns {
+	res := make(zoneDbsWithMockedMDns, num)
+
+	for i := 0; i < num; i++ {
+		res[i] = new(zbmEntry)
+
+		Debug.Printf("[test] Creating mocked mDNS server #%d", i)
+		res[i].Server = newMockedMDNSServer(nil)
+
+		Debug.Printf("[test] Creating mocked mDNS client #%d", i)
+		res[i].Client = newMockedMDNSClient([]*mockedMDNSServer{})
+
+		cfg := config
+		cfg.MDNSClient = res[i].Client
+		cfg.MDNSServer = res[i].Server
+
+		Debug.Printf("[test] Creating ZoneDb #%d", i)
+		res[i].Zone, _ = NewZoneDb(cfg)
+
+		// link the mDNS server to its zone
+		// ZoneDbs are connected to mDNS in two directions: they use their mDNS
+		// clients for asking other peers about names/IPs, and export their records
+		// through a mDNS server.
+		res[i].Server.zone = res[i].Zone
+	}
+
+	// link all the clients to all the servers
+	for i := 0; i < num; i++ {
+		for j := 0; j < num; j++ {
+			// with this check, the local client will not ask to the local server
+			// this is not what we currently do, but can be convenient in some cases
+			// for finding some bugs...
+			if i != j {
+				Debug.Printf("[test] Linking mocked mDNS client #%d to server #%d", i, j)
+				res[i].Client.AddServer(res[j].Server)
+			}
+		}
+	}
+
+	return res
+}
+
+func (zbs zoneDbsWithMockedMDns) Start() {
+	for _, entry := range zbs {
+		entry.Zone.Start()
+	}
+}
+
+func (zbs zoneDbsWithMockedMDns) Stop() {
+	for _, entry := range zbs {
+		entry.Zone.Stop()
+	}
+}
+
+//////////////////////////////////////////////////////////////////
+
+// A mocked cache where we never find a single thing... ;)
+type mockedCache struct {
+	NumGets     int
+	NumPuts     int
+	NumRemovals int
+}
+
+func newMockedCache() *mockedCache { return &mockedCache{} }
+
+func (c *mockedCache) Get(request *dns.Msg, maxLen int) (reply *dns.Msg, err error) {
+	c.NumGets += 1
+	return nil, nil
+}
+func (c *mockedCache) Put(request *dns.Msg, reply *dns.Msg, ttl int, flags uint8) int {
+	c.NumPuts += 1
+	return 0
+}
+func (c *mockedCache) Remove(question *dns.Question) { c.NumRemovals += 1 }
+func (c *mockedCache) Purge()                        {}
+func (c *mockedCache) Clear()                        {}
+func (c *mockedCache) Len() int                      { return 0 }
+func (c *mockedCache) Capacity() int                 { return DefaultCacheLen }
+
+//////////////////////////////////////////////////////////////////
+
+// A mocked fallback server
+type mockedFallback struct {
+	CliConfig *dns.ClientConfig
+	Addr      string
+	Port      int
+
+	udpSrv *dns.Server
+	tcpSrv *dns.Server
+}
+
+// Create a mocked fallback server
+// You can use the server's `CliConfig` as the `UpstreamCfg` of a `DNSServer`...
+func newMockedFallback(udpH dns.HandlerFunc, tcpH dns.HandlerFunc) (*mockedFallback, error) {
+	udpSrv, fallbackAddr, err := runLocalUDPServer("127.0.0.1:0", udpH)
+	if err != nil {
+		return nil, err
+	}
+	_, fallbackPort, err := net.SplitHostPort(fallbackAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	fallbackPortI, _ := strconv.Atoi(fallbackPort)
+
+	res := mockedFallback{
+		udpSrv: udpSrv,
+		Addr:   fallbackAddr,
+		Port:   fallbackPortI,
+		CliConfig: &dns.ClientConfig{
+			Servers: []string{"127.0.0.1"},
+			Port:    fallbackPort,
+		},
+	}
+
+	if tcpH != nil {
+		fallbackTCPAddr := fmt.Sprintf("127.0.0.1:%s", fallbackPort)
+		res.tcpSrv, _, err = runLocalTCPServer(fallbackTCPAddr, tcpH)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &res, nil
+}
+
+// Start the fallback server
+func (mf *mockedFallback) Start() error {
+	return nil
+}
+
+// Stop the fallback server
+func (mf *mockedFallback) Stop() error {
+	if mf.tcpSrv != nil {
+		mf.udpSrv.Shutdown()
+		mf.udpSrv = nil
+	}
+	if mf.tcpSrv != nil {
+		mf.tcpSrv.Shutdown()
+		mf.udpSrv = nil
+	}
+	return nil
+}
+
+// Run a UDP fallback server
+func runLocalUDPServer(laddr string, handler dns.HandlerFunc) (*dns.Server, string, error) {
+	Debug.Printf("[mocked fallback] Starting fallback UDP server at %s", laddr)
+	pc, err := net.ListenPacket("udp", laddr)
+	if err != nil {
+		return nil, "", err
+	}
+	server := &dns.Server{PacketConn: pc, Handler: handler, ReadTimeout: testSocketTimeout * time.Millisecond}
+
+	go func() {
+		server.ActivateAndServe()
+		pc.Close()
+	}()
+
+	Debug.Printf("[mocked fallback] Fallback UDP server listening at %s", pc.LocalAddr())
+	return server, pc.LocalAddr().String(), nil
+}
+
+// Run a TCP fallback server
+func runLocalTCPServer(laddr string, handler dns.HandlerFunc) (*dns.Server, string, error) {
+	Debug.Printf("[mocked fallback] Starting fallback TCP server at %s", laddr)
+	laddrTCP, err := net.ResolveTCPAddr("tcp", laddr)
+	if err != nil {
+		return nil, "", err
+	}
+
+	l, err := net.ListenTCP("tcp", laddrTCP)
+	if err != nil {
+		return nil, "", err
+	}
+	server := &dns.Server{Listener: l, Handler: handler, ReadTimeout: testSocketTimeout * time.Millisecond}
+
+	go func() {
+		server.ActivateAndServe()
+		l.Close()
+	}()
+
+	Debug.Printf("[mocked fallback] Fallback TCP server listening at %s", l.Addr().String())
+	return server, l.Addr().String(), nil
+}
+
+//////////////////////////////////////////////////////////////////
+
+// Perform a DNS query and assert the reply code, number or answers, etc
+func assertExchange(t *testing.T, z string, ty uint16, port int, minAnswers int, maxAnswers int, expErr int) (*dns.Msg, *dns.Msg) {
+	wt.AssertNotEqualInt(t, port, 0, "invalid DNS server port")
+
+	c := &dns.Client{
+		UDPSize: testUDPBufSize,
+	}
+
+	m := new(dns.Msg)
+	m.RecursionDesired = true
+	m.SetQuestion(z, ty)
+	m.SetEdns0(testUDPBufSize, false) // we don't want to play with truncation here...
+
+	lstAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	r, _, err := c.Exchange(m, lstAddr)
+	t.Logf("Response from '%s':\n%+v\n", lstAddr, r)
+	if err != nil {
+		t.Fatalf("Error when querying DNS server at %s: %s", lstAddr, err)
+	}
+	wt.AssertNoErr(t, err)
+	if minAnswers == 0 && maxAnswers == 0 {
+		wt.AssertStatus(t, r.Rcode, expErr, "DNS response code")
+	} else {
+		wt.AssertStatus(t, r.Rcode, dns.RcodeSuccess, "DNS response code")
+	}
+	answers := len(r.Answer)
+	if minAnswers >= 0 && answers < minAnswers {
+		wt.Fatalf(t, "Number of answers >= %d", minAnswers)
+	}
+	if maxAnswers >= 0 && answers > maxAnswers {
+		wt.Fatalf(t, "Number of answers <= %d", maxAnswers)
+	}
+	return m, r
+}
+
+// Assert that we have a response in the cache for a query `q`
+func assertInCache(t *testing.T, cache ZoneCache, q *dns.Msg, desc string) {
+	r, err := cache.Get(q, maxUDPSize)
+	wt.AssertNoErr(t, err)
+	wt.AssertNotNil(t, r, fmt.Sprintf("value in the cache: %s", desc))
+}
+
+// Assert that we have a response in the cache for a query `q`
+func assertNotLocalInCache(t *testing.T, cache ZoneCache, q *dns.Msg, desc string) {
+	r, err := cache.Get(q, maxUDPSize)
+	if !(r == nil && err == errNoLocalReplies) {
+		t.Fatalf("Cache does not return a noLocalReplies error for query %s", q)
+	}
+}
+
+// Assert that we do not have a response in the cache for a query `q`
+func assertNotInCache(t *testing.T, cache ZoneCache, q *dns.Msg, desc string) {
+	r, err := cache.Get(q, maxUDPSize)
+	wt.AssertNoErr(t, err)
+	wt.AssertNil(t, r, fmt.Sprintf("value in the cache: %s\n%s", desc, r))
 }

--- a/nameserver/mocks_test.go
+++ b/nameserver/mocks_test.go
@@ -2,15 +2,16 @@ package nameserver
 
 import (
 	"fmt"
-	"github.com/benbjohnson/clock"
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 const (
@@ -153,7 +154,7 @@ func (mc *mockedMDNSClient) LookupName(name string) ([]ZoneRecord, error) {
 	defer mc.Unlock()
 
 	// get a random result
-	mc.NumLookupsName += 1
+	mc.NumLookupsName++
 	for _, server := range mc.servers {
 		r, err := server.Zone().LookupName(name)
 		if err == nil {
@@ -168,7 +169,7 @@ func (mc *mockedMDNSClient) LookupInaddr(inaddr string) ([]ZoneRecord, error) {
 	defer mc.Unlock()
 
 	// get a random result
-	mc.NumLookupsInaddr += 1
+	mc.NumLookupsInaddr++
 	for _, server := range mc.servers {
 		r, err := server.Zone().LookupInaddr(inaddr)
 		if err == nil {
@@ -182,8 +183,8 @@ func (mc *mockedMDNSClient) InsistentLookupName(name string) ([]ZoneRecord, erro
 	mc.Lock()
 	defer mc.Unlock()
 
-	res := make([]ZoneRecord, 0)
-	mc.NumInsLookupsName += 1
+	var res []ZoneRecord
+	mc.NumInsLookupsName++
 	for _, server := range mc.servers {
 		r, err := server.Zone().LookupName(name)
 		if err == nil {
@@ -200,8 +201,8 @@ func (mc *mockedMDNSClient) InsistentLookupInaddr(inaddr string) ([]ZoneRecord, 
 	mc.Lock()
 	defer mc.Unlock()
 
-	res := make([]ZoneRecord, 0)
-	mc.NumInsLookupsInaddr += 1
+	var res []ZoneRecord
+	mc.NumInsLookupsInaddr++
 	for _, server := range mc.servers {
 		r, err := server.Zone().LookupInaddr(inaddr)
 		if err == nil {
@@ -231,7 +232,7 @@ func (mc *mockedMDNSClient) RemoveServer(srv ZoneMDNSServer) {
 type zbmEntry struct {
 	Server *mockedMDNSServer
 	Client *mockedMDNSClient
-	Zone   *zoneDb
+	Zone   *ZoneDb
 }
 type zoneDbsWithMockedMDns []*zbmEntry
 
@@ -303,14 +304,14 @@ type mockedCache struct {
 func newMockedCache() *mockedCache { return &mockedCache{} }
 
 func (c *mockedCache) Get(request *dns.Msg, maxLen int) (reply *dns.Msg, err error) {
-	c.NumGets += 1
+	c.NumGets++
 	return nil, nil
 }
 func (c *mockedCache) Put(request *dns.Msg, reply *dns.Msg, ttl int, flags uint8) int {
-	c.NumPuts += 1
+	c.NumPuts++
 	return 0
 }
-func (c *mockedCache) Remove(question *dns.Question) { c.NumRemovals += 1 }
+func (c *mockedCache) Remove(question *dns.Question) { c.NumRemovals++ }
 func (c *mockedCache) Purge()                        {}
 func (c *mockedCache) Clear()                        {}
 func (c *mockedCache) Len() int                      { return 0 }

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	DefaultLocalDomain   = "weave.local."     // The default name used for the local domain
 	DefaultServerPort    = 53                 // The default server port
 	DefaultCLICfgFile    = "/etc/resolv.conf" // default "resolv.conf" file to try to load
 	DefaultUDPBuflen     = 4096               // bigger than the default 512

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -120,7 +120,7 @@ func NewDNSServer(config DNSServerConfig, zone Zone, iface *net.Interface) (s *D
 	if err != nil {
 		return
 	}
-	s.mdnsSrv, err = NewMDNSServer(s.Zone)
+	s.mdnsSrv, err = NewMDNSServer(s.Zone, false)
 	if err != nil {
 		return
 	}

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -3,13 +3,14 @@ package nameserver
 import (
 	"bytes"
 	"fmt"
-	"github.com/benbjohnson/clock"
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
 	"net"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
 )
 
 const (

--- a/nameserver/server.go
+++ b/nameserver/server.go
@@ -232,14 +232,21 @@ func (s *DNSServer) Status() string {
 // Perform a graceful shutdown
 func (s *DNSServer) Stop() error {
 	// Stop the listeners/handlers
-	if err := s.tcpSrv.Shutdown(); err != nil {
-		return err
+	if s.tcpSrv != nil {
+		if err := s.tcpSrv.Shutdown(); err != nil {
+			return err
+		}
+		s.lst.Close()
+		s.tcpSrv = nil
 	}
-	if err := s.udpSrv.Shutdown(); err != nil {
-		return err
+	if s.udpSrv != nil {
+		if err := s.udpSrv.Shutdown(); err != nil {
+			return err
+		}
+		s.pc.Close()
+		s.udpSrv = nil
 	}
 	s.listenersWg.Wait()
-
 	return nil
 }
 

--- a/nameserver/server_cache_test.go
+++ b/nameserver/server_cache_test.go
@@ -2,12 +2,13 @@ package nameserver
 
 import (
 	"fmt"
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 // Check if the names updates lead to cache invalidations

--- a/nameserver/server_cache_test.go
+++ b/nameserver/server_cache_test.go
@@ -42,6 +42,7 @@ func TestServerCacheRefresh(t *testing.T) {
 		Cache:             cache,
 		Clock:             clk,
 		ListenReadTimeout: testSocketTimeout,
+		MaxAnswers:        4,
 	})
 	wt.AssertNoErr(t, err)
 	go srv.Start()

--- a/nameserver/server_cache_test.go
+++ b/nameserver/server_cache_test.go
@@ -1,0 +1,105 @@
+package nameserver
+
+import (
+	"fmt"
+	"github.com/benbjohnson/clock"
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
+	"net"
+	"testing"
+	"time"
+)
+
+// Check if the names updates lead to cache invalidations
+func TestServerCacheRefresh(t *testing.T) {
+	const (
+		containerID     = "somecontainer"
+		testName1       = "first.weave.local."
+		testName2       = "second.weave.local."
+		refreshInterval = int(localTTL) / 3
+	)
+
+	InitDefaultLogging(testing.Verbose())
+	Info.Println("TestServerCacheRefresh starting")
+
+	clk := clock.NewMock()
+	forwardClock := func(secs int) {
+		Debug.Printf(">>>>>>> Moving clock forward %d seconds - Time traveling >>>>>>>", secs)
+		clk.Add(time.Duration(secs) * time.Second)
+		Debug.Printf("<<<<<<< Time travel finished! We are at %s <<<<<<<", clk.Now())
+	}
+
+	Debug.Printf("Creating 2 zone databases")
+	zoneConfig := ZoneConfig{
+		RefreshInterval: refreshInterval,
+		Clock:           clk,
+	}
+	dbs := newZoneDbsWithMockedMDns(2, zoneConfig)
+	dbs.Start()
+	defer dbs.Stop()
+
+	Debug.Printf("Creating a cache")
+	cache, err := NewCache(1024, clk)
+	wt.AssertNoErr(t, err)
+
+	Debug.Printf("Creating a real DNS server for the first zone database and with the cache")
+	srv, err := NewDNSServer(DNSServerConfig{
+		Zone:              dbs[0].Zone,
+		Cache:             cache,
+		Clock:             clk,
+		ListenReadTimeout: testSocketTimeout,
+	})
+	wt.AssertNoErr(t, err)
+	go srv.Start()
+	defer srv.Stop()
+	time.Sleep(100 * time.Millisecond) // Allow sever goroutine to start
+
+	testPort, err := srv.GetPort()
+	wt.AssertNoErr(t, err)
+	wt.AssertNotEqualInt(t, testPort, 0, "listen port")
+
+	Debug.Printf("Adding an IPs to %s", testName1)
+	dbs[1].Zone.AddRecord(containerID, testName1, net.ParseIP("10.2.2.1"))
+
+	// Zone database #2 at this point:
+	//   first.weave.local  = 10.2.2.1
+
+	// testName1 and testName2 should have no IPs yet
+	qName1, _ := assertExchange(t, testName1, dns.TypeA, testPort, 1, 1, 0)
+	qName2, _ := assertExchange(t, testName2, dns.TypeA, testPort, 0, 0, dns.RcodeNameError)
+	assertInCache(t, cache, qName1, "after asking for first name")
+	assertNotLocalInCache(t, cache, qName2, "after asking for second name")
+
+	forwardClock(refreshInterval / 2)
+
+	Debug.Printf("Adding an IP to %s and to %s", testName1, testName2)
+	dbs[1].Zone.AddRecord(containerID, testName1, net.ParseIP("10.2.2.2"))
+	dbs[1].Zone.AddRecord(containerID, testName2, net.ParseIP("10.9.9.2"))
+
+	// Zone database #2 at this point:
+	//   first.weave.local    = 10.2.2.1 10.2.2.2
+	//   second.weave.local   = 10.9.9.2
+	forwardClock(refreshInterval/2 + 2)
+
+	// at this point, the testName1 should have been refreshed
+	// so it should have two IPs, and the cache entry should have been invalidated
+	assertNotInCache(t, cache, qName1, fmt.Sprintf("after asking for %s", testName1))
+	assertNotLocalInCache(t, cache, qName2, fmt.Sprintf("after asking for %s", testName2))
+
+	qName1, _ = assertExchange(t, testName1, dns.TypeA, testPort, 2, 2, 0)
+	qName2, _ = assertExchange(t, testName2, dns.TypeA, testPort, 0, 0, dns.RcodeNameError)
+	assertInCache(t, cache, qName1, fmt.Sprintf("after asking for %s", testName1))
+	assertNotLocalInCache(t, cache, qName2, "after asking for a unknown name")
+
+	// delete the IPs, and some time passes by so the cache should be purged...
+	dbs[1].Zone.DeleteRecord(containerID, net.ParseIP("10.2.2.1"))
+	dbs[1].Zone.DeleteRecord(containerID, net.ParseIP("10.2.2.2"))
+	forwardClock(refreshInterval + 1)
+
+	qName1, _ = assertExchange(t, testName1, dns.TypeA, testPort, 0, 0, dns.RcodeNameError)
+	qName2, _ = assertExchange(t, testName2, dns.TypeA, testPort, 0, 0, dns.RcodeNameError)
+	assertNotLocalInCache(t, cache, qName1, "after asking for a unknown name")
+	assertNotLocalInCache(t, cache, qName2, "after asking for a unknown name")
+
+}

--- a/nameserver/server_test.go
+++ b/nameserver/server_test.go
@@ -3,12 +3,13 @@ package nameserver
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/miekg/dns"
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 const (
@@ -180,7 +181,7 @@ func TestTCPDNSServer(t *testing.T) {
 	fallback.Start()
 	defer fallback.Stop()
 
-	t.Logf("Creating a WeaveDNS server instance, falling back to 127.0.0.1:%s", fallback.Port)
+	t.Logf("Creating a WeaveDNS server instance, falling back to 127.0.0.1:%d", fallback.Port)
 	srv, err := NewDNSServer(DNSServerConfig{
 		Zone:              zone,
 		UpstreamCfg:       fallback.CliConfig,

--- a/nameserver/server_test.go
+++ b/nameserver/server_test.go
@@ -44,8 +44,15 @@ func TestUDPDNSServer(t *testing.T) {
 	)
 	testCIDR1 := testAddr1 + "/24"
 
-	InitDefaultLogging(true)
-	var zone = NewZoneDb(DefaultLocalDomain)
+	InitDefaultLogging(testing.Verbose())
+	Info.Println("TestUDPDNSServer starting")
+
+	zone, err := NewZoneDb(ZoneConfig{})
+	wt.AssertNoErr(t, err)
+	err = zone.Start()
+	wt.AssertNoErr(t, err)
+	defer zone.Stop()
+
 	ip, _, _ := net.ParseCIDR(testCIDR1)
 	zone.AddRecord(containerID, successTestName, ip)
 
@@ -125,9 +132,15 @@ func TestTCPDNSServer(t *testing.T) {
 	)
 	dnsAddr := fmt.Sprintf("localhost:%d", testPort)
 
-	InitDefaultLogging(true)
-	var zone = NewZoneDb(DefaultLocalDomain)
+	InitDefaultLogging(testing.Verbose())
+	Info.Println("TestTCPDNSServer starting")
 
+	zone, err := NewZoneDb(ZoneConfig{})
+	wt.AssertNoErr(t, err)
+	err = zone.Start()
+	wt.AssertNoErr(t, err)
+	defer zone.Stop()
+	
 	// generate a list of `numAnswers` IP addresses
 	var addrs []ZoneRecord
 	bs := make([]byte, 4)

--- a/nameserver/zone.go
+++ b/nameserver/zone.go
@@ -122,7 +122,7 @@ func (re *recordEntry) notifyIPObservers() {
 	}
 }
 
-func (re recordEntry) TTL() int {
+func (re *recordEntry) TTL() int {
 	// if we never set the TTL (eg, when using AddRecord()), return the standard value...
 	if re.ttl == 0 {
 		return int(localTTL)
@@ -131,11 +131,11 @@ func (re recordEntry) TTL() int {
 }
 
 // Check if the info in this record is still valid according to the TTL
-func (re recordEntry) hasExpired(now time.Time) bool {
+func (re *recordEntry) hasExpired(now time.Time) bool {
 	return re.ttl > 0 && now.Sub(re.insTime).Seconds() > float64(re.ttl)
 }
 
-func (re recordEntry) String() string {
+func (re *recordEntry) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%s", re.Record)
 	lobs := len(re.observers)
@@ -163,10 +163,10 @@ func newName(n string) *name {
 		observers: make([]ZoneRecordObserver, 0),
 	}
 }
-func (n name) len() int             { return len(n.ipv4) }
-func (n name) empty() bool          { return n.len() == 0 }
-func (n name) hasIP(ip net.IP) bool { return n.hasIPv4(ipToIPv4(ip)) }
-func (n name) hasIPv4(ip IPv4) bool { _, found := n.ipv4[ip]; return found }
+func (n *name) len() int             { return len(n.ipv4) }
+func (n *name) empty() bool          { return n.len() == 0 }
+func (n *name) hasIP(ip net.IP) bool { return n.hasIPv4(ipToIPv4(ip)) }
+func (n *name) hasIPv4(ip IPv4) bool { _, found := n.ipv4[ip]; return found }
 
 // Get all the entries for this name
 func (n *name) getAllEntries() (res []*recordEntry) {
@@ -257,7 +257,7 @@ func (n *name) notifyNameObservers() {
 }
 
 // Convert a set of IP records to a comma-separated string
-func (n name) String() string {
+func (n *name) String() string {
 	var buf bytes.Buffer
 	for _, ip := range n.ipv4 {
 		fmt.Fprintf(&buf, "%s, ", ip)
@@ -276,10 +276,10 @@ type namesSet struct {
 	names map[string]*name
 }
 
-func newNamesSet() *namesSet    { return &namesSet{names: make(map[string]*name)} }
-func (ns namesSet) len() int    { return len(ns.names) }
-func (ns namesSet) empty() bool { return ns.len() == 0 }
-func (ns namesSet) hasName(name string) bool {
+func newNamesSet() *namesSet     { return &namesSet{names: make(map[string]*name)} }
+func (ns *namesSet) len() int    { return len(ns.names) }
+func (ns *namesSet) empty() bool { return ns.len() == 0 }
+func (ns *namesSet) hasName(name string) bool {
 	if n, found := ns.names[name]; !found {
 		return false
 	} else {
@@ -365,7 +365,7 @@ func (ns *namesSet) deleteIP(ip IPv4) error {
 }
 
 // Get the name query time
-func (ns namesSet) getNameLastAccess(n string) time.Time {
+func (ns *namesSet) getNameLastAccess(n string) time.Time {
 	if name, found := ns.names[n]; found {
 		return name.lastAccessTime
 	}
@@ -383,7 +383,7 @@ func (ns *namesSet) touchName(name string, now time.Time) {
 	}
 }
 
-func (ns namesSet) String() string {
+func (ns *namesSet) String() string {
 	var buf bytes.Buffer
 	for _, name := range ns.names {
 		fmt.Fprintf(&buf, "%s, ", name)

--- a/nameserver/zone.go
+++ b/nameserver/zone.go
@@ -3,40 +3,26 @@ package nameserver
 import (
 	"bytes"
 	"fmt"
+	"github.com/benbjohnson/clock"
 	"github.com/miekg/dns"
 	. "github.com/weaveworks/weave/common"
 	"net"
 	"sync"
+	"time"
 )
 
 const (
 	RDNSDomain = "in-addr.arpa."
 )
 
+const (
+	DefaultLocalDomain     = "weave.local." // The default name used for the local domain
+
+	defaultRemoteIdent    = "weave:remote" // Ident used for info obtained from mDNS
+)
+
 // +1 to also exclude a dot
 var rdnsDomainLen = len(RDNSDomain) + 1
-
-type Zone interface {
-	AddRecord(ident string, name string, ip net.IP) error
-	DeleteRecord(ident string, ip net.IP) error
-	DeleteRecordsFor(ident string) error
-	Domain() string
-	ZoneLookup
-}
-
-type dbRecord struct {
-	Ident string
-	Name  string
-	IP    net.IP
-}
-
-// Very simple data structure for now, with linear searching.
-// TODO: make more sophisticated to improve performance.
-type ZoneDb struct {
-	mx     sync.RWMutex
-	recs   []dbRecord
-	domain string
-}
 
 type LookupError string
 
@@ -51,103 +37,609 @@ func (dup DuplicateError) Error() string {
 	return "Tried to add a duplicate entry"
 }
 
-func NewZoneDb(domain string) *ZoneDb {
-	return &ZoneDb{
-		domain: domain,
+type Zone interface {
+	ZoneObservable
+	ZoneLookup
+	// The domain where we operate (eg, "weave.local.")
+	Domain() string
+	// Add a record in the local database
+	AddRecord(ident string, name string, ip net.IP) error
+	// Delete a record in the local database
+	DeleteRecord(ident string, ip net.IP) error
+	// Delete all records for an ident in the local database
+	DeleteRecordsFor(ident string) error
+	// Return a status string
+	Status() string
+}
+
+///////////////////////////////////////////////////////////////////
+//
+// Zone database:
+//
+//           idents            names             entry
+//         *-------*          *------*         *------*
+// zone -> | ident |  --*-->  | name |  --*->  | IPv4 |
+//         *-------*    |     *------*    |    *------*
+//         | ident |    *-->  | name |    *->  | IPv4 |
+//         *-------*          *------*         *------*
+//            ...               ...
+//
+// The zone database keeps an ident per container, but also a special
+// ident for names/IPs obtained from remote peers.
+//
+// Each name can have multiple IPs (so far, we only consider IPv4s), and
+// each IP is stored in a `recordEntry` in the database. Entries store
+// some additional information like priority and weight of the IP (for
+// example, for future use with SRV records)
+//
+
+// An entry in the zone database
+type recordEntry struct {
+	Record
+
+	observers []ZoneRecordObserver // the observers for this record
+	insTime   time.Time            // time when this record was inserted
+}
+
+func newRecordEntry(zr ZoneRecord, now time.Time) *recordEntry {
+	return &recordEntry{
+		Record: Record{
+			name:     zr.Name(),
+			ip:       zr.IP(),
+			priority: zr.Priority(),
+			weight:   zr.Weight(),
+			ttl:      zr.TTL(),
+		},
+		insTime:   now,
+		observers: make([]ZoneRecordObserver, 0),
 	}
 }
 
-func (zone *ZoneDb) Domain() string {
-	return zone.domain
+func (i *recordEntry) addIPObserver(zro ZoneRecordObserver) {
+	i.observers = append(i.observers, zro)
 }
 
-func (zone *ZoneDb) indexOf(match func(dbRecord) bool) int {
-	for i, r := range zone.recs {
-		if match(r) {
-			return i
+// Notify all the IP observers and then remove them all
+// IP address observers are notified when
+// - the IP is removed
+// - the name is removed
+func (re *recordEntry) notifyIPObservers() {
+	numObservers := len(re.observers)
+	if numObservers > 0 {
+		Debug.Printf("[zonedb] Notifying %d observers of '%s'", numObservers, re.ip)
+		for _, observer := range re.observers {
+			observer()
 		}
+		re.observers = make([]ZoneRecordObserver, 0)
 	}
-	return -1
 }
 
-func (zone *ZoneDb) String() string {
-	zone.mx.RLock()
-	defer zone.mx.RUnlock()
+func (re recordEntry) TTL() int {
+	// if we never set the TTL (eg, when using AddRecord()), return the standard value...
+	if re.ttl == 0 {
+		return int(localTTL)
+	}
+	return re.ttl
+}
+
+// Check if the info in this record is still valid according to the TTL
+func (re recordEntry) hasExpired(now time.Time) bool {
+	return re.ttl > 0 && now.Sub(re.insTime).Seconds() > float64(re.ttl)
+}
+
+func (re recordEntry) String() string {
 	var buf bytes.Buffer
-	for _, r := range zone.recs {
-		fmt.Fprintf(&buf, "%.12s %s %v\n", r.Ident, r.IP, r.Name)
+	fmt.Fprintf(&buf, "%s", re.Record)
+	lobs := len(re.observers)
+	if lobs > 0 {
+		fmt.Fprintf(&buf, "/OBS:%d", lobs)
 	}
 	return buf.String()
 }
 
-func (zone *ZoneDb) LookupName(name string) ([]ZoneRecord, error) {
+///////////////////////////////////////////////////////////////////
+
+// a name, with group of records by IPv4
+type name struct {
+	name            string
+	ipv4            map[IPv4]*recordEntry // all the IPv4 records for this name
+	observers       []ZoneRecordObserver  // the observers for this name
+	lastAccessTime  time.Time             // last time a Lookup* used info from this name
+}
+
+func newName(n string) *name {
+	return &name{
+		name:      n,
+		ipv4:      make(map[IPv4]*recordEntry),
+		observers: make([]ZoneRecordObserver, 0),
+	}
+}
+func (n name) len() int             { return len(n.ipv4) }
+func (n name) empty() bool          { return n.len() == 0 }
+func (n name) hasIP(ip net.IP) bool { return n.hasIPv4(ipToIPv4(ip)) }
+func (n name) hasIPv4(ip IPv4) bool { _, found := n.ipv4[ip]; return found }
+
+// Get all the entries for this name
+func (n *name) getAllEntries() (res []*recordEntry) {
+	for _, entry := range n.ipv4 {
+		res = append(res, entry)
+	}
+	return
+}
+
+// Get the entry for an IP in this name
+func (n *name) getEntryForIP(ip IPv4) (res *recordEntry) {
+	if entry, found := n.ipv4[ip]; found {
+		res = entry
+	}
+	return
+}
+
+// Add a new IPv4 to this name
+func (n *name) addIP(zr ZoneRecord, now time.Time) (*recordEntry, error) {
+	ne := newRecordEntry(zr, now)
+	ipv4 := ipToIPv4(zr.IP())
+	n.ipv4[ipv4] = ne
+	n.notifyNameObservers()
+	return ne, nil
+}
+
+// Delete an IP for this name
+func (n *name) deleteIP(ip IPv4) bool {
+	if ipRecord, found := n.ipv4[ip]; found {
+		ipRecord.notifyIPObservers()
+		n.notifyNameObservers()
+		delete(n.ipv4, ip)
+		return true
+	}
+	return false
+}
+
+// Update the list of IPs for this name, adding new ones and removing old IPs...
+func (n *name) updateIPs(records []ZoneRecord, now time.Time) (added int, removed int) {
+	ipsMap := make(map[IPv4]bool)
+
+	// add the new IPs
+	for _, record := range records {
+		ipv4 := ipToIPv4(record.IP())
+		ipsMap[ipv4] = true
+		if !n.hasIPv4(ipv4) {
+			n.addIP(record, now)
+			added++
+		}
+	}
+
+	// remove the old IPs
+	for ipv4, ipRecord := range n.ipv4 {
+		if _, isNew := ipsMap[ipv4]; !isNew {
+			ipRecord.notifyIPObservers() // we must notify the observers before removing the IP record...
+			delete(n.ipv4, ipv4)
+			removed++
+		}
+	}
+
+	// notify observers and update times
+	if added > 0 || removed > 0 {
+		n.notifyNameObservers()
+	}
+	return
+}
+
+// Add a observer for this name
+func (n *name) addNameObserver(observer ZoneRecordObserver) {
+	n.observers = append(n.observers, observer)
+}
+
+// Notify and flush all the observers
+// Name observers are notified when
+// - an IP is added
+// - an IP is removed
+// - the name is removed
+func (n *name) notifyNameObservers() {
+	numObservers := len(n.observers)
+	if numObservers > 0 {
+		Debug.Printf("[zonedb] Notifying %d observers of '%s'", numObservers, n.name)
+		for _, observer := range n.observers {
+			observer()
+		}
+		n.observers = make([]ZoneRecordObserver, 0)
+	}
+}
+
+// Convert a set of IP records to a comma-separated string
+func (n name) String() string {
+	var buf bytes.Buffer
+	for _, ip := range n.ipv4 {
+		fmt.Fprintf(&buf, "%s, ", ip)
+	}
+	l := buf.Len()
+	if l > 2 {
+		buf.Truncate(l - 2)
+	}
+	return buf.String()
+}
+
+///////////////////////////////////////////////////////////////////
+
+// all the names in a ident
+type namesSet struct {
+	names map[string]*name
+}
+
+func newNamesSet() *namesSet    { return &namesSet{names: make(map[string]*name)} }
+func (ns namesSet) len() int    { return len(ns.names) }
+func (ns namesSet) empty() bool { return ns.len() == 0 }
+func (ns namesSet) hasName(name string) bool {
+	if n, found := ns.names[name]; !found {
+		return false
+	} else {
+		// the name must have some valid IPs in order to be considered as "existent"
+		return len(n.ipv4) > 0
+	}
+}
+
+// Get the zone entries for a name
+// If the name does not exist and `create` is true, a new name will be created
+func (ns *namesSet) getName(name string, create bool) (n *name) {
+	if n, found := ns.names[name]; !found && create {
+		newName := newName(name)
+		ns.names[name] = newName
+		return newName
+	} else {
+		return n
+	}
+}
+
+// Get all the entries for a name
+func (ns *namesSet) getEntriesForName(name string) (res []*recordEntry) {
+	n := ns.getName(name, false)
+	if n != nil {
+		res = n.getAllEntries()
+	}
+	return
+}
+
+// Get all the entries for an IP, for all names
+func (ns *namesSet) getEntriesForIP(ip IPv4) (res []*recordEntry) {
+	for _, name := range ns.names {
+		entry := name.getEntryForIP(ip)
+		if entry != nil {
+			res = append(res, entry)
+		}
+	}
+	return
+}
+
+// Add a new IPv4 to a name
+func (ns *namesSet) addIPToName(zr ZoneRecord, now time.Time) (*recordEntry, error) {
+	n := ns.getName(zr.Name(), true)
+	ipv4 := ipToIPv4(zr.IP())
+	if n.hasIPv4(ipv4) {
+		return n.getEntryForIP(ipv4), DuplicateError{}
+	}
+	ns.touchName(zr.Name(), now)
+	return n.addIP(zr, now)
+}
+
+// Delete a name in the names set
+func (ns *namesSet) deleteName(n string) error {
+	if name, found := ns.names[n]; found {
+		for _, ipRecord := range name.getAllEntries() {
+			ipRecord.notifyIPObservers()
+		}
+		name.notifyNameObservers()
+		delete(ns.names, n)
+		return nil
+	} else {
+		return LookupError(fmt.Sprintf("%+v", name))
+	}
+}
+
+// Delete an IPv4 from all names
+func (ns *namesSet) deleteIP(ip IPv4) error {
+	cnt := 0
+	for nkey, n := range ns.names {
+		if n.deleteIP(ip) {
+			cnt++
+		}
+		if n.empty() {
+			delete(ns.names, nkey)
+		}
+	}
+
+	// we must return an error if no records have been found and deleted
+	if cnt == 0 {
+		return LookupError(fmt.Sprintf("%+v", ip))
+	}
+	return nil
+}
+
+// Get the name query time
+func (ns namesSet) getNameLastAccess(n string) time.Time {
+	if name, found := ns.names[n]; found {
+		return name.lastAccessTime
+	}
+	return time.Time{}
+}
+
+// Touch the last access time for a name
+// The access time is saved only for locally-introduced records (otherwise it could
+// be lost when names are irrelevant...)
+func (ns *namesSet) touchName(name string, now time.Time) {
+	Debug.Printf("[zonedb] Touching name %s", name)
+	n := ns.getName(name, false)
+	if n != nil {
+		n.lastAccessTime = now
+	}
+}
+
+func (ns namesSet) String() string {
+	var buf bytes.Buffer
+	for _, name := range ns.names {
+		fmt.Fprintf(&buf, "%s, ", name)
+	}
+	l := buf.Len()
+	if l > 2 {
+		buf.Truncate(l - 2)
+	}
+	return buf.String()
+}
+
+///////////////////////////////////////////////////////////////////
+
+// Names sets, by ident name
+type identRecordsSet map[string]*namesSet
+
+func (irs identRecordsSet) String() string {
+	var buf bytes.Buffer
+	for ident, nameset := range irs {
+		fmt.Fprintf(&buf, "%.12s: %s\n", ident, nameset)
+	}
+	return buf.String()
+}
+
+///////////////////////////////////////////////////////////////////
+
+type ZoneConfig struct {
+	// The local domain
+	Domain string
+	// The interface where mDNS operates
+	Iface *net.Interface
+	// Force a specific mDNS client
+	MDNSClient ZoneMDNSClient
+	// Force a specific mDNS server
+	MDNSServer ZoneMDNSServer
+	// For a specific clock provider
+	Clock clock.Clock
+}
+
+// Zone database
+// The zone database contains the locally known information about the zone.
+// The zone database uses some other mechanisms (eg, mDNS) for finding unknown
+// information or for keeping current information up to date.
+type zoneDb struct {
+	mx     sync.RWMutex
+	idents identRecordsSet
+
+	mdnsCli       ZoneMDNSClient
+	mdnsSrv       ZoneMDNSServer
+	iface         *net.Interface
+	domain        string        // the local domain
+	clock         clock.Clock
+}
+
+// Create a new zone database
+func NewZoneDb(config ZoneConfig) (zone *zoneDb, err error) {
+	zone = &zoneDb{
+		domain:           config.Domain,
+		idents:           make(identRecordsSet),
+		mdnsCli:          config.MDNSClient,
+		mdnsSrv:          config.MDNSServer,
+		iface:            config.Iface,
+		clock:            config.Clock,
+	}
+
+	// fix the default configuration parameters
+	if zone.clock == nil {
+		zone.clock = clock.New()
+	}
+	if len(zone.domain) == 0 {
+		zone.domain = DefaultLocalDomain
+	}
+
+	// Create the mDNS client and server
+	if zone.mdnsCli == nil {
+		if zone.mdnsCli, err = NewMDNSClient(); err != nil {
+			return
+		}
+	}
+	if zone.mdnsSrv == nil {
+		if zone.mdnsSrv, err = NewMDNSServer(zone, false); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// Start the zone database
+func (zone *zoneDb) Start() (err error) {
+	if zone.iface != nil {
+		Info.Printf("[zonedb] Using mDNS on %s", zone.iface)
+	} else {
+		Info.Printf("[zonedb] Using mDNS on all interfaces")
+	}
+
+	if err = zone.mdnsCli.Start(zone.iface); err != nil {
+		return
+	}
+	if err = zone.mdnsSrv.Start(zone.iface); err != nil {
+		return
+	}
+	return
+}
+
+// Perform a graceful shutdown of the zone database
+func (zone *zoneDb) Stop() error {
+	Debug.Printf("[zonedb] Exiting mDNS client and server...")
+	zone.mdnsCli.Stop()
+	zone.mdnsSrv.Stop()
+	return nil
+}
+
+// Obtain the domain where this database keeps information for
+func (zone *zoneDb) Domain() string {
+	return zone.domain
+}
+
+// Return the status string
+func (zone *zoneDb) Status() string {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, "Local domain", zone.domain)
+	fmt.Fprintln(&buf, "Interface", zone.iface)
+	fmt.Fprintf(&buf, "Zone database:\n%s", zone)
+	return buf.String()
+}
+
+// Add a record with `name` pointing to `ip`
+func (zone *zoneDb) AddRecord(ident string, name string, ip net.IP) (err error) {
+	zone.mx.Lock()
+	defer zone.mx.Unlock()
+	Debug.Printf("[zonedb] Adding record: '%s'/'%s'[%s]", ident, name, ip)
+	record := Record{dns.Fqdn(name), ip, 0, 0, 0}
+	_, err = zone.getNamesSet(ident).addIPToName(record, zone.clock.Now())
+	return
+}
+
+// Delete all records for an ident
+func (zone *zoneDb) DeleteRecordsFor(ident string) (err error) {
+	zone.mx.Lock()
+	defer zone.mx.Unlock()
+	Debug.Printf("[zonedb] Deleting records for ident '%s'", ident)
+	zone.deleteIdent(ident)
+	return
+}
+
+// Delete an IP in a ident
+func (zone *zoneDb) DeleteRecord(ident string, ip net.IP) (err error) {
+	zone.mx.Lock()
+	defer zone.mx.Unlock()
+
+	Debug.Printf("[zonedb] Deleting record '%s'/[%s]", ident, ip)
+	if _, found := zone.idents[ident]; found {
+		err = zone.idents[ident].deleteIP(ipToIPv4(ip))
+		if zone.idents[ident].empty() {
+			zone.deleteIdent(ident)
+		}
+	} else {
+		err = LookupError(ident)
+	}
+	return
+}
+
+// Observe a name.
+// The name must have at least one valid IP address.
+// Name observers are notified when
+// - an IP is added
+// - an IP is removed
+// - the name is removed
+// The observer will be invoked on any change/removal that affects this name.
+// Each observer will be invoked at least once (but possibly more). After that, they will be removed.
+// The observer should not try to lock the ZoneDB (you will get a deadlock)
+func (zone *zoneDb) ObserveName(name string, observer ZoneRecordObserver) (err error) {
+	zone.mx.Lock()
+	defer zone.mx.Unlock()
+
+	cnt := 0
+	name = dns.Fqdn(name)
+	for _, nameset := range zone.idents {
+		if n := nameset.getName(name, false); n != nil {
+			n.addNameObserver(observer)
+			cnt += 1
+		}
+	}
+	if cnt == 0 {
+		err = LookupError(fmt.Sprintf("%s", name))
+	}
+	return
+}
+
+// Observe a IP address.
+// The IP address must be exit in the database.
+// IP address observers are notified when
+// - the IP is removed
+// - the name is removed
+// The observer will be invoked on any change/removal that affects this IP.
+// Each observer will be invoked at least once (but possibly more). After that, they will be removed.
+// The observer should not try to lock the ZoneDB (you will get a deadlock)
+func (zone *zoneDb) ObserveInaddr(inaddr string, observer ZoneRecordObserver) (err error) {
+	zone.mx.Lock()
+	defer zone.mx.Unlock()
+
+	cnt := 0
+	revIP, err := raddrToIPv4(inaddr)
+	if err != nil {
+		return newParseError("lookup address", inaddr)
+	}
+	for _, nameset := range zone.idents {
+		for _, entry := range nameset.getEntriesForIP(revIP) {
+			entry.addIPObserver(observer)
+			cnt += 1
+		}
+	}
+	if cnt == 0 {
+		err = LookupError(fmt.Sprintf("%+v/%+v", inaddr, revIP))
+	}
+	return
+}
+
+// Get the string representation of a zone
+func (zone zoneDb) String() string {
 	zone.mx.RLock()
 	defer zone.mx.RUnlock()
-	for _, r := range zone.recs {
-		if r.Name == name {
-			return []ZoneRecord{Record{r.Name, r.IP, 0, 0, 0}}, nil
-		}
-	}
-	return nil, LookupError(name)
+	return zone.idents.String()
 }
 
-func (zone *ZoneDb) LookupInaddr(inaddr string) ([]ZoneRecord, error) {
-	if revIP := net.ParseIP(inaddr[:len(inaddr)-rdnsDomainLen]); revIP != nil {
-		revIP4 := revIP.To4()
-		ip := []byte{revIP4[3], revIP4[2], revIP4[1], revIP4[0]}
-		Debug.Printf("[zonedb] Looking for address: %+v", ip)
-		zone.mx.RLock()
-		defer zone.mx.RUnlock()
-		for _, r := range zone.recs {
-			if r.IP.Equal(ip) {
-				return []ZoneRecord{Record{r.Name, r.IP, 0, 0, 0}}, nil
-			}
-		}
-		return nil, LookupError(inaddr)
-	}
-	Warning.Printf("[zonedb] Asked to reverse lookup %s", inaddr)
-	return nil, LookupError(inaddr)
-}
-
-func (zone *ZoneDb) AddRecord(ident string, name string, ip net.IP) error {
-	zone.mx.Lock()
-	defer zone.mx.Unlock()
-	fqdn := dns.Fqdn(name)
-	pred := func(r dbRecord) bool { return r.Name == fqdn && r.IP.Equal(ip) && r.Ident == ident }
-	if index := zone.indexOf(pred); index != -1 {
-		return DuplicateError{}
-	}
-	zone.recs = append(zone.recs, dbRecord{ident, fqdn, ip})
-	return nil
-}
-
-func (zone *ZoneDb) DeleteRecord(ident string, ip net.IP) error {
-	zone.mx.Lock()
-	defer zone.mx.Unlock()
-	pred := func(r dbRecord) bool { return r.Ident == ident && r.IP.Equal(ip) }
-	if index := zone.indexOf(pred); index != -1 {
-		zone.recs = append(zone.recs[:index], zone.recs[index+1:]...)
-		return nil
-	}
-	return LookupError(ident)
-}
-
-func (zone *ZoneDb) DeleteRecordsFor(ident string) error {
-	zone.mx.Lock()
-	defer zone.mx.Unlock()
-	w := 0 // write index
-
-	for _, r := range zone.recs {
-		if r.Ident != ident {
-			zone.recs[w] = r
-			w++
-		}
-	}
-	zone.recs = zone.recs[:w]
-	return nil
-}
-
-func (zone *ZoneDb) ContainerDied(ident string) error {
+// Notify that a container has died
+func (zone *zoneDb) ContainerDied(ident string) error {
 	Info.Printf("[zonedb] Container %s down. Removing records", ident)
 	return zone.DeleteRecordsFor(ident)
+}
+
+// Return true if the we have obtained some information for a name from remote peers
+// We can have both local (eg, introduced through the HTTP API) and remote (eg, mDNS)
+// information for a name. This method only checks if there is remote information...
+func (zone *zoneDb) HasNameRemoteInfo(n string) bool {
+	zone.mx.Lock()
+	defer zone.mx.Unlock()
+
+	remoteNamesSet := zone.getNamesSet(defaultRemoteIdent)
+	if remoteNamesSet != nil {
+		return remoteNamesSet.hasName(n)
+	}
+	return false
+}
+
+// Get or create a names set
+func (zone *zoneDb) getNamesSet(ident string) *namesSet {
+	ns, found := zone.idents[ident]
+	if !found {
+		ns = newNamesSet()
+		zone.idents[ident] = ns
+	}
+	return ns
+}
+
+// Delete a ident
+func (zone *zoneDb) deleteIdent(ident string) {
+	Info.Printf("[zonedb] Removing everything for ident '%s'", ident)
+	if ns, found := zone.idents[ident]; found {
+		for _, n := range ns.names {
+			for _, entry := range n.getAllEntries() {
+				entry.notifyIPObservers()
+			}
+			n.notifyNameObservers()
+		}
+		delete(zone.idents, ident)
+	}
 }

--- a/nameserver/zone.go
+++ b/nameserver/zone.go
@@ -48,6 +48,10 @@ type Zone interface {
 	DeleteRecord(ident string, ip net.IP) error
 	// Delete all records for an ident in the local database
 	DeleteRecordsFor(ident string) error
+	// Lookup for a name in the whole domain
+	DomainLookupName(name string) ([]ZoneRecord, error)
+	// Lookup for an address in the whole domain
+	DomainLookupInaddr(inaddr string) ([]ZoneRecord, error)
 	// Return a status string
 	Status() string
 }

--- a/nameserver/zone_lookup.go
+++ b/nameserver/zone_lookup.go
@@ -28,6 +28,67 @@ func (zone *zoneDb) LookupName(name string) (res []ZoneRecord, err error) {
 	return
 }
 
+// Perform a lookup for a name in the zone
+// The name can be resolved locally with the local database or with some other resolution method (eg, a mDNS query)
+func (zone *zoneDb) DomainLookupName(name string) (res []ZoneRecord, err error) {
+	name = dns.Fqdn(name)
+	Debug.Printf("[zonedb] Looking for name '%s' in local(&remote) database", name)
+
+	zone.mx.RLock()
+	now := zone.clock.Now()
+	for identName, nameset := range zone.idents {
+		for _, ze := range nameset.getEntriesForName(name) {
+			// filter the entries with expired TTL
+			// locally introduced entries are nver expired as the always have TTL=0
+			if ze.hasExpired(now) {
+				Debug.Printf("[zonedb] '%s': expired entry '%s' ignored: removing", name, ze)
+				nameset.deleteName(name)
+			} else {
+				res = append(res, ze)
+			}
+		}
+		if identName != defaultRemoteIdent {
+			nameset.touchName(name, now)
+		}
+	}
+	zone.mx.RUnlock()
+
+	if len(res) > 0 {
+		Debug.Printf("[zonedb] '%s' resolved in local database", name)
+	} else {
+		// no local results have been obtained in the local database: try with a mDNS query
+		// (this request is not a background query, so we cannot delay the response)
+		Debug.Printf("[zonedb] name '%s' not in local database: trying with mDNS", name)
+		ips, err := zone.mdnsCli.LookupName(name)
+		if err != nil {
+			Debug.Printf("[zonedb] mDNS lookup error for '%s': %s", name, err)
+			return nil, err
+		}
+
+		// if the request has been successful, save the IP in the local database and return the corresponding ZoneRecord
+		// (we do not get the remote ident in the mDNS reply, so we save it in a "remote" ident)
+		Debug.Printf("[zonedb] adding '%s' (obtained with mDNS) to '%s'", ips, name)
+		res = make([]ZoneRecord, len(ips))
+		zone.mx.Lock()
+		now = zone.clock.Now()
+		for i, zr := range ips {
+			res[i], err = zone.getNamesSet(defaultRemoteIdent).addIPToName(zr, now)
+			if err != nil {
+				zone.mx.Unlock()
+				Warning.Printf("[zonedb] IP [%s] insertion for '%s' failed: %s", ips, name, err)
+				return nil, err
+			}
+		}
+		zone.mx.Unlock()
+	}
+
+	if len(res) > 0 {
+		return res, nil
+	}
+
+	return nil, LookupError(name)
+}
+
 // Perform a lookup for a IP address in the zone
 // The address can be resolved locally with the local database
 func (zone *zoneDb) LookupInaddr(inaddr string) (res []ZoneRecord, err error) {
@@ -53,3 +114,70 @@ func (zone *zoneDb) LookupInaddr(inaddr string) (res []ZoneRecord, err error) {
 	}
 	return
 }
+
+// Perform a lookup for a IP address in the zone
+// The address can be resolved either with the local database or
+// with some other resolution method (eg, a mDNS query)
+func (zone *zoneDb) DomainLookupInaddr(inaddr string) (res []ZoneRecord, err error) {
+	revIPv4, err := raddrToIPv4(inaddr)
+	if err != nil {
+		return nil, newParseError("lookup address", inaddr)
+	}
+
+	Debug.Printf("[zonedb] Looking for address in local(&remote) database: '%s' (%s)", revIPv4, inaddr)
+
+	zone.mx.RLock()
+	now := zone.clock.Now()
+	for identName, nameset := range zone.idents {
+		for _, ze := range nameset.getEntriesForIP(revIPv4) {
+			// filter the entries with expired TTL
+			// locally introduced entries are nver expired as the always have TTL=0
+			if ze.hasExpired(now) {
+				Debug.Printf("[zonedb] '%s': expired entry '%s' ignored: removing", revIPv4, ze)
+				nameset.deleteIP(revIPv4)
+			} else {
+				res = append(res, ZoneRecord(ze))
+				if identName != defaultRemoteIdent {
+					nameset.touchName(ze.Name(), now)
+				}
+			}
+		}
+	}
+	zone.mx.RUnlock()
+
+	if len(res) > 0 {
+		Debug.Printf("[zonedb] '%s' resolved in local database", inaddr)
+	} else {
+		// no local results have been obtained in the local database: try with a mDNS query
+		Debug.Printf("[zonedb] '%s'(%+v) not in local database... trying with mDNS", inaddr, revIPv4)
+		names, err := zone.mdnsCli.LookupInaddr(inaddr)
+		if err != nil {
+			Debug.Printf("[zonedb] mDNS lookup error for '%s': %s", inaddr, err)
+			return nil, err
+		}
+
+		// if the request has been successful, save the IP in the local database and return the corresponding ZoneRecord
+		// (we do not get the remote ident in the mDNS reply, so we save it in a "remote" ident)
+		Debug.Printf("[zonedb] adding '%s' (obtained with mDNS) to '%s'", names, revIPv4)
+		res = make([]ZoneRecord, len(names))
+		zone.mx.Lock()
+		now = zone.clock.Now()
+		for i, name := range names {
+			res[i], err = zone.getNamesSet(defaultRemoteIdent).addIPToName(name, now)
+			if err != nil {
+				zone.mx.Unlock()
+				Warning.Printf("[zonedb] Name '%s' insertion for %s failed: %s", name.Name(), revIPv4, err)
+				return nil, err
+			}
+		}
+		zone.mx.Unlock()
+	}
+
+	if len(res) > 0 {
+		return res, nil
+	}
+
+	return nil, LookupError(inaddr)
+
+}
+

--- a/nameserver/zone_lookup.go
+++ b/nameserver/zone_lookup.go
@@ -1,0 +1,55 @@
+package nameserver
+
+import (
+	"github.com/miekg/dns"
+	. "github.com/weaveworks/weave/common"
+)
+
+// Perform a lookup for a name in the zone
+// The name can be resolved locally with the local database
+func (zone *zoneDb) LookupName(name string) (res []ZoneRecord, err error) {
+	zone.mx.RLock()
+	defer zone.mx.RUnlock()
+
+	// note: LookupName() is usually called from the mDNS server, so we do not touch the name
+	name = dns.Fqdn(name)
+	Debug.Printf("[zonedb] Looking for name '%s' in local database", name)
+	for identName, nameset := range zone.idents {
+		if identName != defaultRemoteIdent {
+			for _, ze := range nameset.getEntriesForName(name) {
+				res = append(res, ze)
+			}
+		}
+	}
+
+	if len(res) == 0 {
+		err = LookupError(name)
+	}
+	return
+}
+
+// Perform a lookup for a IP address in the zone
+// The address can be resolved locally with the local database
+func (zone *zoneDb) LookupInaddr(inaddr string) (res []ZoneRecord, err error) {
+	zone.mx.RLock()
+	defer zone.mx.RUnlock()
+
+	// note: LookupInaddr() is usually called from the mDNS server, so we do not touch the name
+
+	revIPv4, err := raddrToIPv4(inaddr)
+	if err != nil {
+		return nil, newParseError("lookup address", inaddr)
+	}
+	Debug.Printf("[zonedb] Looking for address in local database: '%s' (%s)", revIPv4, inaddr)
+	for identName, nameset := range zone.idents {
+		if identName != defaultRemoteIdent {
+			for _, ze := range nameset.getEntriesForIP(revIPv4) {
+				res = append(res, ZoneRecord(ze))
+			}
+		}
+	}
+	if len(res) == 0 {
+		err = LookupError(inaddr)
+	}
+	return
+}

--- a/nameserver/zone_lookup.go
+++ b/nameserver/zone_lookup.go
@@ -6,6 +6,20 @@ import (
 	"time"
 )
 
+func (zone *zoneDb) lookup(target string, lfun func(ns *namesSet) []*recordEntry) (res []ZoneRecord, err error) {
+	for identName, nameset := range zone.idents {
+		if identName != defaultRemoteIdent {
+			for _, ze := range lfun(nameset) {
+				res = append(res, ze)
+			}
+		}
+	}
+	if len(res) == 0 {
+		err = LookupError(target)
+	}
+	return
+}
+
 // Perform a lookup for a name in the zone
 // The name can be resolved locally with the local database
 func (zone *zoneDb) LookupName(name string) (res []ZoneRecord, err error) {
@@ -15,17 +29,50 @@ func (zone *zoneDb) LookupName(name string) (res []ZoneRecord, err error) {
 	// note: LookupName() is usually called from the mDNS server, so we do not touch the name
 	name = dns.Fqdn(name)
 	Debug.Printf("[zonedb] Looking for name '%s' in local database", name)
-	for identName, nameset := range zone.idents {
-		if identName != defaultRemoteIdent {
-			for _, ze := range nameset.getEntriesForName(name) {
-				res = append(res, ze)
-			}
-		}
+	return zone.lookup(name, func(ns *namesSet) []*recordEntry { return ns.getEntriesForName(name) })
+}
+
+// Perform a lookup for a IP address in the zone
+// The address can be resolved locally with the local database
+func (zone *zoneDb) LookupInaddr(inaddr string) (res []ZoneRecord, err error) {
+	zone.mx.RLock()
+	defer zone.mx.RUnlock()
+
+	// note: LookupInaddr() is usually called from the mDNS server, so we do not touch the name
+	revIPv4, err := raddrToIPv4(inaddr)
+	if err != nil {
+		return nil, newParseError("lookup address", inaddr)
+	}
+	Debug.Printf("[zonedb] Looking for address in local database: '%s' (%s)", revIPv4, inaddr)
+	return zone.lookup(inaddr, func(ns *namesSet) []*recordEntry { return ns.getEntriesForIP(revIPv4) })
+}
+
+// Perform a domain lookup with mDNS
+func (zone *zoneDb) domainLookup(target string, lfun ZoneLookupFunc) (res []ZoneRecord, err error) {
+	// no local results have been obtained in the local database: try with a mDNS query
+	Debug.Printf("[zonedb] '%s' not in local database... trying with mDNS", target)
+	lanswers, err := lfun(target)
+	if err != nil {
+		Debug.Printf("[zonedb] mDNS lookup error for '%s': %s", target, err)
+		return nil, err
 	}
 
-	if len(res) == 0 {
-		err = LookupError(name)
+	// if the request has been successful, save the IP in the local database and return the corresponding ZoneRecord
+	// (we do not get the remote ident in the mDNS reply, so we save it in a "remote" ident)
+	Debug.Printf("[zonedb] adding '%s' (obtained with mDNS) to '%s'", lanswers, target)
+	res = make([]ZoneRecord, len(lanswers))
+	zone.mx.Lock()
+	now := zone.clock.Now()
+	remoteIdent := zone.getNamesSet(defaultRemoteIdent)
+	for i, answer := range lanswers {
+		res[i], err = remoteIdent.addIPToName(answer, now)
+		if err != nil {
+			zone.mx.Unlock()
+			Warning.Printf("[zonedb] '%s' insertion for %s failed: %s", answer, target, err)
+			return nil, err
+		}
 	}
+	zone.mx.Unlock()
 	return
 }
 
@@ -40,7 +87,7 @@ func (zone *zoneDb) DomainLookupName(name string) (res []ZoneRecord, err error) 
 	for identName, nameset := range zone.idents {
 		for _, ze := range nameset.getEntriesForName(name) {
 			// filter the entries with expired TTL
-			// locally introduced entries are nver expired as the always have TTL=0
+			// locally introduced entries are never expired: they always have TTL=0
 			if ze.hasExpired(now) {
 				Debug.Printf("[zonedb] '%s': expired entry '%s' ignored: removing", name, ze)
 				nameset.deleteName(name)
@@ -57,67 +104,14 @@ func (zone *zoneDb) DomainLookupName(name string) (res []ZoneRecord, err error) 
 	if len(res) > 0 {
 		Debug.Printf("[zonedb] '%s' resolved in local database", name)
 	} else {
-		// no local results have been obtained in the local database: try with a mDNS query
-		// (this request is not a background query, so we cannot delay the response)
-		Debug.Printf("[zonedb] name '%s' not in local database: trying with mDNS", name)
-		ips, err := zone.mdnsCli.LookupName(name)
-		if err != nil {
-			Debug.Printf("[zonedb] mDNS lookup error for '%s': %s", name, err)
-			return nil, err
-		}
-
-		// if the request has been successful, save the IP in the local database and return the corresponding ZoneRecord
-		// (we do not get the remote ident in the mDNS reply, so we save it in a "remote" ident)
-		Debug.Printf("[zonedb] adding '%s' (obtained with mDNS) to '%s'", ips, name)
-		res = make([]ZoneRecord, len(ips))
-		zone.mx.Lock()
-		now = zone.clock.Now()
-		for i, zr := range ips {
-			res[i], err = zone.getNamesSet(defaultRemoteIdent).addIPToName(zr, now)
-			if err != nil {
-				zone.mx.Unlock()
-				Warning.Printf("[zonedb] IP [%s] insertion for '%s' failed: %s", ips, name, err)
-				return nil, err
-			}
-		}
-		zone.mx.Unlock()
+		res, err = zone.domainLookup(name, zone.mdnsCli.LookupName)
 	}
 
 	if len(res) > 0 {
-		// start (if we need to) a background refresh for the name
-		// note: we do not spend time trying to update names that did not return an initial response...
 		zone.startUpdatingName(name)
-
 		return res, nil
 	}
-
 	return nil, LookupError(name)
-}
-
-// Perform a lookup for a IP address in the zone
-// The address can be resolved locally with the local database
-func (zone *zoneDb) LookupInaddr(inaddr string) (res []ZoneRecord, err error) {
-	zone.mx.RLock()
-	defer zone.mx.RUnlock()
-
-	// note: LookupInaddr() is usually called from the mDNS server, so we do not touch the name
-
-	revIPv4, err := raddrToIPv4(inaddr)
-	if err != nil {
-		return nil, newParseError("lookup address", inaddr)
-	}
-	Debug.Printf("[zonedb] Looking for address in local database: '%s' (%s)", revIPv4, inaddr)
-	for identName, nameset := range zone.idents {
-		if identName != defaultRemoteIdent {
-			for _, ze := range nameset.getEntriesForIP(revIPv4) {
-				res = append(res, ZoneRecord(ze))
-			}
-		}
-	}
-	if len(res) == 0 {
-		err = LookupError(inaddr)
-	}
-	return
 }
 
 // Perform a lookup for a IP address in the zone
@@ -136,7 +130,7 @@ func (zone *zoneDb) DomainLookupInaddr(inaddr string) (res []ZoneRecord, err err
 	for identName, nameset := range zone.idents {
 		for _, ze := range nameset.getEntriesForIP(revIPv4) {
 			// filter the entries with expired TTL
-			// locally introduced entries are nver expired as the always have TTL=0
+			// locally introduced entries are never expired: they always have TTL=0
 			if ze.hasExpired(now) {
 				Debug.Printf("[zonedb] '%s': expired entry '%s' ignored: removing", revIPv4, ze)
 				nameset.deleteIP(revIPv4)
@@ -153,44 +147,20 @@ func (zone *zoneDb) DomainLookupInaddr(inaddr string) (res []ZoneRecord, err err
 	if len(res) > 0 {
 		Debug.Printf("[zonedb] '%s' resolved in local database", inaddr)
 	} else {
-		// no local results have been obtained in the local database: try with a mDNS query
-		Debug.Printf("[zonedb] '%s'(%+v) not in local database... trying with mDNS", inaddr, revIPv4)
-		names, err := zone.mdnsCli.LookupInaddr(inaddr)
-		if err != nil {
-			Debug.Printf("[zonedb] mDNS lookup error for '%s': %s", inaddr, err)
-			return nil, err
-		}
-
-		// if the request has been successful, save the IP in the local database and return the corresponding ZoneRecord
-		// (we do not get the remote ident in the mDNS reply, so we save it in a "remote" ident)
-		Debug.Printf("[zonedb] adding '%s' (obtained with mDNS) to '%s'", names, revIPv4)
-		res = make([]ZoneRecord, len(names))
-		zone.mx.Lock()
-		now = zone.clock.Now()
-		for i, name := range names {
-			res[i], err = zone.getNamesSet(defaultRemoteIdent).addIPToName(name, now)
-			if err != nil {
-				zone.mx.Unlock()
-				Warning.Printf("[zonedb] Name '%s' insertion for %s failed: %s", name.Name(), revIPv4, err)
-				return nil, err
-			}
-		}
-		zone.mx.Unlock()
+		res, err = zone.domainLookup(inaddr, zone.mdnsCli.LookupInaddr)
 	}
 
 	if len(res) > 0 {
 		// note: even for reverse addresses, we perform the background updates in the name, not in the IP
 		//       this simplifies the process and produces basically the same results...
 		// note: we do not spend time trying to update names that did not return an initial response...
-		for _, name := range res {
-			zone.startUpdatingName(name.Name())
+		for _, r := range res {
+			zone.startUpdatingName(r.Name())
 		}
 
 		return res, nil
 	}
-
 	return nil, LookupError(inaddr)
-
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/nameserver/zone_lookup_test.go
+++ b/nameserver/zone_lookup_test.go
@@ -1,0 +1,114 @@
+package nameserver
+
+import (
+	"github.com/benbjohnson/clock"
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
+	"net"
+	"testing"
+	"time"
+)
+
+// Check that the refreshing mechanism works as expected
+func TestZoneRefresh(t *testing.T) {
+	const (
+		refreshInterval = 5
+		relevantTime    = 30
+	)
+	var (
+		name  = "mysql.weave.local."
+		addr1 = "10.2.8.4"
+		addr2 = "10.2.8.5"
+		addr3 = "10.2.8.6"
+		addr4 = "10.2.8.7"
+	)
+
+	InitDefaultLogging(testing.Verbose())
+	Info.Println("TestZoneRefresh starting")
+
+	clk := clock.NewMock()
+	forwardClock := func(secs int) {
+		Debug.Printf(">>>>>>> Moving clock forward %d seconds - Time traveling >>>>>>>", secs)
+		clk.Add(time.Duration(secs) * time.Second)
+		Debug.Printf("<<<<<<< Time travel finished! We are at %s <<<<<<<", clk.Now())
+	}
+
+	// Create multiple zone databases, linked through mocked mDNS connections
+	zc := ZoneConfig{
+		RefreshInterval: refreshInterval,
+		RelevantTime:    relevantTime,
+		Clock:           clk,
+	}
+	dbs := newZoneDbsWithMockedMDns(2, zc)
+	dbs.Start()
+	defer dbs.Stop()
+
+	time.Sleep(100 * time.Millisecond) // allow for server to get going
+
+	Debug.Printf("Adding '%s' to Db #1", name)
+	dbs[0].Zone.AddRecord("someident", name, net.ParseIP(addr1))
+
+	Debug.Printf("Checking that the name %s is relevant (as it has been locally inserted) and not remote", name)
+	wt.AssertTrue(t, dbs[0].Zone.IsNameRelevant(name), "name relevant")
+	wt.AssertTrue(t, dbs[0].Zone.HasNameLocalInfo(name), "local name info")
+	wt.AssertFalse(t, dbs[0].Zone.HasNameRemoteInfo(name), "remote name info")
+
+	Debug.Printf("Asking for '%s' to Db #1: should get 1 IP from the local database...", name)
+	res, err := dbs[0].Zone.DomainLookupName(name)
+	wt.AssertNoErr(t, err)
+	Debug.Printf("Got: %s", res)
+	t.Logf("Db #1 after the lookup:\n%s", dbs[0].Zone)
+	wt.AssertEqualInt(t, len(res), 1, "lookup result")
+
+	forwardClock(refreshInterval / 2)
+	Debug.Printf("A couple of seconds later, we should still have one IP for that name")
+	res, err = dbs[0].Zone.DomainLookupName(name)
+	wt.AssertNoErr(t, err)
+	wt.AssertEqualInt(t, len(res), 1, "lookup result")
+
+	Debug.Printf("And then we add 2 IPs for that name at ZoneDb 2")
+	forwardClock(1)
+	Debug.Printf("Adding 2 IPs to '%s' in Db #2", name)
+	dbs[1].Zone.AddRecord("someident", name, net.ParseIP(addr2))
+	dbs[1].Zone.AddRecord("someident", name, net.ParseIP(addr3))
+
+	Debug.Printf("Perform a lookup, to ensure the name will be updated in the background...")
+	dbs[0].Zone.DomainLookupName(name)
+
+	Debug.Printf("Wait for a while, until a refresh is performed...")
+	forwardClock(refreshInterval + 1)
+
+	Debug.Printf("A refresh should have been scheduled now: we should have 3 IPs:")
+	Debug.Printf("the first (local) IP and the others obtained from zone2 with a mDNS query")
+	Debug.Printf("Asking for '%s' again... we should have 3 IPs now", name)
+	res, err = dbs[0].Zone.DomainLookupName(name)
+	Debug.Printf("Got: %s", res)
+	t.Logf("Db #1 after the second lookup:\n%s", dbs[0].Zone)
+	wt.AssertEqualInt(t, len(res), 3, "lookup result length")
+
+	Debug.Printf("We will not ask for `name` for a while, so it will become irrelevant and will be removed...")
+	forwardClock(relevantTime + refreshInterval + 1)
+
+	// the name should be irrelevant now, and all remote info should have been
+	// removed from the zone database
+	Debug.Printf("Name '%s' should not be in the remote database in ZoneDb 1", name)
+	wt.AssertFalse(t, dbs[0].Zone.IsNameRelevant(name), "name still relevant after some inactivity time")
+	wt.AssertTrue(t, dbs[0].Zone.HasNameLocalInfo(name), "local name info")
+	wt.AssertFalse(t, dbs[0].Zone.HasNameRemoteInfo(name), "remote name info")
+
+	Debug.Printf("There is no remote info about this name at zone 1: a new IP appears remotely meanwhile...")
+	forwardClock(1)
+	Debug.Printf("Adding '%s' to Db #2", name)
+	dbs[1].Zone.AddRecord("someident", name, net.ParseIP(addr4))
+
+	Debug.Printf("When we ask about this name again, we get 4 IPs (1 local, 3 remote)")
+	forwardClock(1)
+	Debug.Printf("Asking for '%s' again... the first lookup will return only the local results", name)
+	res, err = dbs[0].Zone.DomainLookupName(name)
+	wt.AssertEqualInt(t, len(res), 1, "lookup result length")
+	Debug.Printf("... but a second lookup should return all the results in the network")
+	forwardClock(1)
+	res, err = dbs[0].Zone.DomainLookupName(name)
+	Debug.Printf("Got: %s", res)
+	wt.AssertEqualInt(t, len(res), 4, "lookup result length") // TODO: this fails 1% of the runs... !!??
+}

--- a/nameserver/zone_lookup_test.go
+++ b/nameserver/zone_lookup_test.go
@@ -1,11 +1,12 @@
 package nameserver
 
 import (
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"testing"
 	"time"
+
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 // Check that the refreshing mechanism works as expected

--- a/nameserver/zone_test.go
+++ b/nameserver/zone_test.go
@@ -1,6 +1,8 @@
 package nameserver
 
 import (
+	"fmt"
+	. "github.com/weaveworks/weave/common"
 	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"testing"
@@ -8,60 +10,118 @@ import (
 
 func TestZone(t *testing.T) {
 	var (
-		containerID      = "deadbeef"
-		otherContainerID = "cowjuice"
-		successTestName  = "test1.weave."
-		testAddr1        = "10.2.2.1/24"
+		container1    = "deadbeef"
+		container2    = "cowjuice"
+		name1         = "test1.weave."
+		name1Addr1    = "10.9.2.1/24"
+		name1Addr2    = "10.9.2.2/24"
+		revName1Addr1 = "1.2.9.10.in-addr.arpa."
 	)
 
-	var zone = NewZoneDb(DefaultLocalDomain)
+	InitDefaultLogging(testing.Verbose())
 
-	ip, _, _ := net.ParseCIDR(testAddr1)
-	err := zone.AddRecord(containerID, successTestName, ip)
+	zone, err := NewZoneDb(ZoneConfig{})
+	wt.AssertNoErr(t, err)
+	err = zone.Start()
+	wt.AssertNoErr(t, err)
+	defer zone.Stop()
+
+	ip1, _, _ := net.ParseCIDR(name1Addr1)
+	t.Logf("Adding '%s'/%s to '%s'", name1, ip1, container1)
+	err = zone.AddRecord(container1, name1, ip1)
 	wt.AssertNoErr(t, err)
 
 	// Add a few more records to make the job harder
-	err = zone.AddRecord("abcdef0123", "adummy.weave.", net.ParseIP("10.2.0.1"))
+	t.Logf("Adding 'adummy.weave.' to 'abcdef0123'")
+	err = zone.AddRecord("abcdef0123", "adummy.weave.", net.ParseIP("10.9.0.1"))
 	wt.AssertNoErr(t, err)
-	err = zone.AddRecord("0123abcdef", "zdummy.weave.", net.ParseIP("10.2.0.2"))
+	t.Logf("Adding 'zdummy.weave.' to '0123abcdef'")
+	err = zone.AddRecord("0123abcdef", "zdummy.weave.", net.ParseIP("10.9.0.2"))
+	wt.AssertNoErr(t, err)
+	t.Logf("Zone database:\n%s", zone)
+
+	t.Logf("Checking if we can find the name '%s'", name1)
+	foundIPs, err := zone.LookupName(name1)
 	wt.AssertNoErr(t, err)
 
-	// Check that the address is now there.
-	foundIP, err := zone.LookupName(successTestName)
-	wt.AssertNoErr(t, err)
-
-	if !foundIP[0].IP().Equal(ip) {
-		t.Fatal("Unexpected result for", successTestName, foundIP)
+	if !foundIPs[0].IP().Equal(ip1) {
+		t.Fatal("Unexpected result for", name1, foundIPs)
 	}
 
-	// See if we can find the address by IP.
-	foundName, err := zone.LookupInaddr("1.2.2.10.in-addr.arpa.")
+	t.Logf("Checking if we cannot find some silly name like 'something.wrong'")
+	foundIPs, err = zone.LookupName("something.wrong")
+	wt.AssertErrorType(t, err, (*LookupError)(nil), fmt.Sprintf("unknown name: %+v", foundIPs))
+
+	ip2, _, _ := net.ParseCIDR(name1Addr2)
+	t.Logf("Adding a second IP for '%s'/%s to '%s'", name1, ip2, container1)
+	err = zone.AddRecord(container1, name1, ip2)
 	wt.AssertNoErr(t, err)
 
-	if foundName[0].Name() != successTestName {
-		t.Fatal("Unexpected result for", ip, foundName)
+	t.Logf("Checking if we can find both the old IP and the new IP for '%s'", name1)
+	foundIPs, err = zone.LookupName(name1)
+	wt.AssertNoErr(t, err)
+	if !(foundIPs[0].IP().Equal(ip1) || foundIPs[1].IP().Equal(ip1)) {
+		t.Fatal("Unexpected result for", name1, foundIPs)
+	}
+	if !(foundIPs[0].IP().Equal(ip2) || foundIPs[1].IP().Equal(ip2)) {
+		t.Fatal("Unexpected result for", name1, foundIPs)
 	}
 
-	err = zone.AddRecord(containerID, successTestName, ip)
+	t.Logf("Checking if we can find the address by IP '1.2.9.10.in-addr.arpa.'")
+	foundNames, err := zone.LookupInaddr("1.2.9.10.in-addr.arpa.")
+	wt.AssertNoErr(t, err)
+
+	if foundNames[0].Name() != name1 {
+		t.Fatal("Unexpected result for", ip1, foundNames)
+	}
+
+	t.Logf("Checking we can not find an unknown address '30.20.10.1.in-addr.arpa.'")
+	foundNames, err = zone.LookupInaddr("30.20.10.1.in-addr.arpa.")
+	wt.AssertErrorType(t, err, (*LookupError)(nil), fmt.Sprintf("unknown IP: %+v", foundNames))
+
+	t.Logf("Checking if adding again '%s'/%s in %s results in an error", name1, ip1, container1)
+	err = zone.AddRecord(container1, name1, ip1)
 	wt.AssertErrorType(t, err, (*DuplicateError)(nil), "duplicate add")
 
-	err = zone.AddRecord(otherContainerID, successTestName, ip)
-	// Delete the record for the original container
-	err = zone.DeleteRecord(containerID, ip)
+	t.Logf("Adding '%s'/%s in %s too", name1, ip1, container2)
+	err = zone.AddRecord(container2, name1, ip1)
 	wt.AssertNoErr(t, err)
 
-	_, err = zone.LookupName(successTestName)
+	name1Removed := 0
+	err = zone.ObserveName(name1, func() { t.Logf("Observer #1 for '%s' notified.", name1); name1Removed++ })
+	wt.AssertNoErr(t, err)
+	err = zone.ObserveName(name1, func() { t.Logf("Observer #2 for '%s' notified.", name1); name1Removed++ })
+	wt.AssertNoErr(t, err)
+	err = zone.ObserveInaddr(revName1Addr1, func() { t.Logf("Observer #1 for '%s' notified.", revName1Addr1); name1Removed++ })
 	wt.AssertNoErr(t, err)
 
-	err = zone.DeleteRecord(otherContainerID, ip)
+	t.Logf("Zone database:\n%s", zone)
+	t.Logf("Deleting the %s in %s", ip1, container1)
+	err = zone.DeleteRecord(container1, ip1)
+	wt.AssertNoErr(t, err)
+	t.Logf("Zone database:\n%s", zone)
+
+	t.Logf("Checking %s's observers have been notified on removal", name1)
+	if name1Removed < 3 {
+		t.Logf("Zone database:\n%s", zone)
+		t.Fatalf("Unexpected number (%d) of calls to observers", name1Removed)
+	}
+
+	t.Logf("Checking %s can be found", name1)
+	_, err = zone.LookupName(name1)
 	wt.AssertNoErr(t, err)
 
-	// Check that the address is not there now.
-	_, err = zone.LookupName(successTestName)
+	t.Logf("Checking %s is not found after removing %s it in %s and %s in %s",
+		name1, ip1, container2, ip2, container1)
+	err = zone.DeleteRecord(container1, ip2)
+	err = zone.DeleteRecord(container2, ip1)
+	wt.AssertNoErr(t, err)
+	t.Logf("Zone database:\n%s", zone)
+	_, err = zone.LookupName(name1)
 	wt.AssertErrorType(t, err, (*LookupError)(nil), "after deleting record")
 
-	// Delete a record that isn't there
-	err = zone.DeleteRecord(containerID, net.ParseIP("0.0.0.0"))
+	t.Logf("Checking if removing an unknown record results in an error")
+	err = zone.DeleteRecord(container1, net.ParseIP("0.0.0.0"))
 	wt.AssertErrorType(t, err, (*LookupError)(nil), "when deleting record that doesn't exist")
 }
 
@@ -72,14 +132,22 @@ func TestDeleteFor(t *testing.T) {
 		addr1 = "10.2.2.3/24"
 		addr2 = "10.2.7.8/24"
 	)
-	zone := NewZoneDb(DefaultLocalDomain)
+
+	InitDefaultLogging(testing.Verbose())
+
+	zone, err := NewZoneDb(ZoneConfig{})
+	wt.AssertNoErr(t, err)
+	err = zone.Start()
+	wt.AssertNoErr(t, err)
+	defer zone.Stop()
+
 	for _, addr := range []string{addr1, addr2} {
 		ip, _, _ := net.ParseCIDR(addr)
 		err := zone.AddRecord(id, name, ip)
 		wt.AssertNoErr(t, err)
 	}
 
-	_, err := zone.LookupName(name)
+	_, err = zone.LookupName(name)
 	wt.AssertNoErr(t, err)
 
 	err = zone.DeleteRecordsFor(id)

--- a/nameserver/zone_test.go
+++ b/nameserver/zone_test.go
@@ -2,10 +2,11 @@ package nameserver
 
 import (
 	"fmt"
-	. "github.com/weaveworks/weave/common"
-	wt "github.com/weaveworks/weave/testing"
 	"net"
 	"testing"
+
+	. "github.com/weaveworks/weave/common"
+	wt "github.com/weaveworks/weave/testing"
 )
 
 func TestZone(t *testing.T) {

--- a/site/weavedns.md
+++ b/site/weavedns.md
@@ -44,10 +44,9 @@ $ docker attach $shell1
 ```
 
 Note that it is permissible to register multiple containers with the
-same name. weaveDNS picks one address to return when asked for the
-name. Since weaveDNS removes any container that dies, this is a simple
-way to implement redundancy.  In the current implementation it does
-not attempt to do load-balancing.
+same name: weaveDNS picks one address at random on each request. Since
+weaveDNS removes any container that dies, this is a simple way to
+implement redundancy.
 
 Each weaveDNS container started with `launch-dns` needs to be given
 its own, unique, IP address, in a subnet that is a) common to all
@@ -102,6 +101,9 @@ The inverse operation can be carried out using the `dns-remove` command:
 ```bash
 $ weave dns-remove 10.2.1.27 $shell2
 ```
+
+When queried about a name with multiple IPs, weaveDNS returns a random
+result from the set of IPs available.
 
 ## <a name="hot-swapping"></a>Hot-swapping service containers
 

--- a/test/210_dns_multicast_test.sh
+++ b/test/210_dns_multicast_test.sh
@@ -3,7 +3,9 @@
 . ./config.sh
 
 C1=10.2.3.78
-C2=10.2.3.34
+C2_1=10.2.3.34
+C2_2=10.2.3.35
+C2_3=10.2.3.36
 UNIVERSE=10.2.4.0/24
 NAME2=seetwo.weave.local
 NAME4=seefour.weave.local
@@ -16,13 +18,17 @@ weave_on $HOST2 launch -iprange $UNIVERSE $HOST1
 weave_on $HOST1 launch-dns 10.2.254.1/24
 weave_on $HOST2 launch-dns 10.2.254.2/24
 
-start_container          $HOST2 $C2/24 --name=c2 -h $NAME2
-start_container          $HOST2        --name=c4 -h $NAME4
+start_container $HOST2 $C2_1/24 --name=c2 -h $NAME2
+start_container $HOST2          --name=c4 -h $NAME4
+
+weave_on $HOST2 dns-add $C2_2 c2 -h $NAME2
+weave_on $HOST2 dns-add $C2_3 c2 -h $NAME2
+
 start_container_with_dns $HOST1 $C1/24 --name=c1
 start_container_with_dns $HOST1        --name=c3
 C4=$(container_ip $HOST2 c4)
 
-assert_dns_record $HOST1 c1 $NAME2 $C2
+assert_dns_record $HOST1 c1 $NAME2 $C2_1 $C2_2 $C2_3
 assert_dns_record $HOST1 c3 $NAME4 $C4
 
 assert_raises "exec_on $HOST1 c1 getent hosts 8.8.8.8 | grep google"

--- a/test/240_dns_add_name_test.sh
+++ b/test/240_dns_add_name_test.sh
@@ -9,7 +9,7 @@ NAME2=seetwo.weave.local
 
 start_suite "Add and remove names on a single host"
 
-weave_on $HOST1 launch-dns 10.2.254.1/24
+weave_on $HOST1 launch-dns 10.2.254.1/24 --no-cache
 
 start_container          $HOST1 $C2/24 --name=c2
 start_container_with_dns $HOST1 $C1/24 --name=c1
@@ -24,6 +24,6 @@ assert "exec_on $HOST1 c1 getent hosts $C1 | tr -s ' '" "$C1 $NAME1"
 
 weave_on $HOST1 dns-remove $C1 c1
 
-assert_raises "exec_on $HOST1 c1 getent hosts $NAME1" 2
+assert_no_dns_record $HOST1 c1 $NAME1
 
 end_suite

--- a/test/290_dns_fallback_test.sh
+++ b/test/290_dns_fallback_test.sh
@@ -4,7 +4,7 @@
 
 start_suite "Resolve a non-weave address"
 
-weave_on $HOST1 launch-dns 10.2.254.1/24
+weave_on $HOST1 launch-dns 10.2.254.1/24 --no-cache
 
 start_container_with_dns $HOST1 10.2.1.5/24 --name=c1
 

--- a/test/500_weave_multi_cidr_test.sh
+++ b/test/500_weave_multi_cidr_test.sh
@@ -21,11 +21,11 @@ assert_zone_records() {
     FQDN=$1; shift
 
     # Assert correct number of records exist
-    assert "weave_on $HOST status | grep \"^$CID\" | wc -l" $#
+    assert "weave_on $HOST status | grep \"^$CID\" | grep -oE \"\b([0-9]{1,3}\.){3}[0-9]{1,3}\b\" | wc -l" $#
 
     # Assert correct records exist
     for IP; do
-        assert_raises "weave_on $HOST status | grep \"^$CID $IP $FQDN$\""
+        assert_raises "weave_on $HOST status | grep \"$CID\" | grep \"$IP\" | grep \"$FQDN\""
     done
 }
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -34,6 +34,11 @@ def configure_docker(host, hostname, ip)
   cleanup(host.vm)
 end
 
+def configure_resolv_conf(host)
+  # Fix the resolution errors by using 8.8.8.8
+  host.vm.provision :shell, :inline => "echo 'nameserver 8.8.8.8' > /etc/resolv.conf"
+end
+
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -48,6 +53,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   (1..n_machines).each do |i|
     config.vm.define "host#{i}" do |host|
       ip_suffix = ip_suffix_base + i
+      configure_resolv_conf(host)
       configure_docker(host, "host#{i}", "#{ip_prefix}.#{ip_suffix}")
     end
   end

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
+	"os"
+
 	. "github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/common/updater"
 	weavedns "github.com/weaveworks/weave/nameserver"
 	weavenet "github.com/weaveworks/weave/net"
-	"net"
-	"os"
 )
 
 var version = "(unreleased version)"

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -96,13 +96,15 @@ func main() {
 	}
 
 	srvConfig := weavedns.DNSServerConfig{
-		Port:      dnsPort,
-		CacheLen:  cacheLen,
-		Timeout:   timeout,
-		UDPBufLen: udpbuf,
+		Zone:          zone,
+		Port:          dnsPort,
+		CacheLen:      cacheLen,
+		Timeout:       timeout,
+		UDPBufLen:     udpbuf,
+		CacheDisabled: cacheDisabled,
 	}
 
-	srv, err := weavedns.NewDNSServer(srvConfig, zone, iface)
+	srv, err := weavedns.NewDNSServer(srvConfig)
 	if err != nil {
 		Error.Fatal("[main] Failed to initialize the WeaveDNS server", err)
 	}

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -15,19 +15,21 @@ var version = "(unreleased version)"
 
 func main() {
 	var (
-		justVersion bool
-		ifaceName   string
-		apiPath     string
-		domain      string
-		dnsPort     int
-		httpPort    int
-		wait        int
-		timeout     int
-		udpbuf      int
-		cacheLen    int
-		watch       bool
-		debug       bool
-		err         error
+		justVersion     bool
+		ifaceName       string
+		apiPath         string
+		domain          string
+		dnsPort         int
+		httpPort        int
+		wait            int
+		timeout         int
+		udpbuf          int
+		refreshInterval int
+		relevantTime    int
+		cacheLen        int
+		watch           bool
+		debug           bool
+		err             error
 	)
 
 	flag.BoolVar(&justVersion, "version", false, "print version and exit")
@@ -42,6 +44,9 @@ func main() {
 	flag.IntVar(&cacheLen, "cache", weavedns.DefaultCacheLen, "cache length")
 	flag.BoolVar(&watch, "watch", true, "watch the docker socket for container events")
 	flag.BoolVar(&debug, "debug", false, "output debugging info to stderr")
+	// advanced options
+	flag.IntVar(&refreshInterval, "refresh", weavedns.DefaultRefreshInterval, "refresh interval (in secs) for local names (0=disable)")
+	flag.IntVar(&relevantTime, "relevant", weavedns.DefaultRelevantTime, "life time for info in the absence of queries (in secs)")
 	flag.Parse()
 
 	if justVersion {
@@ -50,7 +55,7 @@ func main() {
 	}
 
 	InitDefaultLogging(debug)
-	Info.Printf("WeaveDNS version %s\n", version) // first thing in log: the version
+	Info.Printf("[main] WeaveDNS version %s\n", version) // first thing in log: the version
 
 	var iface *net.Interface
 	if ifaceName != "" {
@@ -67,6 +72,8 @@ func main() {
 	zoneConfig := weavedns.ZoneConfig{
 		Domain:          domain,
 		Iface:           iface,
+		RefreshInterval: refreshInterval,
+		RelevantTime:    relevantTime,
 	}
 	zone, err := weavedns.NewZoneDb(zoneConfig)
 	if err != nil {

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -27,6 +27,7 @@ func main() {
 		refreshInterval int
 		refreshWorkers  int
 		relevantTime    int
+		maxAnswers      int
 		cacheLen        int
 		cacheDisabled   bool
 		watch           bool
@@ -47,6 +48,7 @@ func main() {
 	// advanced options
 	flag.IntVar(&refreshInterval, "refresh", weavedns.DefaultRefreshInterval, "refresh interval (in secs) for local names (0=disable)")
 	flag.IntVar(&refreshWorkers, "refresh-workers", weavedns.DefaultNumUpdaters, "default number of background updaters")
+	flag.IntVar(&maxAnswers, "max-answers", weavedns.DefaultMaxAnswers, "maximum number of answers returned to clients (0=unlimited)")
 	flag.IntVar(&relevantTime, "relevant", weavedns.DefaultRelevantTime, "life time for info in the absence of queries (in secs)")
 	flag.IntVar(&udpbuf, "udpbuf", weavedns.DefaultUDPBuflen, "UDP buffer length")
 	flag.IntVar(&timeout, "timeout", weavedns.DefaultTimeout, "timeout for resolutions (in millisecs)")
@@ -102,6 +104,7 @@ func main() {
 		Zone:          zone,
 		Port:          dnsPort,
 		CacheLen:      cacheLen,
+		MaxAnswers:    maxAnswers,
 		Timeout:       timeout,
 		UDPBufLen:     udpbuf,
 		CacheDisabled: cacheDisabled,

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -25,6 +25,7 @@ func main() {
 		timeout         int
 		udpbuf          int
 		refreshInterval int
+		refreshWorkers  int
 		relevantTime    int
 		cacheLen        int
 		cacheDisabled   bool
@@ -45,6 +46,7 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "output debugging info to stderr")
 	// advanced options
 	flag.IntVar(&refreshInterval, "refresh", weavedns.DefaultRefreshInterval, "refresh interval (in secs) for local names (0=disable)")
+	flag.IntVar(&refreshWorkers, "refresh-workers", weavedns.DefaultNumUpdaters, "default number of background updaters")
 	flag.IntVar(&relevantTime, "relevant", weavedns.DefaultRelevantTime, "life time for info in the absence of queries (in secs)")
 	flag.IntVar(&udpbuf, "udpbuf", weavedns.DefaultUDPBuflen, "UDP buffer length")
 	flag.IntVar(&timeout, "timeout", weavedns.DefaultTimeout, "timeout for resolutions (in millisecs)")
@@ -76,6 +78,7 @@ func main() {
 		Domain:          domain,
 		Iface:           iface,
 		RefreshInterval: refreshInterval,
+		RefreshWorkers:  refreshWorkers,
 		RelevantTime:    relevantTime,
 	}
 	zone, err := weavedns.NewZoneDb(zoneConfig)


### PR DESCRIPTION
This PR implements
- an improved Zone database, where names can have multiple IPs.
  - The Zone database can also store (and differentiate) locally introduced information as well as data obtained from remote peers (with mDNS)
  - Names and IPs accept _observers_ that will we invoked when they change, currently used for cache invalidation but with more potential use cases (eg, remote peers notifications)
  - The mDNS client and server has been moved inside the Zone database. The Zone database will use them for obtaining missing information, for keeping information up to date, etc (this integration between mDNS and the Zone database could be even tighter in the future...)
  - The _mDNS server_ responds with all the answers available in the Zone database, and the _mDNS client_ can make use of multiple answers from other peers for adding information to the local database.
  - The internal structure has also been improved by using maps instead of slices for storing records.
- an _update mechanism_ for keeping names in the database up to date. So far, queries about information not in the database resulted in mDNS queries. Clients would then obtain the first response WeaveDNS could get from other peers, as waiting for more responses would also mean more latency. In this new mechanism, we also trigger an immediate update request for that name in order to get all the other IPs we didn't wait for, and we will repeat that update periodically until either a) there is no local interest in that name or b) no other peer answers our request (more details [here](https://github.com/inercia/weave/blob/weave-583-2/nameserver/zone_lookup.go#L198))
- vastly improved unit tests, with
  - use of an external clock provider, specially useful for testing expirations in the cache and names updates (eg, names that appear and disappear in the network).
  - more mocks, in particular the new mocked mDNS client and server (an external, mocked clock provider would lead to unexpected results with real network senders&receivers)

Note: compared to #615, this PR:
- fixes a timeout problem when contacting the fallback servers
- fixes a missing DNS status output
- WeaveDNS does not answer mDNS queries coming from any local interface
