### PR TITLE
Return of the Fix for the zone refresh unit test

### DIFF
--- a/common/sched_queue.go
+++ b/common/sched_queue.go
@@ -1,0 +1,145 @@
+package common
+
+import (
+	"container/heap"
+	"math"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"runtime"
+	"sync/atomic"
+)
+
+// A callable is a function that is called and return an (optional) next scheduled time
+type callable func() time.Time
+
+type schedCall struct {
+	t time.Time
+	c callable
+}
+
+func (sc *schedCall) FromNow(now time.Time) time.Duration {
+	if sc.t.After(now) {
+		return time.Duration(sc.t.Sub(now).Nanoseconds())
+	}
+	return time.Duration(0)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// A min-heap of scheduled callables
+type schedCallsHeap []*schedCall
+
+func (ch *schedCallsHeap) Len() int           { return len(*ch) }
+func (ch *schedCallsHeap) Less(i, j int) bool { return (*ch)[i].t.Before((*ch)[j].t) }
+func (ch *schedCallsHeap) Swap(i, j int) {
+	(*ch)[i], (*ch)[j] = (*ch)[j], (*ch)[i]
+}
+
+func (ch *schedCallsHeap) Push(x interface{}) {
+	// Push and Pop use pointer receivers because they modify the slice's length,
+	// not just its contents.
+	entry := x.(*schedCall)
+	*ch = append(*ch, entry)
+}
+
+func (ch *schedCallsHeap) Pop() interface{} {
+	old := *ch
+	n := len(old)
+	item := old[n-1]
+	*ch = old[0 : n-1]
+	return item
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// SchedQueue is queue of scheduled callables
+type SchedQueue struct {
+	clock      clock.Clock
+	callablesH schedCallsHeap
+	schedChan  chan *schedCall
+	closeChan  chan bool
+	counter    uint64 // number of calls invoked so far (used for stats). Note: it will wrap.
+}
+
+// NewSchedQueue creates a new scheduled queue
+func NewSchedQueue(clock clock.Clock) *SchedQueue {
+	cq := SchedQueue{
+		clock:     clock,
+		schedChan: make(chan *schedCall),
+		closeChan: make(chan bool),
+	}
+	heap.Init(&cq.callablesH)
+	return &cq
+}
+
+// Start starts the scheduled queue
+func (cq *SchedQueue) Start() {
+	go func() {
+		defer func() { Debug.Printf("[sched-q] Quitting (%d calls pending)", len(cq.callablesH)) }()
+
+		var now time.Time
+		timer := cq.clock.Timer(time.Duration(math.MaxInt64))
+
+		for {
+			// Wait until an insertion, until the next callable or until we are Stop()ed
+			select {
+			case ce := <-cq.schedChan:
+				heap.Push(&cq.callablesH, ce)
+				now = cq.clock.Now()
+				Debug.Printf("[sched-q] Call scheduled [len:%d]", len(cq.callablesH))
+			case <-cq.closeChan:
+				return
+			case now = <-timer.C:
+			}
+
+			timer.Stop()
+			durationUntilNext := cq.durationUntilNext(now)
+			for durationUntilNext == 0 {
+				sched := heap.Pop(&cq.callablesH).(*schedCall)
+
+				atomic.AddUint64(&cq.counter, 1)
+				schedNextTime := sched.c()
+
+				if !schedNextTime.IsZero() {
+					Debug.Printf("[sched-q] Re-scheduled at %s", schedNextTime)
+					sched.t = schedNextTime
+					heap.Push(&cq.callablesH, sched) // TODO: use a Fix() instead of Pop()&Push()
+				}
+
+				now = cq.clock.Now()
+				durationUntilNext = cq.durationUntilNext(now)
+			}
+
+			timer = cq.clock.Timer(durationUntilNext)
+		}
+	}()
+}
+
+// Stop stops the scheduled queue
+func (cq *SchedQueue) Stop() {
+	Debug.Printf("[sched-q] Stopping...")
+	cq.closeChan <- true
+}
+
+// Add schedules a call.
+// The callable should not modify the scheduled queue in any way.
+func (cq *SchedQueue) Add(c callable, t time.Time) {
+	Debug.Printf("[sched-q] Adding call at %s", t)
+	ce := schedCall{c: c, t: t}
+	cq.schedChan <- &ce
+}
+
+// Counter returns the number of calls invoked in the queued
+// Note: the result will wrap over time.
+func (cq *SchedQueue) Count() uint64 {
+	return atomic.LoadUint64(&cq.counter)
+}
+
+func (cq *SchedQueue) durationUntilNext(now time.Time) time.Duration {
+	if len(cq.callablesH) > 0 {
+		firstSched := cq.callablesH[0]
+		return firstSched.FromNow(now)
+	}
+	return time.Duration(math.MaxInt64)
+}

--- a/common/sched_queue.go
+++ b/common/sched_queue.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"runtime"
 	"sync/atomic"
 )
 

--- a/common/sched_queue_test.go
+++ b/common/sched_queue_test.go
@@ -24,8 +24,10 @@ func TestSchedCallsBasic(t *testing.T) {
 	}
 
 	schedQueue.Add(c, clk.Now().Add(time.Second))
+	schedQueue.Flush()
 	for i := 0; i < testSecs; i++ {
 		clk.Add(time.Second)
+		schedQueue.Flush()
 	}
 
 	t.Logf("Now: %s - calls: %d", clk.Now(), schedQueue.Count())
@@ -51,8 +53,10 @@ func TestSchedCallsGap(t *testing.T) {
 	}
 
 	schedQueue.Add(c2, clk.Now().Add(time.Second))
+	schedQueue.Flush()
 	for i := 0; i < testSecs; i++ {
 		clk.Add(time.Second)
+		schedQueue.Flush()
 	}
 
 	t.Logf("Now: %s - calls: %d", clk.Now(), schedQueue.Count())
@@ -77,8 +81,10 @@ func TestSchedCallsStop(t *testing.T) {
 	}
 
 	schedQueue.Add(c2, clk.Now().Add(time.Second))
+	schedQueue.Flush()
 	for i := 0; i < testSecs; i++ {
 		clk.Add(time.Second)
+		schedQueue.Flush()
 	}
 
 	t.Logf("Now: %s - calls: %d", clk.Now(), schedQueue.Count())

--- a/common/sched_queue_test.go
+++ b/common/sched_queue_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/benbjohnson/clock"
 	wt "github.com/weaveworks/weave/testing"
-	"log"
 )
 
 // Ensure we can add new calls while forwarding the clock

