### PR TITLE
[proxy] Add support for WEAVE_CIDR=none

### DIFF
--- a/proxy/common.go
+++ b/proxy/common.go
@@ -28,13 +28,16 @@ func callWeave(args ...string) ([]byte, error) {
 	return out, err
 }
 
-func weaveCIDRsFromConfig(config *docker.Config) ([]string, bool) {
+func weaveCIDRsFromConfig(config *docker.Config, noDefaultIPAM bool) ([]string, bool) {
 	for _, e := range config.Env {
 		if strings.HasPrefix(e, "WEAVE_CIDR=") {
+			if e[11:] == "none" {
+				return nil, false
+			}
 			return strings.Fields(e[11:]), true
 		}
 	}
-	return nil, false
+	return nil, !noDefaultIPAM
 }
 
 func marshalRequestBody(r *http.Request, body interface{}) error {

--- a/proxy/common.go
+++ b/proxy/common.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os/exec"
 	"regexp"
-	"strings"
 
 	"github.com/fsouza/go-dockerclient"
 	. "github.com/weaveworks/weave/common"
@@ -26,18 +25,6 @@ func callWeave(args ...string) ([]byte, error) {
 	cmd.Env = []string{"PROCFS=/hostproc", "PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 	out, err := cmd.CombinedOutput()
 	return out, err
-}
-
-func weaveCIDRsFromConfig(config *docker.Config, noDefaultIPAM bool) ([]string, bool) {
-	for _, e := range config.Env {
-		if strings.HasPrefix(e, "WEAVE_CIDR=") {
-			if e[11:] == "none" {
-				return nil, false
-			}
-			return strings.Fields(e[11:]), true
-		}
-	}
-	return nil, !noDefaultIPAM
 }
 
 func marshalRequestBody(r *http.Request, body interface{}) error {

--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -33,7 +33,7 @@ func (i *createContainerInterceptor) InterceptRequest(r *http.Request) error {
 		return err
 	}
 
-	if cidrs, ok := weaveCIDRsFromConfig(container.Config, i.proxy.NoDefaultIPAM); ok {
+	if cidrs, ok := i.proxy.weaveCIDRsFromConfig(container.Config); ok {
 		Info.Printf("Creating container with WEAVE_CIDR \"%s\"", strings.Join(cidrs, " "))
 		if container.HostConfig == nil {
 			container.HostConfig = &docker.HostConfig{}

--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -33,7 +33,7 @@ func (i *createContainerInterceptor) InterceptRequest(r *http.Request) error {
 		return err
 	}
 
-	if cidrs, ok := weaveCIDRsFromConfig(container.Config); ok || !i.proxy.NoDefaultIPAM {
+	if cidrs, ok := weaveCIDRsFromConfig(container.Config, i.proxy.NoDefaultIPAM); ok {
 		Info.Printf("Creating container with WEAVE_CIDR \"%s\"", strings.Join(cidrs, " "))
 		if container.HostConfig == nil {
 			container.HostConfig = &docker.HostConfig{}

--- a/proxy/create_exec_interceptor.go
+++ b/proxy/create_exec_interceptor.go
@@ -29,7 +29,7 @@ func (i *createExecInterceptor) InterceptRequest(r *http.Request) error {
 		return err
 	}
 
-	if cidrs, ok := weaveCIDRsFromConfig(container.Config); ok || !i.proxy.NoDefaultIPAM {
+	if cidrs, ok := weaveCIDRsFromConfig(container.Config, i.proxy.NoDefaultIPAM); ok {
 		Info.Printf("Exec in container %s with WEAVE_CIDR \"%s\"", container.ID, strings.Join(cidrs, " "))
 		cmd := append(weaveWaitEntrypoint, "-s")
 		options.Cmd = append(cmd, options.Cmd...)

--- a/proxy/create_exec_interceptor.go
+++ b/proxy/create_exec_interceptor.go
@@ -29,7 +29,7 @@ func (i *createExecInterceptor) InterceptRequest(r *http.Request) error {
 		return err
 	}
 
-	if cidrs, ok := weaveCIDRsFromConfig(container.Config, i.proxy.NoDefaultIPAM); ok {
+	if cidrs, ok := i.proxy.weaveCIDRsFromConfig(container.Config); ok {
 		Info.Printf("Exec in container %s with WEAVE_CIDR \"%s\"", container.ID, strings.Join(cidrs, " "))
 		cmd := append(weaveWaitEntrypoint, "-s")
 		options.Cmd = append(cmd, options.Cmd...)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/fsouza/go-dockerclient"
 	. "github.com/weaveworks/weave/common"
@@ -112,4 +113,16 @@ func (proxy *Proxy) ListenAndServe() error {
 	Info.Println("proxy listening on", proxy.ListenAddr)
 
 	return (&http.Server{Handler: proxy}).Serve(listener)
+}
+
+func (proxy *Proxy) weaveCIDRsFromConfig(config *docker.Config) ([]string, bool) {
+	for _, e := range config.Env {
+		if strings.HasPrefix(e, "WEAVE_CIDR=") {
+			if e[11:] == "none" {
+				return nil, false
+			}
+			return strings.Fields(e[11:]), true
+		}
+	}
+	return nil, !proxy.NoDefaultIPAM
 }

--- a/proxy/start_container_interceptor.go
+++ b/proxy/start_container_interceptor.go
@@ -21,8 +21,8 @@ func (i *startContainerInterceptor) InterceptResponse(r *http.Response) error {
 		return err
 	}
 
-	cidrs, ok := weaveCIDRsFromConfig(container.Config)
-	if !ok && i.proxy.NoDefaultIPAM {
+	cidrs, ok := weaveCIDRsFromConfig(container.Config, i.proxy.NoDefaultIPAM)
+	if !ok {
 		Debug.Print("No Weave CIDR, ignoring")
 		return nil
 	}

--- a/proxy/start_container_interceptor.go
+++ b/proxy/start_container_interceptor.go
@@ -21,7 +21,7 @@ func (i *startContainerInterceptor) InterceptResponse(r *http.Response) error {
 		return err
 	}
 
-	cidrs, ok := weaveCIDRsFromConfig(container.Config, i.proxy.NoDefaultIPAM)
+	cidrs, ok := i.proxy.weaveCIDRsFromConfig(container.Config)
 	if !ok {
 		Debug.Print("No Weave CIDR, ignoring")
 		return nil

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -109,8 +109,13 @@ To use a specific IP, we pass a `WEAVE_CIDR` to the container, e.g.
 
     host1$ docker run -ti -e WEAVE_CIDR=10.2.1.1/24 ubuntu
 
-To start containers without connecting them to the weave network, the
-proxy needs to be passed the `--no-default-ipam` flag, e.g.
+To start a container without connecting it to the weave network, pass
+`WEAVE_CIDR=none`, e.g.
+
+    host1$ docker run -ti -e WEAVE_CIDR=none ubuntu
+
+If you do not want IPAM to be used by default, the proxy needs to be
+passed the `--no-default-ipam` flag, e.g.
 
     host1$ docker launch-proxy --no-default-ipam
 

--- a/test/650_proxy_env_test.sh
+++ b/test/650_proxy_env_test.sh
@@ -10,4 +10,9 @@ CMD="run -e WEAVE_CIDR=10.2.1.4/24 $SMALL_IMAGE $CHECK_ETHWE_UP"
 assert_raises "eval '$(weave_on $HOST1 proxy-env)' ; docker $CMD"
 assert_raises "docker $(weave_on $HOST1 proxy-config) $CMD"
 
+# Check we can use the weave script through the proxy
+assert_raises "eval '$(weave_on $HOST1 proxy-env)' ; $WEAVE version"
+assert_raises "eval '$(weave_on $HOST1 proxy-env)' ; $WEAVE ps"
+assert_raises "eval '$(weave_on $HOST1 proxy-env)' ; $WEAVE launch"
+
 end_suite

--- a/test/660_proxy_ipam_test.sh
+++ b/test/660_proxy_ipam_test.sh
@@ -4,23 +4,35 @@
 
 UNIVERSE=10.2.2.0/24
 
+start() {
+  host=$1
+  shift
+  proxy docker_on "$host" run "$@" -dt $SMALL_IMAGE /bin/sh
+}
+
+assert_no_ethwe() {
+  assert_raises "container_ip $1 $2" 1
+  assert_raises "proxy exec_on $1 $2 ip link show | grep -v ethwe"
+}
+
 start_suite "Ping proxied containers over cross-host weave network (with IPAM)"
 
 weave_on $HOST1 launch -iprange $UNIVERSE
 weave_on $HOST1 launch-proxy
+start $HOST1 --name=auto
+start $HOST1 --name=none       -e WEAVE_CIDR=none
+
 weave_on $HOST2 launch -iprange $UNIVERSE $HOST1
 weave_on $HOST2 launch-proxy --no-default-ipam
-
-proxy docker_on $HOST1 run                --name=auto     -dt $SMALL_IMAGE /bin/sh
-proxy docker_on $HOST2 run -e WEAVE_CIDR= --name=explicit -dt $SMALL_IMAGE /bin/sh
-proxy docker_on $HOST2 run                --name=none     -dt $SMALL_IMAGE /bin/sh
+start $HOST2 --name=explicit   -e WEAVE_CIDR=
+start $HOST2 --name=no-default
 
 AUTO=$(container_ip $HOST1 auto)
 EXPLICIT=$(container_ip $HOST2 explicit)
 assert_raises "proxy exec_on $HOST1 auto     $PING $EXPLICIT"
 assert_raises "proxy exec_on $HOST2 explicit $PING $AUTO"
 
-assert_raises "container_ip $HOST2 none" 1
-assert_raises "proxy exec_on $HOST2 none ip link show | grep -v ethwe"
+assert_no_ethwe $HOST1 none
+assert_no_ethwe $HOST2 no-default
 
 end_suite

--- a/weave
+++ b/weave
@@ -76,6 +76,7 @@ exec_remote() {
         -e WEAVE_CONTAINER_NAME \
         -e DOCKER_BRIDGE \
         -e PROXY_HOST="$PROXY_HOST" \
+        -e WEAVE_CIDR=none \
         $WEAVEEXEC_DOCKER_ARGS $EXEC_IMAGE --local "$@"
 }
 
@@ -387,7 +388,7 @@ ask_version() {
                 echo "Unable to find $2 image." >&2
             fi
     fi
-    [ -n "$DOCKERIMAGE" ] && docker run --rm $DOCKERIMAGE --version
+    [ -n "$DOCKERIMAGE" ] && docker run --rm -e WEAVE_CIDR=none $DOCKERIMAGE --version
 }
 
 ######################################################################
@@ -1023,6 +1024,7 @@ case "$COMMAND" in
             -p $PORT:$CONTAINER_PORT/tcp -p $PORT:$CONTAINER_PORT/udp \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e WEAVE_PASSWORD \
+            -e WEAVE_CIDR=none \
             $WEAVE_DOCKER_ARGS $IMAGE -iface $CONTAINER_IFNAME -port $CONTAINER_PORT -name "$PEERNAME" -nickname "$(hostname)" -iprange "$IPRANGE" "$@")
         with_container_netns_or_die $CONTAINER launch
         wait_for_status $CONTAINER_NAME $HTTP_PORT
@@ -1044,6 +1046,7 @@ case "$COMMAND" in
         # when launching the weave container.
         DNS_CONTAINER=$(docker run --privileged -d --name=$DNS_CONTAINER_NAME \
             -p $DOCKER_BRIDGE_IP:53:53/udp \
+            -e WEAVE_CIDR=none \
             -v /var/run/docker.sock:/var/run/docker.sock \
             $WEAVEDNS_DOCKER_ARGS $DNS_IMAGE -iface $CONTAINER_IFNAME -httpiface "$DNS_HTTP_IFNAME" "$@")
         ipam_cidrs_or_die $DNS_CONTAINER $CIDR_ARGS
@@ -1062,6 +1065,7 @@ case "$COMMAND" in
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v /proc:/hostproc \
             -e PROCFS=/hostproc \
+            -e WEAVE_CIDR=none \
             --entrypoint=/home/weave/weaveproxy \
             $WEAVEPROXY_DOCKER_ARGS $EXEC_IMAGE $PROXY_ARGS)
         wait_for_log $PROXY_CONTAINER_NAME "proxy listening"


### PR DESCRIPTION
Tells the proxy not to do anything with this container. We set it when
running weaveexec/weave/etc containers, so that the weave script works
through the proxy.

Fixes #950

Now:
```bash
vagrant@host1:~$ ./weave launch-proxy
d4a0717b0c9e0ab217c02d8f84fa518454cd639f48fc748088b99816f36cee2c
vagrant@host1:~$ eval "$(./weave proxy-env)"
vagrant@host1:~$ ./weave version
weave script (unreleased version)
weave router git-c45b586a4424
weave DNS git-c45b586a4424
weave exec (unreleased version)
vagrant@host1:~$ ./weave launch
f274564cc22d7810f80f2d467485407546a757f02f32238e6421e62421ad9699
```