### PR TITLE
Make the TTL configurable

### DIFF
--- a/nameserver/cache.go
+++ b/nameserver/cache.go
@@ -22,6 +22,8 @@ var (
 )
 
 const (
+	DefaultCacheNegLocalTTL = 30 // Default TTL for negative local resolutions
+
 	defPendingTimeout int = 5 // timeout for a resolution
 )
 

--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -25,8 +25,8 @@ func TestPrune(t *testing.T) {
 		Record{"name", net.ParseIP("10.0.1.4"), 0, 0, 0},
 	}
 
-	reply := makeAddressReply(questionMsg, question, records)
-	reply.Answer[0].Header().Ttl = localTTL
+	reply := makeAddressReply(questionMsg, question, records, DefaultLocalTTL)
+	reply.Answer[0].Header().Ttl = DefaultLocalTTL
 
 	pruned := pruneAnswers(reply.Answer, 1)
 	wt.AssertEqualInt(t, len(pruned), 1, "wrong number of answers")

--- a/nameserver/mdns_server_test.go
+++ b/nameserver/mdns_server_test.go
@@ -21,7 +21,7 @@ func TestServerSimpleQuery(t *testing.T) {
 	Info.Println("TestServerSimpleQuery starting")
 
 	mzone := newMockedZoneWithRecords([]ZoneRecord{testRecord1, testRecord2})
-	mdnsServer, err := NewMDNSServer(mzone, true)
+	mdnsServer, err := NewMDNSServer(mzone, true, DefaultLocalTTL)
 	wt.AssertNoErr(t, err)
 	err = mdnsServer.Start(nil)
 	wt.AssertNoErr(t, err)

--- a/nameserver/mdns_test.go
+++ b/nameserver/mdns_test.go
@@ -18,7 +18,7 @@ func TestClientServerSimpleQuery(t *testing.T) {
 	testInAddr1 := "1.2.2.10.in-addr.arpa."
 
 	mzone := newMockedZoneWithRecords([]ZoneRecord{testRecord1})
-	mdnsServer, err := NewMDNSServer(mzone, true)
+	mdnsServer, err := NewMDNSServer(mzone, true, DefaultLocalTTL)
 	wt.AssertNoErr(t, err)
 	err = mdnsServer.Start(nil)
 	wt.AssertNoErr(t, err)
@@ -94,21 +94,21 @@ func TestClientServerInsistentQuery(t *testing.T) {
 	testInAddr2 := "2.2.2.10.in-addr.arpa."
 
 	mzone1 := newMockedZoneWithRecords([]ZoneRecord{testRecord1})
-	mdnsServer1, err := NewMDNSServer(mzone1, true)
+	mdnsServer1, err := NewMDNSServer(mzone1, true, DefaultLocalTTL)
 	wt.AssertNoErr(t, err)
 	err = mdnsServer1.Start(nil)
 	wt.AssertNoErr(t, err)
 	defer mdnsServer1.Stop()
 
 	mzone2 := newMockedZoneWithRecords([]ZoneRecord{testRecord2})
-	mdnsServer2, err := NewMDNSServer(mzone2, true)
+	mdnsServer2, err := NewMDNSServer(mzone2, true, DefaultLocalTTL)
 	wt.AssertNoErr(t, err)
 	err = mdnsServer2.Start(nil)
 	wt.AssertNoErr(t, err)
 	defer mdnsServer2.Stop()
 
 	// create a third server with exactly the same info as the second server (so we can test duplicates removals)
-	mdnsServer3, err := NewMDNSServer(mzone2, true)
+	mdnsServer3, err := NewMDNSServer(mzone2, true, DefaultLocalTTL)
 	wt.AssertNoErr(t, err)
 	err = mdnsServer3.Start(nil)
 	wt.AssertNoErr(t, err)

--- a/nameserver/server_cache_test.go
+++ b/nameserver/server_cache_test.go
@@ -17,7 +17,7 @@ func TestServerCacheRefresh(t *testing.T) {
 		containerID     = "somecontainer"
 		testName1       = "first.weave.local."
 		testName2       = "second.weave.local."
-		refreshInterval = int(localTTL) / 3
+		refreshInterval = int(DefaultLocalTTL) / 3
 	)
 
 	InitDefaultLogging(testing.Verbose())

--- a/nameserver/server_test.go
+++ b/nameserver/server_test.go
@@ -158,7 +158,7 @@ func TestTCPDNSServer(t *testing.T) {
 
 		t.Logf("Fallback UDP server got asked: returning %d answers", numAnswers)
 		q := req.Question[0]
-		m := makeAddressReply(req, &q, addrs)
+		m := makeAddressReply(req, &q, addrs, DefaultLocalTTL)
 		mLen := m.Len()
 		m.SetEdns0(uint16(maxLen), false)
 
@@ -171,7 +171,7 @@ func TestTCPDNSServer(t *testing.T) {
 	fallbackTCPHandler := func(w dns.ResponseWriter, req *dns.Msg) {
 		t.Logf("Fallback TCP server got asked: returning %d answers", numAnswers)
 		q := req.Question[0]
-		m := makeAddressReply(req, &q, addrs)
+		m := makeAddressReply(req, &q, addrs, DefaultLocalTTL)
 		w.WriteMsg(m)
 	}
 

--- a/site/weavedns.md
+++ b/site/weavedns.md
@@ -134,7 +134,7 @@ Notice how the ping reaches different addresses.
 WeaveDNS removes the addresses of any container that dies. This offers
 a simple way to implement redundancy. E.g. if in our example we stop
 one of the `pingme` containers and re-run the ping tests, eventually
-(within ~30s at most, since that is the weaveDNS cache expiry time) we
+(within ~30s at most, since that is the weaveDNS [cache expiry time](#ttl)) we
 will only be hitting the address of the container that is still alive.
 
 
@@ -178,6 +178,25 @@ to the container args:
 ```bash
 $ weave launch-dns 10.2.254.1/24 --watch=false
 ```
+
+## <a name="ttl"></a>Using a different TTL value
+
+By default, weaveDNS specifies a TTL of 30 seconds in any reply sent to
+another peer. Peers will honor the TTL received and cache the answer
+until it is considered invalid.
+
+However, you can force a different TTL value by launching weaveDNS with
+the `--ttl` argument:
+
+```bash
+$ weave launch-dns 10.2.254.1/24 --ttl=10
+```
+
+This will shorten the lifespan of answers sent to other peers,
+so you will be effectively reducing the probability of them having stale
+information, but you will also be increasing their resolution times (as
+their cache hit rate will be reduced) and the number of request this
+weaveDNS instance will receive.
 
 ## <a name="domain-search-path"></a>Configuring the domain search paths
 

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -25,6 +25,7 @@ func main() {
 		httpPort        int
 		wait            int
 		ttl             int
+		negTTL          int
 		timeout         int
 		udpbuf          int
 		fallback        string
@@ -51,6 +52,7 @@ func main() {
 	flag.BoolVar(&watch, "watch", true, "watch the docker socket for container events")
 	flag.BoolVar(&debug, "debug", false, "output debugging info to stderr")
 	// advanced options
+	flag.IntVar(&negTTL, "neg-ttl", weavedns.DefaultCacheNegLocalTTL, "negative TTL (in secs) for unanswered queries for local names")
 	flag.IntVar(&refreshInterval, "refresh", weavedns.DefaultRefreshInterval, "refresh interval (in secs) for local names (0=disable)")
 	flag.IntVar(&refreshWorkers, "refresh-workers", weavedns.DefaultNumUpdaters, "default number of background updaters")
 	flag.IntVar(&maxAnswers, "max-answers", weavedns.DefaultMaxAnswers, "maximum number of answers returned to clients (0=unlimited)")
@@ -107,14 +109,15 @@ func main() {
 	}
 
 	srvConfig := weavedns.DNSServerConfig{
-		Zone:          zone,
-		Port:          dnsPort,
-		CacheLen:      cacheLen,
-		LocalTTL:      ttl,
-		MaxAnswers:    maxAnswers,
-		Timeout:       timeout,
-		UDPBufLen:     udpbuf,
-		CacheDisabled: cacheDisabled,
+		Zone:             zone,
+		Port:             dnsPort,
+		CacheLen:         cacheLen,
+		LocalTTL:         ttl,
+		CacheNegLocalTTL: negTTL,
+		MaxAnswers:       maxAnswers,
+		Timeout:          timeout,
+		UDPBufLen:        udpbuf,
+		CacheDisabled:    cacheDisabled,
 	}
 
 	if len(fallback) > 0 {

--- a/weavedns/main.go
+++ b/weavedns/main.go
@@ -24,6 +24,7 @@ func main() {
 		dnsPort         int
 		httpPort        int
 		wait            int
+		ttl             int
 		timeout         int
 		udpbuf          int
 		fallback        string
@@ -46,6 +47,7 @@ func main() {
 	flag.IntVar(&dnsPort, "dnsport", weavedns.DefaultServerPort, "port to listen to DNS requests")
 	flag.IntVar(&httpPort, "httpport", 6785, "port to listen to HTTP requests")
 	flag.IntVar(&cacheLen, "cache", weavedns.DefaultCacheLen, "cache length")
+	flag.IntVar(&ttl, "ttl", weavedns.DefaultLocalTTL, "TTL (in secs) for responses for local names")
 	flag.BoolVar(&watch, "watch", true, "watch the docker socket for container events")
 	flag.BoolVar(&debug, "debug", false, "output debugging info to stderr")
 	// advanced options
@@ -82,6 +84,7 @@ func main() {
 	zoneConfig := weavedns.ZoneConfig{
 		Domain:          domain,
 		Iface:           iface,
+		LocalTTL:        ttl,
 		RefreshInterval: refreshInterval,
 		RefreshWorkers:  refreshWorkers,
 		RelevantTime:    relevantTime,
@@ -107,6 +110,7 @@ func main() {
 		Zone:          zone,
 		Port:          dnsPort,
 		CacheLen:      cacheLen,
+		LocalTTL:      ttl,
 		MaxAnswers:    maxAnswers,
 		Timeout:       timeout,
 		UDPBufLen:     udpbuf,


### PR DESCRIPTION
This PR introduces a `--ttl` argument in WeaveDNS for specifying a TTL different from the default 30secs. This TTL is used by WeaveDNS in:

* mDNS answers sent to other peers (these peers will honor this TTL when keeping these answers in the cache)
* DNS answers sent to local clients for locally introduced records (as they are not introduced with a TTL).

Some other changes:
* an undocumented `--neg-ttl` argument has also been introduced (not intended to be used by users)
* some minor refactorings (specially in TTL constants names)

Fixes #711
