### PR TITLE
sleep for 0.1s instead of 1s in the wait_for_status loop

### DIFF
--- a/weave
+++ b/weave
@@ -183,6 +183,21 @@ command_exists() {
     command -v $1 >/dev/null 2>&1
 }
 
+fractional_sleep() {
+    case $1 in
+        *.*)
+            if [ -z "$NO_FRACTIONAL_SLEEP" ] ; then
+                sleep $1 >/dev/null 2>&1 && return 0
+                NO_FRACTIONAL_SLEEP=1
+            fi
+            sleep $((${1%.*} + 1))
+            ;;
+        *)
+            sleep $1
+            ;;
+    esac
+}
+
 run_iptables() {
     # -w is recent addition to iptables
     if [ -z "$CHECKED_IPTABLES_W" ] ; then
@@ -585,7 +600,7 @@ wait_for_status() {
             echo "$err_msg" >&2
             return 1
         fi
-        sleep 1
+        fractional_sleep 0.1
     done
 }
 


### PR DESCRIPTION
This reduces `weave launch|launch-dns` execution time.

Closes #992.

On my machine, `time weave launch` takes ~1.95s before this change, and ~1.15s after.