### PR TITLE
Add "Direct Peers" to weave status

### DIFF
--- a/router/json.go
+++ b/router/json.go
@@ -16,8 +16,8 @@ func (router *Router) StatusJSON(version, encryption string) ([]byte, error) {
 		Macs       *MacCache
 		Peers      *Peers
 		Routes     *Routes
-	}{version, encryption, router.Ourself.Name.String(), router.Ourself.NickName, fmt.Sprintf("%v", router.Iface), router.Macs, router.Peers, router.Routes})
-	// leaving out ConectionMaker due to async complexities
+		ConnectionMakerStatus
+	}{version, encryption, router.Ourself.Name.String(), router.Ourself.NickName, fmt.Sprintf("%v", router.Iface), router.Macs, router.Peers, router.Routes, router.ConnectionMaker.Status()})
 }
 
 func (cache *MacCache) MarshalJSON() ([]byte, error) {

--- a/router/json.go
+++ b/router/json.go
@@ -96,3 +96,20 @@ func (conn *RemoteConnection) MarshalJSON() ([]byte, error) {
 func (name PeerName) MarshalJSON() ([]byte, error) {
 	return json.Marshal(name.String())
 }
+
+func (target Target) MarshalJSON() ([]byte, error) {
+	t := struct {
+		Attempting  bool      `json:"Attempting,omitempty"`
+		TryAfter    time.Time `json:"TryAfter,omitempty"`
+		TryInterval string    `json:"TryInterval,omitempty"`
+		LastError   string    `json:"LastError,omitempty"`
+	}{
+		Attempting:  target.attempting,
+		TryAfter:    target.tryAfter,
+		TryInterval: target.tryInterval.String(),
+	}
+	if target.lastError != nil {
+		t.LastError = target.lastError.Error()
+	}
+	return json.Marshal(t)
+}

--- a/router/router.go
+++ b/router/router.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"bytes"
-	"code.google.com/p/gopacket/layers"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -10,6 +9,8 @@ import (
 	"net"
 	"syscall"
 	"time"
+
+	"code.google.com/p/gopacket/layers"
 )
 
 const macMaxAge = 10 * time.Minute // [1]
@@ -110,7 +111,7 @@ func (router *Router) Status() string {
 	fmt.Fprintf(&buf, "MACs:\n%s", router.Macs)
 	fmt.Fprintf(&buf, "Peers:\n%s", router.Peers)
 	fmt.Fprintf(&buf, "Routes:\n%s", router.Routes)
-	fmt.Fprintf(&buf, "Reconnects:\n%s", router.ConnectionMaker)
+	fmt.Fprint(&buf, router.ConnectionMaker.Status())
 	return buf.String()
 }
 

--- a/test/150_connect_forget_test.sh
+++ b/test/150_connect_forget_test.sh
@@ -5,6 +5,20 @@
 C1=10.2.1.4
 C2=10.2.1.7
 
+direct_peers() {
+  weave_on $1 status | awk "/^Direct Peers:$/{f=1;next} /Reconnects:/{f=0} f"
+}
+
+assert_connected() {
+  assert_raises "direct_peers $HOST2 | grep '^$HOST1$'"
+  assert_raises "exec_on $HOST1 c1 $PING $C2"
+}
+
+assert_disconnected() {
+  assert "direct_peers $HOST2" ""
+  assert_raises "exec_on $HOST1 c1 sh -c '! $PING $C2'"
+}
+
 start_suite "Connecting and forgetting routers after launch"
 
 weave_on $HOST1 launch
@@ -13,14 +27,14 @@ weave_on $HOST2 launch
 start_container $HOST1 $C1/24 --name=c1
 start_container $HOST2 $C2/24 --name=c2
 
-assert_raises "exec_on $HOST1 c1 $PING $C2" 1
+assert_disconnected
 assert_raises "weave_on $HOST2 connect $HOST1 $HOST2"
-assert_raises "exec_on $HOST1 c1 $PING $C2"
+assert_connected
 
 assert_raises "weave_on $HOST2 forget $HOST1 $HOST2"
 assert_raises "weave_on $HOST1 stop"
 assert_raises "weave_on $HOST1 launch"
 
-assert_raises "exec_on $HOST1 c1 $PING $C2" 1
+assert_disconnected
 
 end_suite


### PR DESCRIPTION
Also added connection maker status ("DirectPeers", and "Reconnects") to json status output.

Closes #659 and #660

Text Output is:
```
Direct Peers:
192.168.48.11
Reconnects:
->[192.168.48.11:6783] trying since 2015-05-27 15:03:51.389284634 +0000 UTC
```

JSON Output is:
```json
...
  "DirectPeers" : [
      "192.168.48.11"
   ],
   "Reconnects" : {
      "192.168.48.11:6783" : {
         "TryInterval" : "4.111466676s",
         "Attempting" : true,
         "TryAfter" : "2015-05-27T15:03:51.389284634Z",
         "LastError" : "dial tcp4 192.168.48.11:6783: connection timed out"
      }
   },
...
```