### PR TITLE
Avoid gossip test race conditions

### DIFF
--- a/router/gossip.go
+++ b/router/gossip.go
@@ -332,15 +332,17 @@ func (router *Router) sendPendingGossip() {
 	for _, channel := range router.GossipChannels {
 		channel.Lock()
 		for _, sender := range channel.senders {
-			ch := make(chan struct{})
-			sender.flushch <- ch
-			<-ch
+			sender.flush()
 		}
 		for _, sender := range channel.broadcasters {
-			ch := make(chan struct{})
-			sender.flushch <- ch
-			<-ch
+			sender.flush()
 		}
 		channel.Unlock()
 	}
+}
+
+func (sender *GossipSender) flush() {
+	ch := make(chan struct{})
+	sender.flushch <- ch
+	<-ch
 }

--- a/router/gossip.go
+++ b/router/gossip.go
@@ -60,9 +60,8 @@ func (sender *GossipSender) run() {
 		case pending := <-sender.cell:
 			if pending == nil { // receive zero value when chan is closed
 				return
-			} else {
-				sender.send(pending)
 			}
+			sender.send(pending)
 		case ch := <-sender.flushch:
 			sender.flush()
 			close(ch)
@@ -324,7 +323,7 @@ func (c *GossipChannel) log(args ...interface{}) {
 
 func (router *Router) sendPendingGossip() {
 	// copy the senders so we don't hold the lock for long
-	allSenders := make([]*GossipSender, 0)
+	var allSenders []*GossipSender
 	for _, channel := range router.GossipChannels {
 		channel.Lock()
 		for _, sender := range channel.senders {

--- a/router/gossip_test.go
+++ b/router/gossip_test.go
@@ -30,7 +30,6 @@ func (conn *mockChannelConnection) SendProtocolMsg(protocolMsg ProtocolMsg) {
 	if err := conn.dest.handleGossip(protocolMsg.tag, protocolMsg.msg); err != nil {
 		panic(err)
 	}
-	conn.dest.sendPendingGossip()
 }
 
 func (router *Router) AddTestChannelConnection(r *Router) {
@@ -87,7 +86,9 @@ func (router *Router) tp(routers ...*Router) *Peer {
 
 // Check that the topology of router matches the peers and all of their connections
 func checkTopology(t *testing.T, router *Router, wantedPeers ...*Peer) {
+	router.Peers.RLock()
 	checkTopologyPeers(t, true, router.Peers.allPeers(), wantedPeers...)
+	router.Peers.RUnlock()
 }
 
 func implTestGossipTopology(t *testing.T) {


### PR DESCRIPTION
Make flushing of GossipSender wait till done, and take extra locks to avoid race conditions.

Fixes #885.