### PR TITLE
Let Scope use these integration test helpers

### DIFF
--- a/test/140_weave_local_test.sh
+++ b/test/140_weave_local_test.sh
@@ -4,15 +4,15 @@
 
 start_suite "Run weave with --local"
 
-run_on $HOST1 sudo ./weave --local reset
+run_on $HOST1 sudo weave --local reset
 
-run_on $HOST1 sudo ./weave --local launch -iprange 10.2.5.0/24
+run_on $HOST1 sudo weave --local launch -iprange 10.2.5.0/24
 assert_raises "docker_on $HOST1 ps | grep weave"
 
-run_on $HOST1 sudo ./weave --local run 10.2.6.5/24 -ti --name=c1 $SMALL_IMAGE /bin/sh
+run_on $HOST1 sudo weave --local run 10.2.6.5/24 -ti --name=c1 $SMALL_IMAGE /bin/sh
 assert_raises "exec_on $HOST1 c1 $CHECK_ETHWE_UP"
 
-run_on $HOST1 sudo ./weave --local run             -ti --name=c2 $SMALL_IMAGE /bin/sh
+run_on $HOST1 sudo weave --local run             -ti --name=c2 $SMALL_IMAGE /bin/sh
 assert_raises "exec_on $HOST1 c2 $CHECK_ETHWE_UP"
 
 end_suite

--- a/test/config.sh
+++ b/test/config.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Protect against being sourced multiple times to prevent
 # overwriting assert.sh global state
 if ! [ -z "$SOURCED_CONFIG_SH" ]; then
@@ -25,9 +27,11 @@ fi
 HOST1=$(echo $HOSTS | cut -f 1 -d ' ')
 HOST2=$(echo $HOSTS | cut -f 2 -d ' ')
 
-. ./assert.sh
+. "$DIR/assert.sh"
 
-SSH=${SSH:-ssh -l vagrant -i ./insecure_private_key -o UserKnownHostsFile=./.ssh_known_hosts -o CheckHostIP=no -o StrictHostKeyChecking=no}
+
+SSH_DIR=${SSH_DIR:-$DIR}
+SSH=${SSH:-ssh -l vagrant -i "$SSH_DIR/insecure_private_key" -o "UserKnownHostsFile=$SSH_DIR/.ssh_known_hosts" -o CheckHostIP=no -o StrictHostKeyChecking=no}
 
 SMALL_IMAGE="gliderlabs/alpine"
 DNS_IMAGE="aanand/docker-dnsutils"
@@ -40,6 +44,18 @@ DOCKER_PORT=2375
 
 WEAVEDNS_ARGS="--no-cache"
 [ -n "$DEBUG" ] && WEAVEDNS_ARGS="$WEAVEDNS_ARGS --debug"
+
+
+upload_executable() {
+    host=$1
+    file=$2
+    prefix=${3:-/usr/local/bin/}
+    suffix=$(basename "$file")
+    target="$prefix$suffix"
+    [ -z "$DEBUG" ] || greyly echo "Uploading to $host: $file -> $target" >&2
+    <"$file" remote $host $SSH $host sh -c "cat | sudo tee $target >/dev/null"
+    run_on $host "sudo chmod a+x $target"
+}
 
 remote() {
     rem=$1
@@ -182,5 +198,5 @@ end_suite() {
     whitely assert_end
 }
 
-WEAVE=../weave
-DOCKER_NS=./bin/docker-ns
+WEAVE=$DIR/../weave
+DOCKER_NS=$DIR/../bin/docker-ns

--- a/test/gce.sh
+++ b/test/gce.sh
@@ -9,7 +9,7 @@ set -ex
 
 KEY_FILE=/tmp/gce_private_key.json
 SSH_KEY_FILE=$HOME/.ssh/gce_ssh_key
-PROJECT=positive-cocoa-90213
+PROJECT=${PROJECT:-positive-cocoa-90213}
 IMAGE=ubuntu-14-04
 TEMPLATE_NAME="test-template-2"
 ZONE=us-central1-a

--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-. ./config.sh
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$DIR/config.sh"
 
 whitely echo Sanity checks
-if ! bash ./sanity_check.sh; then
+if ! bash "$DIR/sanity_check.sh"; then
     whitely echo ...failed
     exit 1
 fi
@@ -27,8 +28,8 @@ trap check_test_status EXIT
 TESTS="${@:-*_test.sh}"
 
 # If running on circle, use the scheduler to work out what tests to run
-if [ -n "$CIRCLECI" ]; then
-    TESTS=$(echo $TESTS | ./sched sched $CIRCLE_BUILD_NUM $CIRCLE_NODE_TOTAL $CIRCLE_NODE_INDEX)
+if [ -n "$CIRCLECI" -a -z "$NO_SCHEDULER" ]; then
+    TESTS=$(echo $TESTS | "$DIR/sched" sched $CIRCLE_BUILD_NUM $CIRCLE_NODE_TOTAL $CIRCLE_NODE_INDEX)
 fi
 
 echo Running $TESTS
@@ -39,7 +40,7 @@ for t in $TESTS; do
     . $t
 
     # Report test runtime when running on circle, to help scheduler
-    if [ -n "$CIRCLECI" ]; then
-        ./sched time $t $(bc -l <<< "$tests_time/1000000000")
+    if [ -n "$CIRCLECI" -a -z "$NO_SCHEDULER" ]; then
+        "$DIR/sched" time $t $(bc -l <<< "$tests_time/1000000000")
     fi
 done

--- a/test/sanity_check.sh
+++ b/test/sanity_check.sh
@@ -9,5 +9,22 @@ run_on $HOST2 $PING $HOST1
 run_on $HOST1 $PING $HOST2
 
 whitely echo Check we can reach docker
+echo
+echo Host Version Info: $HOST1
+echo =====================================
+echo "# docker version"
+docker_on $HOST1 version
+echo "# docker info"
 docker_on $HOST1 info
+echo "# weave version"
+weave_on $HOST1 version
+
+echo
+echo Host Version Info: $HOST2
+echo =====================================
+echo "# docker version"
+docker_on $HOST2 version
+echo "# docker info"
 docker_on $HOST2 info
+echo "# weave version"
+weave_on $HOST2 version

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 . ./config.sh
 
 (cd ./tls && go get ./... && go run generate_certs.go $HOSTS)
@@ -11,9 +13,8 @@ echo "  prefetch test images"
 for HOST in $HOSTS; do
     docker_on $HOST load -i ../weave.tar
     run_on $HOST mkdir -p bin
-    cat ../bin/docker-ns | run_on $HOST sh -c "cat > $DOCKER_NS"
-    cat ../weave | run_on $HOST sh -c "cat > ./weave"
-    run_on $HOST chmod a+x $DOCKER_NS ./weave
+    upload_executable $HOST ../bin/docker-ns
+    upload_executable $HOST ../weave
     rsync -az -e "$SSH" ./tls/ $HOST:~/tls
     for IMG in $TEST_IMAGES ; do
         docker_on $HOST inspect --format=" " $IMG >/dev/null 2>&1 || docker_on $HOST pull $IMG


### PR DESCRIPTION
Since scope has to check out the latest weave release anyway, we may as well use the test helpers from there, and only manage them in one place.

This must be merged, and into a release before: https://github.com/weaveworks/scope/pull/273