### PR TITLE
Flush messages from mock gossip in IPAM test

### DIFF
--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -256,13 +256,17 @@ func TestTransfer(t *testing.T) {
 	wt.AssertTrue(t, err == nil, "Failed to get address")
 
 	router.GossipBroadcast(alloc2.Gossip())
+	router.flush()
 	router.GossipBroadcast(alloc3.Gossip())
+	router.flush()
 	router.removePeer(alloc2.ourName)
 	router.removePeer(alloc3.ourName)
 	alloc2.Stop()
 	alloc3.Stop()
+	router.flush()
 	wt.AssertSuccess(t, alloc1.AdminTakeoverRanges(alloc2.ourName.String()))
 	wt.AssertSuccess(t, alloc1.AdminTakeoverRanges(alloc3.ourName.String()))
+	router.flush()
 
 	wt.AssertEquals(t, alloc1.NumFreeAddresses(subnet), address.Offset(1022))
 

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -168,7 +168,7 @@ func TestCancel(t *testing.T) {
 		CIDR = "10.0.1.7/26"
 	)
 
-	router := TestGossipRouter{make(map[router.PeerName]chan gossipMessage), 0.0}
+	router := TestGossipRouter{make(map[router.PeerName]chan interface{}), 0.0}
 
 	alloc1, subnet := makeAllocator("01:00:00:02:00:00", CIDR, 2)
 	alloc1.SetInterfaces(router.connect(alloc1.ourName, alloc1))

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -286,7 +286,8 @@ func TestFakeRouterSimple(t *testing.T) {
 	alloc1 := allocs[0]
 	//alloc2 := allocs[1]
 
-	alloc1.Allocate("foo", subnet, nil)
+	_, err := alloc1.Allocate("foo", subnet, nil)
+	wt.AssertTrue(t, err == nil, "Failed to get address")
 }
 
 func TestAllocatorFuzz(t *testing.T) {

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -210,6 +210,9 @@ type broadcastMessage struct {
 type exitMessage struct {
 	exitChan chan struct{}
 }
+type flushMessage struct {
+	flushChan chan struct{}
+}
 
 type TestGossipRouter struct {
 	gossipChans map[router.PeerName]chan interface{}
@@ -224,6 +227,14 @@ func (grouter *TestGossipRouter) GossipBroadcast(update router.GossipData) error
 		}
 	}
 	return nil
+}
+
+func (grouter *TestGossipRouter) flush() {
+	for _, gossipChan := range grouter.gossipChans {
+		flushChan := make(chan struct{})
+		gossipChan <- flushMessage{flushChan: flushChan}
+		<-flushChan
+	}
 }
 
 func (grouter *TestGossipRouter) removePeer(peer router.PeerName) {
@@ -250,6 +261,9 @@ func (grouter *TestGossipRouter) connect(sender router.PeerName, gossiper router
 				if message, isExit := gossip.(exitMessage); isExit {
 					close(message.exitChan)
 					return
+				}
+				if message, isFlush := gossip.(flushMessage); isFlush {
+					close(message.flushChan)
 				}
 				if rand.Float32() > (1.0 - grouter.loss) {
 					continue
@@ -305,7 +319,7 @@ func makeNetworkOfAllocators(size int, cidr string) ([]*Allocator, TestGossipRou
 	}
 
 	gossipRouter.GossipBroadcast(allocs[size-1].Gossip())
-	time.Sleep(1000 * time.Millisecond)
+	gossipRouter.flush()
 	return allocs, gossipRouter, subnet
 }
 

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -205,7 +205,7 @@ type gossipMessage struct {
 	sender    *router.PeerName
 	buf       []byte            // for unicast
 	data      router.GossipData // for broadcast
-	exitChan  chan bool
+	exitChan  chan struct{}
 }
 
 type TestGossipRouter struct {
@@ -225,7 +225,7 @@ func (grouter *TestGossipRouter) GossipBroadcast(update router.GossipData) error
 
 func (grouter *TestGossipRouter) removePeer(peer router.PeerName) {
 	gossipChan := grouter.gossipChans[peer]
-	resultChan := make(chan bool)
+	resultChan := make(chan struct{})
 	gossipChan <- gossipMessage{exitChan: resultChan}
 	<-resultChan
 	delete(grouter.gossipChans, peer)
@@ -245,7 +245,7 @@ func (grouter *TestGossipRouter) connect(sender router.PeerName, gossiper router
 			select {
 			case message := <-gossipChan:
 				if message.exitChan != nil {
-					message.exitChan <- true
+					close(message.exitChan)
 					return
 				}
 

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -200,23 +200,26 @@ func AssertNothingSentErr(t *testing.T, ch <-chan error) {
 }
 
 // Router to convey gossip from one gossiper to another, for testing
-type gossipMessage struct {
-	isUnicast bool
-	sender    *router.PeerName
-	buf       []byte            // for unicast
-	data      router.GossipData // for broadcast
-	exitChan  chan struct{}
+type unicastMessage struct {
+	sender *router.PeerName
+	buf    []byte
+}
+type broadcastMessage struct {
+	data router.GossipData
+}
+type exitMessage struct {
+	exitChan chan struct{}
 }
 
 type TestGossipRouter struct {
-	gossipChans map[router.PeerName]chan gossipMessage
+	gossipChans map[router.PeerName]chan interface{}
 	loss        float32 // 0.0 means no loss
 }
 
 func (grouter *TestGossipRouter) GossipBroadcast(update router.GossipData) error {
 	for _, gossipChan := range grouter.gossipChans {
 		select {
-		case gossipChan <- gossipMessage{data: update}:
+		case gossipChan <- broadcastMessage{data: update}:
 		default: // drop the message if we cannot send it
 		}
 	}
@@ -226,7 +229,7 @@ func (grouter *TestGossipRouter) GossipBroadcast(update router.GossipData) error
 func (grouter *TestGossipRouter) removePeer(peer router.PeerName) {
 	gossipChan := grouter.gossipChans[peer]
 	resultChan := make(chan struct{})
-	gossipChan <- gossipMessage{exitChan: resultChan}
+	gossipChan <- exitMessage{exitChan: resultChan}
 	<-resultChan
 	delete(grouter.gossipChans, peer)
 }
@@ -237,27 +240,26 @@ type TestGossipRouterClient struct {
 }
 
 func (grouter *TestGossipRouter) connect(sender router.PeerName, gossiper router.Gossiper) router.Gossip {
-	gossipChan := make(chan gossipMessage, 100)
+	gossipChan := make(chan interface{}, 100)
 
 	go func() {
 		gossipTimer := time.Tick(10 * time.Second)
 		for {
 			select {
-			case message := <-gossipChan:
-				if message.exitChan != nil {
+			case gossip := <-gossipChan:
+				if message, isExit := gossip.(exitMessage); isExit {
 					close(message.exitChan)
 					return
 				}
-
 				if rand.Float32() > (1.0 - grouter.loss) {
 					continue
 				}
-
-				if message.isUnicast {
+				switch message := gossip.(type) {
+				case unicastMessage:
 					if err := gossiper.OnGossipUnicast(*message.sender, message.buf); err != nil {
 						panic(fmt.Sprintf("Error doing gossip unicast to %s: %s", sender, err))
 					}
-				} else {
+				case broadcastMessage:
 					for _, msg := range message.data.Encode() {
 						if _, err := gossiper.OnGossipBroadcast(msg); err != nil {
 							panic(fmt.Sprintf("Error doing gossip broadcast to %s: %s", sender, err))
@@ -276,7 +278,7 @@ func (grouter *TestGossipRouter) connect(sender router.PeerName, gossiper router
 
 func (client TestGossipRouterClient) GossipUnicast(dstPeerName router.PeerName, buf []byte) error {
 	select {
-	case client.router.gossipChans[dstPeerName] <- gossipMessage{isUnicast: true, sender: &client.sender, buf: buf}:
+	case client.router.gossipChans[dstPeerName] <- unicastMessage{sender: &client.sender, buf: buf}:
 	default: // drop the message if we cannot send it
 		common.Error.Printf("Dropping message")
 	}
@@ -289,7 +291,7 @@ func (client TestGossipRouterClient) GossipBroadcast(update router.GossipData) e
 
 func makeNetworkOfAllocators(size int, cidr string) ([]*Allocator, TestGossipRouter, address.Range) {
 
-	gossipRouter := TestGossipRouter{make(map[router.PeerName]chan gossipMessage), 0.0}
+	gossipRouter := TestGossipRouter{make(map[router.PeerName]chan interface{}), 0.0}
 	allocs := make([]*Allocator, size)
 	var subnet address.Range
 


### PR DESCRIPTION
(replaces #1017, branched against 1.0 this time)

Refactored mock router, and added a `flush()` function which we then call every time gossip messages are generated in `TestTransfer()`, thus avoiding the problem that they may be dropped if the previous message has not been removed from the channel, or may not have arrived by the time we check what has happened.

`flush()` is not called in the other two tests that use the mock router; one of them hardly does anything, and the other benefits from the message-dropping behaviour, in that it makes it also a test of recovery from network issues.

Fixes #982.

Also replaced a `Sleep` with the `flush`, so the unit tests run faster.