### PR TITLE
Fix deadlock in weavedns

### DIFF
--- a/nameserver/zone_lookup.go
+++ b/nameserver/zone_lookup.go
@@ -235,12 +235,11 @@ func (zone *ZoneDb) DomainLookupInaddr(inaddr string) (res []ZoneRecord, err err
 func (zone *ZoneDb) startUpdatingName(name string) {
 	if zone.refreshInterval > 0 {
 		zone.mx.Lock()
-		defer zone.mx.Unlock()
-
 		// check if we should enqueue a refresh request for this name
 		n := zone.getNameSet(defaultRemoteIdent).getName(name, true)
+		now := zone.clock.Now()
+		zone.mx.Unlock() // Don't hold the lock while talking to the SchedQueue
 		if n.lastRefreshTime.IsZero() {
-			now := zone.clock.Now()
 			n.lastRefreshTime = now
 
 			Debug.Printf("[zonedb] Creating new immediate refresh request for '%s'", name)

--- a/nameserver/zone_lookup.go
+++ b/nameserver/zone_lookup.go
@@ -235,15 +235,18 @@ func (zone *ZoneDb) DomainLookupInaddr(inaddr string) (res []ZoneRecord, err err
 func (zone *ZoneDb) startUpdatingName(name string) {
 	if zone.refreshInterval > 0 {
 		zone.mx.Lock()
+
 		// check if we should enqueue a refresh request for this name
 		n := zone.getNameSet(defaultRemoteIdent).getName(name, true)
-		now := zone.clock.Now()
-		zone.mx.Unlock() // Don't hold the lock while talking to the SchedQueue
 		if n.lastRefreshTime.IsZero() {
+			now := zone.clock.Now()
 			n.lastRefreshTime = now
+			zone.mx.Unlock()
 
 			Debug.Printf("[zonedb] Creating new immediate refresh request for '%s'", name)
 			zone.refreshScheds.Add(func() time.Time { return zone.updater(name) }, now)
+		} else {
+			zone.mx.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
Release lock before sending on a channel, but *after* modifying mutable variables.
Fixes #923, #924, and #926.

Didn't have write-permissions to @bboreham's fork, so opened new PR on main repo.