### PR TITLE
Proxy kills container and returns error when attach fails

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -35,7 +35,7 @@ func (c *client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case err == docker.ErrNoSuchImage:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
-			http.Error(w, "Unable to intercept request", http.StatusInternalServerError)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			Warning.Print("Error intercepting request: ", err)
 		}
 		return
@@ -58,7 +58,7 @@ func (c *client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	err = c.InterceptResponse(resp)
 	if err != nil {
-		http.Error(w, "Unable to intercept response", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		Warning.Print("Error intercepting response: ", err)
 		return
 	}

--- a/proxy/start_container_interceptor.go
+++ b/proxy/start_container_interceptor.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -33,8 +34,10 @@ func (i *startContainerInterceptor) InterceptResponse(r *http.Response) error {
 	args := []string{"attach"}
 	args = append(args, cidrs...)
 	args = append(args, container.ID)
-	if _, err := callWeave(args...); err != nil {
-		Warning.Printf("Attaching container %s to weave network failed: %v", container.ID, err)
+	if output, err := callWeave(args...); err != nil {
+		i.client.KillContainer(docker.KillContainerOptions{ID: container.ID})
+		Warning.Printf("Attaching container %s to weave network failed: %s", container.ID, string(output))
+		return errors.New(string(output))
 	}
 	return nil
 }

--- a/weavewait/main.go
+++ b/weavewait/main.go
@@ -10,21 +10,21 @@ import (
 )
 
 func main() {
-	if _, err := net.EnsureInterface("ethwe", 20); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-	}
+	_, err := net.EnsureInterface("ethwe", 20)
+	checkErr(err)
 
 	if len(os.Args) <= 1 {
 		os.Exit(0)
 	}
 
 	binary, err := exec.LookPath(os.Args[1])
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	checkErr(err)
 
-	if err := syscall.Exec(binary, os.Args[1:], os.Environ()); err != nil {
+	checkErr(syscall.Exec(binary, os.Args[1:], os.Environ()))
+}
+
+func checkErr(err error) {
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
If weavewait times out, it now exits, so that the behaviour is consistent with the proxy failing to attach networking.

Closes #788