### PR TITLE
Make proxy listen on unix:///var/run/weave.sock

### DIFF
--- a/site/proxy.md
+++ b/site/proxy.md
@@ -36,13 +36,14 @@ The first form is more convenient, however you can only pass proxy
 related configuration arguments to `launch-proxy` so if you need to
 modify the default behaviour you will have to use the latter.
 
-By default, the proxy listens on port 12375, on all network
-interfaces. This can be adjusted with the `-H` argument, e.g.
+By default, the proxy listens on /var/run/weave.sock and port 12375, on
+all network interfaces. This can be adjusted with the `-H` argument, e.g.
 
     host1$ weave launch-proxy -H tcp://127.0.0.1:9999
 
-If you are working with a remote docker daemon, then any firewalls
-inbetween need to be configured to permit access to the proxy port.
+Multiple -H arguments can be specified. If you are working with a remote
+docker daemon, then any firewalls inbetween need to be configured to permit
+access to the proxy port.
 
 All docker commands can be run via the proxy, so it is safe to adjust
 your `DOCKER_HOST` to point at the proxy. Weave provides a convenient

--- a/weave
+++ b/weave
@@ -58,7 +58,7 @@ usage() {
     echo "where <peer>     = <ip_address_or_fqdn>[:<port>]"
     echo "      <cidr>     = <ip_address>/<routing_prefix_length>"
     echo "      <addr>     = [ip:]<cidr> | net:<cidr> | net:default"
-    echo "      <endpoint> = [tcp://][<ip_address>]:<port>"
+    echo "      <endpoint> = [tcp://][<ip_address>]:<port> | [unix://]/path/to/socket"
     echo "      <peer_id>  = <nickname> or weave internal peer ID"
     exit 1
 }
@@ -925,11 +925,7 @@ proxy_args() {
 
 proxy_addr() {
     if addr=$(docker logs $PROXY_CONTAINER_NAME 2>/dev/null | head -n3 | grep -oE "proxy listening on .*"); then
-      addr=${addr##* }
-      host=${addr%:*}
-      [ "$host" = "0.0.0.0" ] && host=$PROXY_HOST
-      port=${addr#*:}
-      echo "${1}tcp://${host:-$PROXY_HOST}:${port:-$PROXY_PORT}"
+      echo "${1}${addr##* }" | sed "s/0.0.0.0/$PROXY_HOST/g"
       return 0
     fi
     echo  "$PROXY_CONTAINER_NAME container is not present. Have you launched it?" >&2
@@ -1035,7 +1031,7 @@ launch_proxy() {
     proxy_args "$@"
     PROXY_CONTAINER=$(docker run --privileged -d --name=$PROXY_CONTAINER_NAME --net=host \
         $PROXY_VOLUMES \
-        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /var/run:/var/run \
         -v /proc:/hostproc \
         -e PROCFS=/hostproc \
         -e WEAVE_CIDR=none \


### PR DESCRIPTION
- proxy still listens on 0.0.0.0; can now listen on multiple endpoints
- bind mounts /var/run instead of /var/run/docker.sock so the host can see the proxy sock.
- copies owner & permissions from /var/run/docker.sock to /var/run/weave.sock

Fixes #1003 