### PR TITLE
separate the image build and export phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,10 @@ prog/netcheck/netcheck
 tools/bin
 tools/build
 releases
+.weaver.uptodate
+.weavedns.uptodate
+.weaveexec.uptodate
 weave.tar
-weavedns.tar
-weaveexec.tar
 prog/weaveexec/weave
 prog/weaveexec/weaveproxy
 prog/weaveexec/weavewait

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu
 
-RUN apt-get -y update && apt-get -y install --no-install-recommends build-essential git ca-certificates docker.io mercurial libpcap-dev curl make pkg-config gcc bison flex
+RUN apt-get -y update && apt-get -y install --no-install-recommends ca-certificates apt-transport-https
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
+RUN apt-get -y update && apt-get -y install --no-install-recommends build-essential git lxc-docker-1.3.1 mercurial libpcap-dev curl make pkg-config gcc bison flex
 
 # When doing a build in a container, "apt-get update" happens twice,
 # which can be a very significant overhead for incremental builds.

--- a/site/building.md
+++ b/site/building.md
@@ -57,8 +57,7 @@ $ make
 
 This will build the weave components and package them into three
 Docker images (`weaveworks/weave`, `weaveworks/weavedns`, and
-`weaveworks/weaveexec`).  These are then exported (as `weave.tar`,
-`weavedns.tar` and `weaveexec.tar`).
+`weaveworks/weaveexec`).  These are then exported as `weave.tar`.
 
 ## Building in a Docker container
 
@@ -171,15 +170,13 @@ you can do so with
 $ vagrant ssh -c 'make -C src/github.com/weaveworks/weave'
 ```
 
-you should then find container snapshot tarballs in the top-level
-directory. You can use these snapshots with `docker load` against a
-different host, e.g.
+you should then find a `weave.tar` container snapshot tarball in the
+top-level directory. You can use that snapshot with `docker load`
+against a different host, e.g.
 
 ```bash
 $ export DOCKER_HOST=tcp://<HOST:PORT>
 $ docker load < weave.tar
-$ docker load < weavedns.tar
-$ docker load < weaveexec.tar
 ```
 
 You can provide extra Vagrant configuration by putting a file

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -10,8 +10,6 @@ echo "Copying weave images, scripts, and certificates to hosts, and"
 echo "  prefetch test images"
 for HOST in $HOSTS; do
     docker_on $HOST load -i ../weave.tar
-    docker_on $HOST load -i ../weavedns.tar
-    docker_on $HOST load -i ../weaveexec.tar
     run_on $HOST mkdir -p bin
     cat ../bin/docker-ns | run_on $HOST sh -c "cat > $DOCKER_NS"
     cat ../weave | run_on $HOST sh -c "cat > ./weave"


### PR DESCRIPTION
That way the export can be just a single tar, which is more convenient.