--- a/common/sched_queue_test.go
+++ b/common/sched_queue_test.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	wt "github.com/weaveworks/weave/testing"
+	"log"
+)
+
+// Ensure we can add new calls while forwarding the clock
+func TestSchedCallsBasic(t *testing.T) {
+	InitDefaultLogging(testing.Verbose())
+	Info.Println("TestSchedCallsBasic starting")
+
+	const testSecs = 1000
+	clk := clock.NewMock()
+	schedQueue := NewSchedQueue(clk)
+	schedQueue.Start()
+	defer schedQueue.Stop()
+
+	c := func() time.Time {
+		return clk.Now().Add(time.Second)
+	}
+
+	schedQueue.Add(c, clk.Now().Add(time.Second))
+	for i := 0; i < testSecs; i++ {
+		clk.Add(time.Second)
+	}
+
+	t.Logf("Now: %s - calls: %d", clk.Now(), schedQueue.Count())
+	wt.AssertEqualInt(t, (int)(schedQueue.Count()), testSecs, "Number of calls")
+}
+
+// Ensure we can create a 100 seconds gap in the middle of the time travel
+func TestSchedCallsGap(t *testing.T) {
+	InitDefaultLogging(testing.Verbose())
+	Info.Println("TestSchedCallsGap starting")
+
+	const testSecs = 1000
+	clk := clock.NewMock()
+	schedQueue := NewSchedQueue(clk)
+	schedQueue.Start()
+	defer schedQueue.Stop()
+
+	c2 := func() time.Time {
+		if schedQueue.Count() == testSecs/2 {
+			return clk.Now().Add(time.Duration(100) * time.Second)
+		}
+		return clk.Now().Add(time.Second)
+	}
+
+	schedQueue.Add(c2, clk.Now().Add(time.Second))
+	for i := 0; i < testSecs; i++ {
+		clk.Add(time.Second)
+	}
+
+	t.Logf("Now: %s - calls: %d", clk.Now(), schedQueue.Count())
+	wt.AssertEqualInt(t, (int)(schedQueue.Count()), testSecs-100+1, "Number of calls")
+}
+
+func TestSchedCallsStop(t *testing.T) {
+	InitDefaultLogging(testing.Verbose())
+	Info.Println("TestSchedCallsStop starting")
+
+	const testSecs = 1000
+	clk := clock.NewMock()
+	schedQueue := NewSchedQueue(clk)
+	schedQueue.Start()
+	defer schedQueue.Stop()
+
+	c2 := func() time.Time {
+		if schedQueue.Count() == testSecs/2 {
+			return time.Time{}
+		}
+		return clk.Now().Add(time.Second)
+	}
+
+	schedQueue.Add(c2, clk.Now().Add(time.Second))
+	for i := 0; i < testSecs; i++ {
+		clk.Add(time.Second)
+	}
+
+	t.Logf("Now: %s - calls: %d", clk.Now(), schedQueue.Count())
+	wt.AssertEqualInt(t, (int)(schedQueue.Count()), testSecs/2, "Number of calls")
+}

