### PR TITLE
prefetch test images

### DIFF
--- a/test/610_proxy_wait_for_weave_test.sh
+++ b/test/610_proxy_wait_for_weave_test.sh
@@ -10,9 +10,7 @@ start_suite "Proxy waits for weave to be ready before running container commands
 weave_on $HOST1 launch-proxy
 BASE_IMAGE=busybox
 # Ensure the base image does not exist, so that it will be pulled
-if (docker_on $HOST1 images $BASE_IMAGE | grep -q $BASE_IMAGE); then
-  docker_on $HOST1 rmi $BASE_IMAGE
-fi
+! docker_on $HOST1 inspect --format=" " $BASE_IMAGE >/dev/null 2>&1 || docker_on $HOST1 rmi $BASE_IMAGE
 
 assert_raises "proxy docker_on $HOST1 run --name c1 -e 'WEAVE_CIDR=10.2.1.1/24' $BASE_IMAGE $CHECK_ETHWE_UP"
 

--- a/test/config.sh
+++ b/test/config.sh
@@ -31,6 +31,8 @@ SSH=${SSH:-ssh -l vagrant -i ./insecure_private_key -o UserKnownHostsFile=./.ssh
 
 SMALL_IMAGE="gliderlabs/alpine"
 DNS_IMAGE="aanand/docker-dnsutils"
+TEST_IMAGES="$SMALL_IMAGE $DNS_IMAGE"
+
 PING="ping -nq -W 1 -c 1"
 CHECK_ETHWE_UP="grep ^1$ /sys/class/net/ethwe/carrier"
 

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -6,7 +6,8 @@ set -e
 
 (cd ./tls && go get ./... && go run generate_certs.go $HOSTS)
 
-echo Copying weave images, scripts, and certificates to hosts
+echo "Copying weave images, scripts, and certificates to hosts, and"
+echo "  prefetch docker images"
 for HOST in $HOSTS; do
     docker_on $HOST load -i ../weave.tar
     docker_on $HOST load -i ../weavedns.tar
@@ -16,4 +17,7 @@ for HOST in $HOSTS; do
     cat ../weave | run_on $HOST sh -c "cat > ./weave"
     run_on $HOST chmod a+x $DOCKER_NS ./weave
     rsync -az -e "$SSH" ./tls/ $HOST:~/tls
+    for IMG in $TEST_IMAGES ; do
+        docker_on $HOST inspect --format=" " $IMG >/dev/null 2>&1 || docker_on $HOST pull $IMG
+    done
 done


### PR DESCRIPTION
This gives more consistent test execution times, and also make image fetch failures more apparent and decoupled from the tests.

We could *always* just run `pull`, but it's an expensive operation, so we check for the presence of the image first. The downside is that we could be running old images. That is not a problem on our CI infrastructure though since it spins up fresh VMs per for every tun.