### PR TITLE
weave launch-proxy should handle short-form DOCKER_HOST (w/o tcp://)

### DIFF
--- a/weave
+++ b/weave
@@ -170,10 +170,6 @@ HTTP_PORT=6784
 DNS_HTTP_PORT=6785
 PROXY_PORT=12375
 PROXY_CONTAINER_NAME=weaveproxy
-PROXY_HOST="localhost"
-if [ "$DOCKER_HOST" != "${DOCKER_HOST#tcp://}" ] ; then
-    PROXY_HOST=$(echo "$DOCKER_HOST" | sed -e "s|tcp://\([^:]*\):[0-9]*|\1|")
-fi
 
 
 ######################################################################
@@ -850,7 +846,7 @@ case "$COMMAND" in
             $WEAVEPROXY_DOCKER_ARGS \
             $EXEC_IMAGE "$@")
 
-        wait_for_status_ip $PROXY_HOST $PROXY_PORT /weave
+        wait_for_status_ip 127.0.0.1 $PROXY_PORT /weave
         echo $PROXY_CONTAINER
         ;;
     connect)


### PR DESCRIPTION
Closes #803 