--- a/nameserver/mocks_test.go
+++ b/nameserver/mocks_test.go
@@ -432,6 +432,9 @@ func newMockedClock() *mockedClock {
 	return &mockedClock{clock.NewMock()}
 }
 
+// Note: moving the clock forward does not take into account the data that could
+//       be waiting in channels. So your code should not depend on the channels
+//       for creating new timers. Otherwise, time travelling will not be reliable...
 func (clk *mockedClock) Forward(secs int) {
 	Debug.Printf(">>>>>>> Moving clock forward %d seconds - Time traveling >>>>>>>", secs)
 	clk.Add(time.Duration(secs) * time.Second)

--- a/nameserver/mocks_test.go
+++ b/nameserver/mocks_test.go
@@ -291,6 +291,12 @@ func (zbs zoneDbsWithMockedMDns) Stop() {
 	}
 }
 
+func (zbs zoneDbsWithMockedMDns) Flush() {
+	for _, entry := range zbs {
+		entry.Zone.refreshScheds.Flush()
+	}
+}
+
 //////////////////////////////////////////////////////////////////
 
 // A mocked cache where we never find a single thing... ;)

--- a/nameserver/server_cache_test.go
+++ b/nameserver/server_cache_test.go
@@ -297,6 +297,7 @@ func TestServerCacheRefresh(t *testing.T) {
 
 	Debug.Printf("Adding an IPs to %s", testName1)
 	dbs[1].Zone.AddRecord(containerID, testName1, net.ParseIP("10.2.2.1"))
+	dbs.Flush() // ensure the immediate refresh is done
 
 	// Zone database #2 at this point:
 	//   first.weave.local  = 10.2.2.1
@@ -308,6 +309,7 @@ func TestServerCacheRefresh(t *testing.T) {
 	assertNotLocalInCache(t, cache, qName2, "after asking for second name")
 
 	clk.Forward(refreshInterval / 2)
+	dbs.Flush()
 
 	Debug.Printf("Adding an IP to %s and to %s", testName1, testName2)
 	dbs[1].Zone.AddRecord(containerID, testName1, net.ParseIP("10.2.2.2"))
@@ -317,6 +319,7 @@ func TestServerCacheRefresh(t *testing.T) {
 	//   first.weave.local    = 10.2.2.1 10.2.2.2
 	//   second.weave.local   = 10.9.9.2
 	clk.Forward(refreshInterval/2 + 2)
+	dbs.Flush()
 
 	// at this point, the testName1 should have been refreshed
 	// so it should have two IPs, and the cache entry should have been invalidated
@@ -332,6 +335,7 @@ func TestServerCacheRefresh(t *testing.T) {
 	dbs[1].Zone.DeleteRecords(containerID, "", net.ParseIP("10.2.2.1"))
 	dbs[1].Zone.DeleteRecords(containerID, "", net.ParseIP("10.2.2.2"))
 	clk.Forward(refreshInterval + 1)
+	dbs.Flush()
 
 	qName1, _ = assertExchange(t, testName1, dns.TypeA, testPort, 0, 0, dns.RcodeNameError)
 	qName2, _ = assertExchange(t, testName2, dns.TypeA, testPort, 0, 0, dns.RcodeNameError)

--- a/nameserver/zone_lookup_test.go
+++ b/nameserver/zone_lookup_test.go
@@ -56,6 +56,7 @@ func TestZoneRefresh(t *testing.T) {
 	wt.AssertEqualInt(t, len(res), 1, "lookup result")
 
 	clk.Forward(refreshInterval / 2)
+	dbs.Flush()
 	Debug.Printf("A couple of seconds later, we should still have one IP for that name")
 	res, err = dbs[0].Zone.DomainLookupName(name)
 	wt.AssertNoErr(t, err)
@@ -63,6 +64,7 @@ func TestZoneRefresh(t *testing.T) {
 
 	Debug.Printf("And then we add 2 IPs for that name at ZoneDb 2")
 	clk.Forward(1)
+	dbs.Flush()
 	Debug.Printf("Adding 2 IPs to '%s' in Db #2", name)
 	dbs[1].Zone.AddRecord("someident", name, net.ParseIP(addr2))
 	dbs[1].Zone.AddRecord("someident", name, net.ParseIP(addr3))
@@ -72,6 +74,7 @@ func TestZoneRefresh(t *testing.T) {
 
 	Debug.Printf("Wait for a while, until a refresh is performed...")
 	clk.Forward(refreshInterval + 1)
+	dbs.Flush()
 	Debug.Printf("A refresh should have been scheduled now: we should have 3 IPs:")
 	Debug.Printf("the first (local) IP and the others obtained from zone2 with a mDNS query")
 	Debug.Printf("Asking for '%s' again... we should have 3 IPs now", name)
@@ -82,6 +85,7 @@ func TestZoneRefresh(t *testing.T) {
 
 	Debug.Printf("We will not ask for `name` for a while, so it will become irrelevant and will be removed...")
 	clk.Forward(refreshInterval + relevantTime + 1)
+	dbs.Flush()
 
 	// the name should be irrelevant now, and all remote info should have been
 	// removed from the zone database
@@ -92,6 +96,7 @@ func TestZoneRefresh(t *testing.T) {
 
 	Debug.Printf("There is no remote info about this name at zone 1: a new IP appears remotely meanwhile...")
 	clk.Forward(1)
+	dbs.Flush()
 
 	Debug.Printf("Adding '%s' to Db #2", name)
 	dbs[1].Zone.AddRecord("someident", name, net.ParseIP(addr4))
@@ -103,6 +108,7 @@ func TestZoneRefresh(t *testing.T) {
 	Debug.Printf("... but a second lookup should return all the results in the network")
 
 	clk.Forward(refreshInterval + 1)
+	dbs.Flush()
 
 	res, err = dbs[0].Zone.DomainLookupName(name)
 	Debug.Printf("Got: %s", res)

--- a/nameserver/zone_lookup_test.go
+++ b/nameserver/zone_lookup_test.go
@@ -72,7 +72,6 @@ func TestZoneRefresh(t *testing.T) {
 
 	Debug.Printf("Wait for a while, until a refresh is performed...")
 	clk.Forward(refreshInterval + 1)
-
 	Debug.Printf("A refresh should have been scheduled now: we should have 3 IPs:")
 	Debug.Printf("the first (local) IP and the others obtained from zone2 with a mDNS query")
 	Debug.Printf("Asking for '%s' again... we should have 3 IPs now", name)
@@ -82,7 +81,7 @@ func TestZoneRefresh(t *testing.T) {
 	wt.AssertEqualInt(t, len(res), 3, "lookup result length")
 
 	Debug.Printf("We will not ask for `name` for a while, so it will become irrelevant and will be removed...")
-	clk.Forward(relevantTime + refreshInterval + 1)
+	clk.Forward(refreshInterval + relevantTime + 1)
 
 	// the name should be irrelevant now, and all remote info should have been
 	// removed from the zone database
@@ -93,17 +92,19 @@ func TestZoneRefresh(t *testing.T) {
 
 	Debug.Printf("There is no remote info about this name at zone 1: a new IP appears remotely meanwhile...")
 	clk.Forward(1)
+
 	Debug.Printf("Adding '%s' to Db #2", name)
 	dbs[1].Zone.AddRecord("someident", name, net.ParseIP(addr4))
 
 	Debug.Printf("When we ask about this name again, we get 4 IPs (1 local, 3 remote)")
-	clk.Forward(1)
 	Debug.Printf("Asking for '%s' again... the first lookup will return only the local results", name)
 	res, err = dbs[0].Zone.DomainLookupName(name)
 	wt.AssertEqualInt(t, len(res), 1, "lookup result length")
 	Debug.Printf("... but a second lookup should return all the results in the network")
-	clk.Forward(1)
+
+	clk.Forward(refreshInterval + 1)
+
 	res, err = dbs[0].Zone.DomainLookupName(name)
 	Debug.Printf("Got: %s", res)
-	wt.AssertEqualInt(t, len(res), 4, "lookup result length") // TODO: this fails 1% of the runs... !!??
+	wt.AssertEqualInt(t, len(res), 4, "lookup result length")
 }

--- a/prog/weavedns/main.go
+++ b/prog/weavedns/main.go
@@ -33,7 +33,6 @@ func main() {
 		udpbuf          int
 		fallback        string
 		refreshInterval int
-		refreshWorkers  int
 		relevantTime    int
 		maxAnswers      int
 		cacheLen        int
@@ -58,7 +57,6 @@ func main() {
 	// advanced options
 	flag.IntVar(&negTTL, "neg-ttl", weavedns.DefaultCacheNegLocalTTL, "negative TTL (in secs) for unanswered queries for local names")
 	flag.IntVar(&refreshInterval, "refresh", weavedns.DefaultRefreshInterval, "refresh interval (in secs) for local names (0=disable)")
-	flag.IntVar(&refreshWorkers, "refresh-workers", weavedns.DefaultNumUpdaters, "default number of background updaters")
 	flag.IntVar(&maxAnswers, "max-answers", weavedns.DefaultMaxAnswers, "maximum number of answers returned to clients (0=unlimited)")
 	flag.IntVar(&relevantTime, "relevant", weavedns.DefaultRelevantTime, "life time for info in the absence of queries (in secs)")
 	flag.IntVar(&udpbuf, "udpbuf", weavedns.DefaultUDPBuflen, "UDP buffer length")
@@ -122,7 +120,6 @@ func main() {
 		Iface:           iface,
 		LocalTTL:        ttl,
 		RefreshInterval: refreshInterval,
-		RefreshWorkers:  refreshWorkers,
 		RelevantTime:    relevantTime,
 	}
 	zone, err := weavedns.NewZoneDb(zoneConfig)


### PR DESCRIPTION
This is an extension of #836. Original comment:

Fix the zone refresh unit test by using a scheduled queue where callables are invoked at specific times. This also simplifies the refreshing mechanism in the Zone database. And there are some minor tweaks in the unit test as well...

Fixes #798

Further fixed by ensuring all background calls are flushed ever time we move the mock clock.