### PR TITLE
kill -0 $CONTAINER_PID does not work inside weaveexec container

### DIFF
--- a/weave
+++ b/weave
@@ -335,7 +335,7 @@ with_container_netns() {
     shift 1
     if ! "$@" >$IP_TMPOUT 2>$IP_TMPERR ; then
         STATUS=1
-        if ! kill -0 "$CONTAINER_PID" 2>/dev/null ; then
+        if [ ! -d $PROCFS/$CONTAINER_PID ] ; then
             echo "Container $CONTAINER died" >&2
         else
             echo "Failure during network configuration for container $CONTAINER:" >&2


### PR DESCRIPTION
since $CONTAINER_PID is in a different process namespace.

Fixes #829.