### PR TITLE
weave PROXY_HOST is always localhost, so just hardcode it as that

### DIFF
--- a/weave
+++ b/weave
@@ -171,10 +171,6 @@ HTTP_PORT=6784
 DNS_HTTP_PORT=6785
 PROXY_PORT=12375
 PROXY_CONTAINER_NAME=weaveproxy
-PROXY_HOST="localhost"
-if [ "$DOCKER_HOST" != "${DOCKER_HOST#tcp://}" ] ; then
-    PROXY_HOST=$(echo "$DOCKER_HOST" | sed -e "s|tcp://\([^:]*\):[0-9]*|\1|")
-fi
 
 
 ######################################################################
@@ -868,7 +864,7 @@ case "$COMMAND" in
             $WEAVEPROXY_DOCKER_ARGS \
             $EXEC_IMAGE "$@")
 
-        wait_for_status_ip $PROXY_HOST $PROXY_PORT
+        wait_for_status_ip 127.0.0.1 $PROXY_PORT
         echo $PROXY_CONTAINER
         ;;
     connect)


### PR DESCRIPTION
Because launch-proxy runs in weaveexec container, DOCKER_HOST is never
set.

Closes #807 