### PR TITLE
Add support for custom proxy bind address

### DIFF
--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -29,8 +29,8 @@ func main() {
 	c.Version = version
 	getopt.BoolVarLong(&debug, "debug", 'd', "log debugging information")
 	getopt.BoolVarLong(&justVersion, "version", 0, "print version and exit")
-	getopt.StringVar(&c.ListenAddr, 'L', fmt.Sprintf("address on which to listen (default %s)", defaultListenAddr))
-	getopt.StringVar(&c.DockerAddr, 'H', fmt.Sprintf("docker daemon URL to proxy (default %s)", defaultDockerAddr))
+	getopt.StringVar(&c.ListenAddr, 'H', fmt.Sprintf("address on which to listen (default %s)", defaultListenAddr))
+	getopt.StringVar(&c.DockerAddr, 'D', fmt.Sprintf("docker daemon URL to proxy (default %s)", defaultDockerAddr))
 	getopt.StringVarLong(&c.TLSConfig.CACert, "tlscacert", 0, "Trust certs signed only by this CA")
 	getopt.StringVarLong(&c.TLSConfig.Cert, "tlscert", 0, "Path to TLS certificate file")
 	getopt.BoolVarLong(&c.TLSConfig.Enabled, "tls", 0, "Use TLS; implied by --tlsverify")

--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -13,7 +13,7 @@ import (
 var (
 	version           = "(unreleased version)"
 	defaultDockerAddr = "unix:///var/run/docker.sock"
-	defaultListenAddr = ":12375"
+	defaultListenAddr = "tcp://0.0.0.0:12375"
 )
 
 func main() {
@@ -51,6 +51,16 @@ func main() {
 
 	Info.Println("weave proxy", version)
 	Info.Println("Command line arguments:", strings.Join(os.Args[1:], " "))
+
+	protoAddrParts := strings.SplitN(c.ListenAddr, "://", 2)
+	if len(protoAddrParts) == 2 {
+		if protoAddrParts[0] != "tcp" {
+			Error.Fatalf("Invalid protocol format: %q", protoAddrParts[0])
+		}
+		c.ListenAddr = protoAddrParts[1]
+	} else {
+		c.ListenAddr = protoAddrParts[0]
+	}
 
 	p, err := proxy.NewProxy(c)
 	if err != nil {

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -35,9 +35,13 @@ argument, e.g.
 
     host1$ weave launch-proxy -H tcp://127.0.0.1:4243
 
-The proxy listens on port 12375, on all network interfaces. All docker
-commands can be run via the proxy, so it is safe to globally adjust
-your `DOCKER_HOST` to point at the proxy, e.g.
+By default, the proxy listens on port 12375, on all network
+interfaces. This can be adjusted with the `-L` argument, e.g.
+
+    host1$ weave launch-proxy -L 127.0.0.1:9999
+
+All docker commands can be run via the proxy, so it is safe to
+globally adjust your `DOCKER_HOST` to point at the proxy, e.g.
 
     host1$ export DOCKER_HOST=tcp://localhost:12375
     host1$ docker ps
@@ -46,7 +50,7 @@ your `DOCKER_HOST` to point at the proxy, e.g.
 If you are working with a remote docker daemon, then `localhost` in
 the above needs to be replaced with the docker daemon host, and any
 firewalls inbetween need to be configured to permit access to
-port 12375.
+the proxy port.
 
 ## <a name="usage"></a>Usage
 

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -30,15 +30,15 @@ To start the proxy, run
     host1$ weave launch-proxy
 
 By default, the proxy will connect to docker at
-`unix:///var/run/docker.sock`. This can be adjusted with the `-H`
+`unix:///var/run/docker.sock`. This can be adjusted with the `-D`
 argument, e.g.
 
-    host1$ weave launch-proxy -H tcp://127.0.0.1:4243
+    host1$ weave launch-proxy -D tcp://127.0.0.1:4243
 
 By default, the proxy listens on port 12375, on all network
-interfaces. This can be adjusted with the `-L` argument, e.g.
+interfaces. This can be adjusted with the `-H` argument, e.g.
 
-    host1$ weave launch-proxy -L 127.0.0.1:9999
+    host1$ weave launch-proxy -H tcp://127.0.0.1:9999
 
 All docker commands can be run via the proxy, so it is safe to
 globally adjust your `DOCKER_HOST` to point at the proxy, e.g.

--- a/weave
+++ b/weave
@@ -51,7 +51,7 @@ usage() {
     echo "where <peer>    = <ip_address_or_fqdn>[:<port>]"
     echo "      <cidr>    = <ip_address>/<routing_prefix_length>"
     echo "      <peer_id> = <nickname> or weave internal peer ID"
-    echo "      <address> = [<ip_address>]:<port>"
+    echo "      <address> = [tcp://][<ip_address>]:<port>"
     exit 1
 }
 

--- a/weave
+++ b/weave
@@ -171,7 +171,6 @@ MTU=65535
 PORT=${WEAVE_PORT:-6783}
 HTTP_PORT=6784
 DNS_HTTP_PORT=6785
-PROXY_PORT=12375
 PROXY_CONTAINER_NAME=weaveproxy
 
 
@@ -945,7 +944,6 @@ case "$COMMAND" in
         # when launching the weaveproxy container.
         proxy_args "$@"
         PROXY_CONTAINER=$(docker run --privileged -d --name=$PROXY_CONTAINER_NAME --net=host \
-            -p $PROXY_PORT:$PROXY_PORT/tcp \
             $PROXY_VOLUMES \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v /proc:/hostproc \

--- a/weave
+++ b/weave
@@ -28,7 +28,7 @@ usage() {
     echo "weave launch       [-password <password>] [-nickname <nickname>] [-nodiscovery]"
     echo "                       [-iprange <cidr>] <peer> ..."
     echo "weave launch-dns   <cidr>"
-    echo "weave launch-proxy [-H <docker_endpoint>] [--with-dns] [--with-ipam]"
+    echo "weave launch-proxy [-H <docker_endpoint>] [-L <address>] [--with-dns] [--with-ipam]"
     echo "weave connect      [--replace] [<peer> ...]"
     echo "weave forget       <peer> ..."
     echo "weave run          [--with-dns] [<cidr> ...] <docker run args> ..."
@@ -51,6 +51,7 @@ usage() {
     echo "where <peer>    = <ip_address_or_fqdn>[:<port>]"
     echo "      <cidr>    = <ip_address>/<routing_prefix_length>"
     echo "      <peer_id> = <nickname> or weave internal peer ID"
+    echo "      <address> = [<ip_address>]:<port>"
     exit 1
 }
 

--- a/weave
+++ b/weave
@@ -28,7 +28,7 @@ usage() {
     echo "weave launch       [-password <password>] [-nickname <nickname>] [-nodiscovery]"
     echo "                       [-iprange <cidr>] <peer> ..."
     echo "weave launch-dns   <cidr>"
-    echo "weave launch-proxy [-H <docker_endpoint>] [-L <address>] [--with-dns] [--with-ipam]"
+    echo "weave launch-proxy [-D <docker_endpoint>] [-H <address>] [--with-dns] [--with-ipam]"
     echo "weave connect      [--replace] [<peer> ...]"
     echo "weave forget       <peer> ..."
     echo "weave run          [--with-dns] [<cidr> ...] <docker run args> ..."


### PR DESCRIPTION
Closes #805 and #810

`weave status` will pick a random port to connect on (due to map ordering of `docker inspect`).
Renames `-L` flag to `-H` to match docker daemon, which means renaming the existing `-H` flag to `-D`. The `-H` flag doesn't *completely* match the docker daemon's, which takes a `tcp://` prefix, but is at least closer.

Debating adding a smoke test for this. Would be nice to have, but adds to the test run speed.