### PR TITLE
Fix spurious unit test failure in TestAllocatorFuzz()

### DIFF
--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -289,10 +289,10 @@ func TestAllocatorFuzz(t *testing.T) {
 	common.InitDefaultLogging(false)
 	const (
 		firstpass    = 1000
-		secondpass   = 5000
+		secondpass   = 20000
 		nodes        = 10
 		maxAddresses = 1000
-		concurrency  = 10
+		concurrency  = 30
 		cidr         = "10.0.1.7/22"
 	)
 	allocs, _, subnet := makeNetworkOfAllocators(nodes, cidr)
@@ -398,12 +398,16 @@ func TestAllocatorFuzz(t *testing.T) {
 		addrIndex := rand.Int31n(int32(len(addrs)))
 		addr := addrs[addrIndex]
 		res := state[addr]
+		if res.block {
+			stateLock.Unlock()
+			return
+		}
 		res.block = true
 		state[addr] = res
 		stateLock.Unlock()
 		alloc := allocs[res.alloc]
 
-		//common.Info.Printf("Asking for %s on allocator %d again", addr, res.alloc)
+		//common.Info.Printf("Asking for %s (%s) on allocator %d again", res.name, addr, res.alloc)
 
 		newAddr, _ := alloc.Allocate(res.name, subnet, nil)
 		oldAddr, _ := address.ParseIP(addr)


### PR DESCRIPTION
otherwise we can re-insert the entry into the map after a parallel
`allocateAgain()` has cleared the flag. And if *that* happens in
parallel with a `free()` then the data-structure can get out of sync.

Fixes #915

Also bumped the test parameters up a bit to give more chance of spotting race conditions.