### PR TITLE
[dns] resolve names in `weave.local` by default unless hostname or search path is specified

### DIFF
--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -92,15 +92,19 @@ func (i *createContainerInterceptor) setWeaveDNS(container *createContainerReque
 
 	container.HostConfig.DNS = append(container.HostConfig.DNS, i.proxy.dockerBridgeIP)
 
-	if len(container.HostConfig.DNSSearch) == 0 {
-		container.HostConfig.DNSSearch = []string{"."}
-	}
-
 	name := r.URL.Query().Get("name")
 	if container.Hostname == "" && name != "" {
 		container.Hostname = name
 		// Strip trailing period because it's unusual to see it used on the end of a host name
 		container.Domainname = strings.TrimSuffix(dnsDomain, ".")
+	}
+
+	if len(container.HostConfig.DNSSearch) == 0 {
+		if container.Hostname == "" {
+			container.HostConfig.DNSSearch = []string{dnsDomain}
+		} else {
+			container.HostConfig.DNSSearch = []string{"."}
+		}
 	}
 
 	return nil

--- a/site/weavedns.md
+++ b/site/weavedns.md
@@ -225,9 +225,10 @@ weaveDNS instance will receive.
 
 If you don't supply a domain search path (with `--dns-search=`),
 `weave run ...` tells a container to look for "bare" hostnames, like
-`pingme`, in its own domain. That's why you can just invoke `ping
-pingme` above -- since the hostname is `ubuntu.weave.local`, it will
-look for `pingme.weave.local`.
+`pingme`, in its own domain (or in `weave.local` if it has no domain).
+That's why you can just invoke `ping pingme` above -- since the
+hostname is `ubuntu.weave.local`, it will look for
+`pingme.weave.local`.
 
 If you want to supply other entries for the domain search path,
 e.g. if you want containers in different sub-domains to resolve

--- a/test/230_dns_unqualified_test.sh
+++ b/test/230_dns_unqualified_test.sh
@@ -5,6 +5,7 @@
 C1=10.2.0.78
 C2=10.2.0.34
 C3=10.2.0.57
+C4=10.2.0.99
 DOMAIN=weave.local
 NAME=seeone.$DOMAIN
 
@@ -15,8 +16,14 @@ weave_on $HOST1 launch-dns 10.2.254.1/24 $WEAVEDNS_ARGS
 start_container          $HOST1 $C1/24 --name=c1 -h $NAME
 start_container_with_dns $HOST1 $C2/24 --name=c2 -h seetwo.$DOMAIN
 start_container_with_dns $HOST1 $C3/24 --name=c3 --dns-search=$DOMAIN
+container=$(start_container_with_dns $HOST1 $C4/24)
 
-assert "exec_on $HOST1 c2 getent hosts seeone | tr -s ' '" "$C1 $NAME"
-assert "exec_on $HOST1 c3 getent hosts seeone | tr -s ' '" "$C1 $NAME"
+check() {
+  assert "exec_on $HOST1 $1 getent hosts seeone | tr -s ' '" "$C1 $NAME"
+}
+
+check c2
+check c3
+check "$container"
 
 end_suite

--- a/test/635_proxy_dns_unqualified_test.sh
+++ b/test/635_proxy_dns_unqualified_test.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+. ./config.sh
+
+C1=10.2.0.78
+C2=10.2.0.34
+C3=10.2.0.57
+C4=10.2.0.99
+DOMAIN=weave.local
+NAME=seeone.$DOMAIN
+
+start_container() {
+  proxy docker_on $HOST1 run "$@" -dt $DNS_IMAGE /bin/sh
+}
+
+start_suite "Resolve unqualified names"
+
+weave_on $HOST1 launch-dns 10.2.254.1/24
+weave_on $HOST1 launch-proxy
+
+start_container -e WEAVE_CIDR=$C1/24 --name=c1 -h $NAME
+start_container -e WEAVE_CIDR=$C2/24 --name=c2 -h seetwo.$DOMAIN
+start_container -e WEAVE_CIDR=$C3/24 --name=c3 --dns-search=$DOMAIN
+container=$(start_container -e WEAVE_CIDR=$C4/24)
+
+check() {
+  assert "proxy exec_on $HOST1 $1 getent hosts seeone | tr -s ' '" "$C1 $NAME"
+}
+
+check c2
+check c3
+check "$container"
+
+end_suite

--- a/weave
+++ b/weave
@@ -632,6 +632,13 @@ peer_args() {
 # weaveDNS helpers
 ######################################################################
 
+# Memoized function to query the weaveDNS server for our dns domain.
+dns_domain() {
+  DNS_DOMAIN=${DNS_DOMAIN:-$(call_dns GET /domain 2>/dev/null || true)}
+  DNS_DOMAIN=${DNS_DOMAIN:-weave.local.}
+  echo $DNS_DOMAIN
+}
+
 dns_args() {
     if [ \( "$DOCKER_VERSION_MAJOR" -lt 1 \) -o \
         \( "$DOCKER_VERSION_MAJOR" -eq 1 -a \
@@ -644,16 +651,15 @@ dns_args() {
         exit 1
     fi
     docker_bridge_ip
-    DNS_ARG="--dns $DOCKER_BRIDGE_IP"
-    DNS_SEARCH_ARG="--dns-search=."
     NAME_ARG=""
     HOSTNAME_SPECIFIED=
+    DNS_SEARCH_SPECIFIED=
     WITH_DNS=
     WITHOUT_DNS=
     while [ $# -gt 0 ] ; do
         case "$1" in
             --dns-search=*)
-                DNS_SEARCH_ARG=""
+                DNS_SEARCH_SPECIFIED=1
                 ;;
             --name)
                 NAME_ARG="$2"
@@ -678,11 +684,18 @@ dns_args() {
     if [ -z "$WITH_DNS" ] ; then
         check_running $DNS_CONTAINER_NAME 2>/dev/null || return 0
     fi
-    DNS_ARGS="$DNS_ARG $DNS_SEARCH_ARG"
+    DNS_ARGS="--dns $DOCKER_BRIDGE_IP"
     if [ -n "$NAME_ARG" -a -z "$HOSTNAME_SPECIFIED" ] ; then
-        DOMAIN=$(call_dns GET /domain 2>/dev/null) || DOMAIN=weave.local.
-        # Strip trailing period off DNS domain to reduce surprise
+        DOMAIN=$(dns_domain)
         DNS_ARGS="$DNS_ARGS --hostname=$NAME_ARG.${DOMAIN%.}"
+        HOSTNAME_SPECIFIED=1
+    fi
+    if [ -z "$DNS_SEARCH_SPECIFIED" ] ; then
+      if [ -z "$HOSTNAME_SPECIFIED" ] ; then
+        DNS_ARGS="$DNS_ARGS --dns-search=$(dns_domain)"
+      else
+        DNS_ARGS="$DNS_ARGS --dns-search=."
+      fi
     fi
 }
 


### PR DESCRIPTION
Behaviour is:
* If search-domain specified by user, do nothing
* If hostname specified by user, search domain is .
* If weaveDNS is available, set search domain to the weaveDNS domain
* Otherwise, set to `.weave.local.`

Fixes #749

@awh, please review.