### PR TITLE
[proxy] Use USR2 signal to tell weavewait when to continue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ travis: $(EXES)
 update: $(EXES)
 	go get -u -f -v -tags -netgo $(addprefix ./,$(dir $(EXES)))
 
-$(WEAVER_EXE) $(WEAVEDNS_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE): common/*.go common/*/*.go net/*.go
+$(WEAVER_EXE) $(WEAVEDNS_EXE) $(WEAVEPROXY_EXE): common/*.go common/*/*.go net/*.go
 	go get -tags netgo ./$(@D)
 	go build -ldflags "-extldflags \"-static\" -X main.version $(WEAVE_VERSION)" -tags netgo -o $@ ./$(@D)
 	@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
@@ -55,11 +55,14 @@ $(WEAVER_EXE) $(WEAVEDNS_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE): common/*.go co
 $(WEAVER_EXE): router/*.go ipam/*.go ipam/*/*.go prog/weaver/main.go
 $(WEAVEDNS_EXE): nameserver/*.go prog/weavedns/main.go
 $(WEAVEPROXY_EXE): proxy/*.go prog/weaveproxy/main.go
-$(WEAVEWAIT_EXE): prog/weavewait/*.go
 
-# Sigproxy needs separate rule as it fails the netgo check in the main
-# build stanza due to not importing net package
+# Sigproxy and weavewait need separate rules as they fail the netgo check in
+# the main build stanza due to not importing net package
+
 $(SIGPROXY_EXE): prog/sigproxy/main.go
+	go build -o $@ ./$(@D)
+
+$(WEAVEWAIT_EXE): prog/weavewait/main.go
 	go build -o $@ ./$(@D)
 
 $(WEAVER_EXPORT): prog/weaver/Dockerfile $(WEAVER_EXE)

--- a/prog/weavewait/main.go
+++ b/prog/weavewait/main.go
@@ -1,17 +1,23 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"syscall"
-
-	"github.com/weaveworks/weave/net"
+	"time"
 )
 
 func main() {
-	_, err := net.EnsureInterface("ethwe", 20)
-	checkErr(err)
+	usr2 := make(chan os.Signal)
+	signal.Notify(usr2, syscall.SIGUSR2)
+	select {
+	case <-usr2:
+	case <-time.After(20 * time.Second):
+		checkErr(errors.New("Container timed out waiting for signal from proxy"))
+	}
 
 	if len(os.Args) <= 1 {
 		os.Exit(0)

--- a/proxy/start_container_interceptor.go
+++ b/proxy/start_container_interceptor.go
@@ -39,5 +39,6 @@ func (i *startContainerInterceptor) InterceptResponse(r *http.Response) error {
 		Warning.Printf("Attaching container %s to weave network failed: %s", container.ID, string(output))
 		return errors.New(string(output))
 	}
-	return nil
+
+	return i.client.KillContainer(docker.KillContainerOptions{ID: container.ID, Signal: docker.SIGUSR2})
 }


### PR DESCRIPTION
There was a race condition with containers running and exiting before
`weave attach` was finished, which would cause an error.

Closes #812