### PR TITLE
Use /10 instead of /9 for default iprange

### DIFF
--- a/site/ipam.md
+++ b/site/ipam.md
@@ -27,7 +27,7 @@ You can see which address was allocated with
 [`weave ps`](troubleshooting.html#list-attached-containers):
 
     host1# weave ps $C
-    a7aff7249393 7a:51:d1:09:21:78 10.128.0.1/9
+    a7aff7249393 7a:51:d1:09:21:78 10.128.0.1/10
 
 Weave detects when a container has exited and releases its
 automatically allocated addresses so they can be re-used.
@@ -68,7 +68,7 @@ time, you can give the number of peers like this:
 
 ## <a name="range"></a>Choosing an allocation range
 
-By default, weave will allocate IP addresses in the 10.128.0.0/9
+By default, weave will allocate IP addresses in the 10.128.0.0/10
 range. This can be overridden with the `-iprange` option, e.g.
 
     host1# weave launch -iprange 10.2.0.0/16

--- a/weave
+++ b/weave
@@ -985,7 +985,7 @@ case "$COMMAND" in
         done
         eval "set -- $ARGS"
         if [ -z "$IPRANGE" ] ; then
-            IPRANGE="-iprange 10.128.0.0/9"
+            IPRANGE="-iprange 10.128.0.0/10"
             if command_exists netcheck && ! netcheck ${IPRANGE#* } ; then
                 echo "Default" $IPRANGE "overlaps with existing route." >&2
                 echo "Please pick another range and set it on all hosts." >&2


### PR DESCRIPTION
... so it doesn't clash with CircleCI address

We were getting a lot of failures like this:

````
---= Running 150_connect_forget_test.sh =---
Connecting and forgetting routers after launch
network 10.128.0.0/9 would overlap with route 10.240.0.1/32
Default -iprange 10.128.0.0/9 overlaps with existing route.
Please pick another range and set it on all hosts.
````