### PR TITLE
[proxy] We can only rely on receiving a signal when we are a container

### DIFF
--- a/proxy/create_exec_interceptor.go
+++ b/proxy/create_exec_interceptor.go
@@ -34,7 +34,8 @@ func (i *createExecInterceptor) InterceptRequest(r *http.Request) error {
 
 	if cidrs, ok := weaveCIDRsFromConfig(container.Config); ok || i.withIPAM {
 		Info.Printf("Exec in container %s with WEAVE_CIDR \"%s\"", container.ID, strings.Join(cidrs, " "))
-		options.Cmd = append(weaveWaitEntrypoint, options.Cmd...)
+		cmd := append(weaveWaitEntrypoint, "-s")
+		options.Cmd = append(cmd, options.Cmd...)
 	}
 
 	if err := marshalRequestBody(r, options); err != nil {


### PR DESCRIPTION
Due to https://github.com/docker/docker/issues/9098, there is no way to
signal an exec. Instead we'll have to just poll the interface and hope.

Adds `weavewait -s` which is the way to tell weavewait to skip waiting for a signal, which we use on execs