### PR TITLE
limit acceptance rate on peer connections

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -13,10 +13,17 @@ import (
 	"code.google.com/p/gopacket/layers"
 )
 
-const macMaxAge = 10 * time.Minute // [1]
+const (
+	macMaxAge      = 10 * time.Minute     // [1]
+	tcpAcceptDelay = 1 * time.Millisecond // [2]
+)
 
 // [1] should be greater than typical ARP cache expiries, i.e. > 3/2 *
 // /proc/sys/net/ipv4_neigh/*/base_reachable_time_ms on Linux
+
+// [2] time to wait between accepting tcp connections. This guards
+// against brute-force attacks on the password when encryption is in
+// use. It is also a basic DoS defence.
 
 type LogFrameFunc func(string, []byte, *layers.Ethernet)
 
@@ -199,6 +206,7 @@ func (router *Router) listenTCP(localPort int) {
 				continue
 			}
 			router.acceptTCP(tcpConn)
+			time.Sleep(tcpAcceptDelay)
 		}
 	}()
 }

--- a/site/how-it-works.md
+++ b/site/how-it-works.md
@@ -274,15 +274,19 @@ local peer in the usual Diffie-Hellman way, resulting in both peers
 arriving at the same shared key. To this is appended the supplied
 password, and the result is hashed through SHA256, to form the final
 ephemeral session key. Thus the supplied password is never exchanged
-directly, and is thoroughly mixed into the shared secret. The shared
-key formed by Diffie-Hellman is 256 bits long, appending the password
-to this obviously makes it longer by an unknown amount, and the use of
-SHA256 reduces this back to 256 bits, to form the final ephemeral
-session key. This late combination with the password eliminates "Man
-In The Middle" attacks: sniffing the public key exchange between the
-two peers and faking their responses will not grant an attacker
-knowledge of the password, and so an attacker would not be able to
-form valid ephemeral session keys.
+directly, and is thoroughly mixed into the shared secret. Furthermore,
+the rate at which TCP connections are accepted is limited by weave to
+1kHz, which twarts online dictionary attacks on reasonably strong
+passwords.
+
+The shared key formed by Diffie-Hellman is 256 bits long, appending
+the password to this obviously makes it longer by an unknown amount,
+and the use of SHA256 reduces this back to 256 bits, to form the final
+ephemeral session key. This late combination with the password
+eliminates "Man In The Middle" attacks: sniffing the public key
+exchange between the two peers and faking their responses will not
+grant an attacker knowledge of the password, and so an attacker would
+not be able to form valid ephemeral session keys.
 
 The same ephemeral session key is used for both TCP and UDP traffic
 between two peers.


### PR DESCRIPTION
The main purpose of this is to set an upper bound on the rate at which
an attacker might execute a brute force attack on the weave password.

No need to get clever or precise here.

Closes #837.