### PR TITLE
Improve ipam status message before and after pending consensus

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -456,10 +456,12 @@ func (alloc *Allocator) actorLoop(actionChan <-chan func()) {
 
 func (alloc *Allocator) string() string {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "Allocator subnet %s/%d\n", alloc.subnetStart.String(), alloc.prefixLen)
+	fmt.Fprintf(&buf, "Allocator subnet %s/%d", alloc.subnetStart.String(), alloc.prefixLen)
 
 	if alloc.ring.Empty() {
-		fmt.Fprintf(&buf, "Awaiting consensus: %s", alloc.paxos.String())
+		if alloc.paxosTicker != nil {
+			fmt.Fprintf(&buf, " awaiting consensus: %s", alloc.paxos.String())
+		}
 	} else {
 		localFreeSpace := alloc.space.NumFreeAddresses()
 		remoteFreeSpace := alloc.ring.TotalRemoteFree()
@@ -469,14 +471,14 @@ func (alloc *Allocator) string() string {
 
 		fmt.Fprint(&buf, "Owned Ranges:")
 		alloc.ring.FprintWithNicknames(&buf, alloc.nicknames)
-		if len(alloc.pendingAllocates)+len(alloc.pendingClaims) > 0 {
-			fmt.Fprintf(&buf, "\nPending requests for ")
-			for _, op := range alloc.pendingAllocates {
-				fmt.Fprintf(&buf, "%s, ", op.String())
-			}
-			for _, op := range alloc.pendingClaims {
-				fmt.Fprintf(&buf, "%s, ", op.String())
-			}
+	}
+	if len(alloc.pendingAllocates)+len(alloc.pendingClaims) > 0 {
+		fmt.Fprintf(&buf, "\nPending requests for ")
+		for _, op := range alloc.pendingAllocates {
+			fmt.Fprintf(&buf, "%s, ", op.String())
+		}
+		for _, op := range alloc.pendingClaims {
+			fmt.Fprintf(&buf, "%s, ", op.String())
 		}
 	}
 	return buf.String()

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -473,12 +473,12 @@ func (alloc *Allocator) string() string {
 		alloc.ring.FprintWithNicknames(&buf, alloc.nicknames)
 	}
 	if len(alloc.pendingAllocates)+len(alloc.pendingClaims) > 0 {
-		fmt.Fprintf(&buf, "\nPending requests for ")
+		fmt.Fprintf(&buf, "\nPending requests:")
 		for _, op := range alloc.pendingAllocates {
-			fmt.Fprintf(&buf, "%s, ", op.String())
+			fmt.Fprintf(&buf, "\n  %s", op.String())
 		}
 		for _, op := range alloc.pendingClaims {
-			fmt.Fprintf(&buf, "%s, ", op.String())
+			fmt.Fprintf(&buf, "\n  %s", op.String())
 		}
 	}
 	return buf.String()


### PR DESCRIPTION
Use the presence of a ticker object to determine whether we are actually waiting for consensus.
I also pulled the 'pending' bit out of the if-I-have-a-ring clause, because it is of interest either way.

Status before anything has happened now looks like this:

    Allocator subnet 10.3.0.0/16

and after one `weave run`:

    Allocator subnet 10.3.0.0/16 awaiting consensus: Nodes known: 1, Quorum size: 5
    Pending requests for Allocate for 8450fe9a4cf18299cc745d32b8d052ac9e6cb3f069710a58eaff19abed78d607, 

Fixes #787 