### PR TITLE
include image name in errors

### DIFF
--- a/proxy/proxy_intercept.go
+++ b/proxy/proxy_intercept.go
@@ -16,11 +16,10 @@ import (
 
 func (proxy *Proxy) Intercept(i interceptor, w http.ResponseWriter, r *http.Request) {
 	if err := i.InterceptRequest(r); err != nil {
-		_, isNoSuchContainer := err.(*docker.NoSuchContainer)
-		switch {
-		case isNoSuchContainer:
+		switch err.(type) {
+		case *docker.NoSuchContainer:
 			http.Error(w, err.Error(), http.StatusNotFound)
-		case err == docker.ErrNoSuchImage:
+		case *ErrNoSuchImage:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
The go docker client's `ErrNoSuchImage` does not include the image name. However, it is imperative that this name appears in error messages sent to clients, since the docker client, as of version
1.7.0, only automatically pulls images when their name is present in the error.

Fixes #967.