### PR TITLE
Change one IPAM proxy example to use a network

### DIFF
--- a/site/proxy.md
+++ b/site/proxy.md
@@ -91,9 +91,9 @@ special environment variables or other options*.
 
     host1$ docker run -ti ubuntu
 
-To use a specific IP, we pass a `WEAVE_CIDR` to the container, e.g.
+To use a specific subnet, we pass a `WEAVE_CIDR` to the container, e.g.
 
-    host1$ docker run -ti -e WEAVE_CIDR=10.2.1.1/24 ubuntu
+    host1$ docker run -ti -e WEAVE_CIDR=net:10.128.0.0/24 ubuntu
 
 To start a container without connecting it to the weave network, pass
 `WEAVE_CIDR=none`, e.g.


### PR DESCRIPTION
Previously, no proxy examples used the `net:` syntax, and this particular example duplicated the one 18 lines above.