### PR TITLE
In test/setup.sh, remove existing containers

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -16,5 +16,7 @@ for HOST in $HOSTS; do
     cat ../weave | run_on $HOST sh -c "cat > ./weave"
     run_on $HOST chmod a+x $DOCKER_NS ./weave
     rsync -az -e "$SSH" ./tls/ $HOST:~/tls
+    containers=$(docker_on $host ps -aq 2>/dev/null)
+    [ -n "$containers" ] && docker_on $host rm -f $containers >/dev/null 2>&1
     run_on $HOST sudo service docker restart
 done


### PR DESCRIPTION
Leaving containers lying around when doing a `service docker restart` seems to contribute to the symptom that docker takes ages to do the next removal. The old containers are in state "dead" if you do `docker ps -a`.

This pr simply repeats the code from `config.sh` to remove any containers known to docker before doing the restart.