### PR TITLE
[proxy] Remove spurious output from proxy-(env|config)

### DIFF
--- a/weave
+++ b/weave
@@ -892,7 +892,7 @@ proxy_args() {
 }
 
 proxy_addr() {
-    if addr=$(docker logs weaveproxy | head -n3 | grep -oE "proxy listening on .*"); then
+    if addr=$(docker logs $PROXY_CONTAINER_NAME 2>/dev/null | head -n3 | grep -oE "proxy listening on .*"); then
       addr=${addr##* }
       host=${addr%:*}
       [ "$host" = "0.0.0.0" ] && host=$PROXY_HOST


### PR DESCRIPTION
`docker log` outputs an error if stdout is closed before it is done, so
silence that

Fixes #939