### PR TITLE
feed full container id on `weave start` to DNS/IPAM

### DIFF
--- a/weave
+++ b/weave
@@ -1023,12 +1023,13 @@ case "$COMMAND" in
         collect_cidr_args "$@"
         shift $CIDR_COUNT
         [ $# -eq 1 ] || usage
-        CONTAINER=$(docker start $1)
+        RES=$(docker start $1)
+        CONTAINER=$(container_id $1)
         create_bridge
         get_ipam_cidr $CONTAINER
         with_container_netns_or_die $CONTAINER attach $CIDR_ARGS
         when_dns_running with_container_fqdn $CONTAINER put_dns_fqdn $CIDR_ARGS
-        echo $CONTAINER
+        echo $RES
         ;;
     attach)
         collect_cidr_args "$@"


### PR DESCRIPTION
We erroneously assumed that `docker start` returned the full container id. It doesn't and as a result we populated DNS with records with ids other than full container ids. And that's also what we told IPAM. As a result, DNS and IPAM didn't clean up after the container's death, resulting in stale DNS entries and leaked IPs.

Fixes #881.