### PR TITLE
shorten proxy entrypoint

### DIFF
--- a/proxy/common.go
+++ b/proxy/common.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	containerIDRegexp   = regexp.MustCompile("^/v[0-9\\.]*/containers/([^/]*)/.*")
-	weaveWaitEntrypoint = []string{"/home/weavewait/weavewait"}
+	weaveWaitEntrypoint = []string{"/w/w"}
 )
 
 func callWeave(args ...string) ([]byte, error) {

--- a/weaveexec/Dockerfile
+++ b/weaveexec/Dockerfile
@@ -16,9 +16,9 @@ WORKDIR /home/weave
 ADD ./weave /home/weave/
 ADD ./sigproxy /home/weave/
 ADD ./weaveproxy /home/weave/
-ADD ./weavewait /home/weavewait/weavewait
+ADD ./weavewait /w/w
 ADD ./docker.tgz /
 
-VOLUME /home/weavewait
+VOLUME /w
 
 ENTRYPOINT ["/home/weave/sigproxy", "/home/weave/weave"]


### PR DESCRIPTION
...so that the default output of the likes of `docker ps` shows some of the real entrypoint/command.

Closes #768.