### PR TITLE
[ipam] Fix race conditions in unit tests

### DIFF
--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -88,7 +88,7 @@ func TestBootstrap(t *testing.T) {
 
 	CheckAllExpectedMessagesSent(alloc1, alloc2)
 
-	alloc1.tryPendingOps()
+	alloc1.actionChan <- func() { alloc1.tryPendingOps() }
 	AssertNothingSent(t, done)
 
 	CheckAllExpectedMessagesSent(alloc1, alloc2)

--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -40,7 +40,6 @@ var (
 	ErrInvalidEntry     = errors.New("Received invalid state update!")
 	ErrEntryInMyRange   = errors.New("Received new entry in my range!")
 	ErrNoFreeSpace      = errors.New("No free space found!")
-	ErrTooMuchFreeSpace = errors.New("Entry reporting too much free space!")
 	ErrInvalidTimeout   = errors.New("dt must be greater than 0")
 	ErrNotFound         = errors.New("No entries for peer found")
 )
@@ -76,7 +75,7 @@ func (r *Ring) checkInvariants() error {
 		distance := r.distance(entry.Token, next.Token)
 
 		if entry.Free > distance {
-			return ErrTooMuchFreeSpace
+			return fmt.Errorf("Entry %s-%s reporting too much free space: %d > %d", entry.Token, next.Token, entry.Free, distance)
 		}
 	}
 


### PR DESCRIPTION
`go test -race` found a couple of race conditions in the ipam unit tests

Note the race conditions arise purely from short-cuts in the unit tests, not from the deployed code.