### PR TITLE
Flush messages from mock gossip in IPAM test

### DIFF
--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -256,13 +256,17 @@ func TestTransfer(t *testing.T) {
 	require.True(t, err == nil, "Failed to get address")
 
 	router.GossipBroadcast(alloc2.Gossip())
+	router.flush()
 	router.GossipBroadcast(alloc3.Gossip())
+	router.flush()
 	router.removePeer(alloc2.ourName)
 	router.removePeer(alloc3.ourName)
 	alloc2.Stop()
 	alloc3.Stop()
+	router.flush()
 	require.NoError(t, alloc1.AdminTakeoverRanges(alloc2.ourName.String()))
 	require.NoError(t, alloc1.AdminTakeoverRanges(alloc3.ourName.String()))
+	router.flush()
 
 	require.Equal(t, address.Offset(1022), alloc1.NumFreeAddresses(subnet))
 

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -286,7 +286,8 @@ func TestFakeRouterSimple(t *testing.T) {
 	alloc1 := allocs[0]
 	//alloc2 := allocs[1]
 
-	alloc1.Allocate("foo", subnet, nil)
+	_, err := alloc1.Allocate("foo", subnet, nil)
+	require.True(t, err == nil, "Failed to get address")
 }
 
 func TestAllocatorFuzz(t *testing.T) {

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -168,7 +168,7 @@ func TestCancel(t *testing.T) {
 		CIDR = "10.0.1.7/26"
 	)
 
-	router := TestGossipRouter{make(map[router.PeerName]chan gossipMessage), 0.0}
+	router := TestGossipRouter{make(map[router.PeerName]chan interface{}), 0.0}
 
 	alloc1, subnet := makeAllocator("01:00:00:02:00:00", CIDR, 2)
 	alloc1.SetInterfaces(router.connect(alloc1.ourName, alloc1))

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -200,7 +200,7 @@ type gossipMessage struct {
 	sender    *router.PeerName
 	buf       []byte            // for unicast
 	data      router.GossipData // for broadcast
-	exitChan  chan bool
+	exitChan  chan struct{}
 }
 
 type TestGossipRouter struct {
@@ -220,7 +220,7 @@ func (grouter *TestGossipRouter) GossipBroadcast(update router.GossipData) error
 
 func (grouter *TestGossipRouter) removePeer(peer router.PeerName) {
 	gossipChan := grouter.gossipChans[peer]
-	resultChan := make(chan bool)
+	resultChan := make(chan struct{})
 	gossipChan <- gossipMessage{exitChan: resultChan}
 	<-resultChan
 	delete(grouter.gossipChans, peer)
@@ -240,7 +240,7 @@ func (grouter *TestGossipRouter) connect(sender router.PeerName, gossiper router
 			select {
 			case message := <-gossipChan:
 				if message.exitChan != nil {
-					message.exitChan <- true
+					close(message.exitChan)
 					return
 				}
 

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -196,7 +196,7 @@ func AssertNothingSentErr(t *testing.T, ch <-chan error) {
 
 // Router to convey gossip from one gossiper to another, for testing
 type unicastMessage struct {
-	sender *router.PeerName
+	sender router.PeerName
 	buf    []byte
 }
 type broadcastMessage struct {
@@ -245,41 +245,47 @@ type TestGossipRouterClient struct {
 	sender router.PeerName
 }
 
-func (grouter *TestGossipRouter) connect(sender router.PeerName, gossiper router.Gossiper) router.Gossip {
-	gossipChan := make(chan interface{}, 100)
+func (grouter *TestGossipRouter) run(gossiper router.Gossiper, gossipChan chan interface{}) {
+	gossipTimer := time.Tick(10 * time.Second)
+	for {
+		select {
+		case gossip := <-gossipChan:
+			switch message := gossip.(type) {
+			case exitMessage:
+				close(message.exitChan)
+				return
 
-	go func() {
-		gossipTimer := time.Tick(10 * time.Second)
-		for {
-			select {
-			case gossip := <-gossipChan:
-				if message, isExit := gossip.(exitMessage); isExit {
-					close(message.exitChan)
-					return
-				}
-				if message, isFlush := gossip.(flushMessage); isFlush {
-					close(message.flushChan)
-				}
+			case flushMessage:
+				close(message.flushChan)
+
+			case unicastMessage:
 				if rand.Float32() > (1.0 - grouter.loss) {
 					continue
 				}
-				switch message := gossip.(type) {
-				case unicastMessage:
-					if err := gossiper.OnGossipUnicast(*message.sender, message.buf); err != nil {
-						panic(fmt.Sprintf("Error doing gossip unicast to %s: %s", sender, err))
-					}
-				case broadcastMessage:
-					for _, msg := range message.data.Encode() {
-						if _, err := gossiper.OnGossipBroadcast(msg); err != nil {
-							panic(fmt.Sprintf("Error doing gossip broadcast to %s: %s", sender, err))
-						}
+				if err := gossiper.OnGossipUnicast(message.sender, message.buf); err != nil {
+					panic(fmt.Sprintf("Error doing gossip unicast to %s: %s", message.sender, err))
+				}
+
+			case broadcastMessage:
+				if rand.Float32() > (1.0 - grouter.loss) {
+					continue
+				}
+				for _, msg := range message.data.Encode() {
+					if _, err := gossiper.OnGossipBroadcast(msg); err != nil {
+						panic(fmt.Sprintf("Error doing gossip broadcast: %s", err))
 					}
 				}
-			case <-gossipTimer:
-				grouter.GossipBroadcast(gossiper.Gossip())
 			}
+		case <-gossipTimer:
+			grouter.GossipBroadcast(gossiper.Gossip())
 		}
-	}()
+	}
+}
+
+func (grouter *TestGossipRouter) connect(sender router.PeerName, gossiper router.Gossiper) router.Gossip {
+	gossipChan := make(chan interface{}, 100)
+
+	go grouter.run(gossiper, gossipChan)
 
 	grouter.gossipChans[sender] = gossipChan
 	return TestGossipRouterClient{grouter, sender}
@@ -287,7 +293,7 @@ func (grouter *TestGossipRouter) connect(sender router.PeerName, gossiper router
 
 func (client TestGossipRouterClient) GossipUnicast(dstPeerName router.PeerName, buf []byte) error {
 	select {
-	case client.router.gossipChans[dstPeerName] <- unicastMessage{sender: &client.sender, buf: buf}:
+	case client.router.gossipChans[dstPeerName] <- unicastMessage{sender: client.sender, buf: buf}:
 	default: // drop the message if we cannot send it
 		common.Error.Printf("Dropping message")
 	}


### PR DESCRIPTION
Refactored mock router, and added a `flush()` function which we then call every time gossip messages are generated in `TestTransfer()`, thus avoiding the problem that they may be dropped if the previous message has not been removed from the channel, or may not have arrived by the time we check what has happened.

`flush()` is not called in the other two tests that use the mock router; one of them hardly does anything, and the other benefits from the message-dropping behaviour, in that it makes it also a test of recovery from network issues.

Fixes #982.

Also replaced a `Sleep` with the `flush`, so the unit tests run faster.