### PR TITLE
Call `weave reset` earlier in smoke-test set-up, to improve reliability

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -170,8 +170,8 @@ assert_dns_ptr_record() {
 start_suite() {
     for host in $HOST1 $HOST2; do
         [ -z "$DEBUG" ] || echo "Cleaning up on $host: removing all containers and resetting weave"
-        rm_containers $host $(docker_on $host ps -aq 2>/dev/null)
         weave_on $host reset 2>/dev/null
+        rm_containers $host $(docker_on $host ps -aq 2>/dev/null)
     done
     whitely echo "$@"
 }


### PR DESCRIPTION
As discussed at #1042, calling `conntrack -D` before shutting down older containers seems to improve the reliability of our smoke tests.

Also it gives a more gentle shut-down, so a better model to copy in case someone is trying to do something similar.

Replaces #1052, which was against the wrong branch.