### PR TITLE
[proxy] Only prepend weavewait if not already present

### DIFF
--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -89,7 +89,10 @@ func (i *createContainerInterceptor) setWeaveWaitEntrypoint(container *docker.Co
 		}
 	}
 
-	container.Entrypoint = append(weaveWaitEntrypoint, container.Entrypoint...)
+	if len(container.Entrypoint) == 0 || container.Entrypoint[0] != weaveWaitEntrypoint[0] {
+		container.Entrypoint = append(weaveWaitEntrypoint, container.Entrypoint...)
+	}
+
 	return nil
 }
 

--- a/test/610_proxy_wait_for_weave_test.sh
+++ b/test/610_proxy_wait_for_weave_test.sh
@@ -2,6 +2,10 @@
 
 . ./config.sh
 
+entrypoint() {
+  docker_on $HOST1 inspect --format="{{.Config.Entrypoint}}" "$@"
+}
+
 start_suite "Proxy waits for weave to be ready before running container commands"
 weave_on $HOST1 launch-proxy
 BASE_IMAGE=busybox
@@ -10,6 +14,11 @@ if (docker_on $HOST1 images $BASE_IMAGE | grep -q $BASE_IMAGE); then
   docker_on $HOST1 rmi $BASE_IMAGE
 fi
 
-assert_raises "proxy docker_on $HOST1 run -e 'WEAVE_CIDR=10.2.1.1/24' $BASE_IMAGE $CHECK_ETHWE_UP"
+assert_raises "proxy docker_on $HOST1 run --name c1 -e 'WEAVE_CIDR=10.2.1.1/24' $BASE_IMAGE $CHECK_ETHWE_UP"
+
+# Check committed containers only have one weavewait prepended
+COMMITTED_IMAGE=$(proxy docker_on $HOST1 commit c1)
+assert_raises "proxy docker_on $HOST1 run --name c2 $COMMITTED_IMAGE"
+assert "entrypoint c2" "$(entrypoint $COMMITTED_IMAGE)"
 
 end_suite


### PR DESCRIPTION
This way `docker commit` will not stack up weavewaits.

Fixes #979