### PR TITLE
Register the "dns.weave.local" name in WeaveDNS

### DIFF
--- a/nameserver/zone.go
+++ b/nameserver/zone.go
@@ -21,7 +21,8 @@ const (
 	DefaultRefreshInterval = int(DefaultLocalTTL) // Period for background updates with mDNS
 	DefaultRelevantTime    = 60                   // When to forget info about remote info if nobody asks...
 
-	defaultRemoteIdent = "weave:remote" // Ident used for info obtained from mDNS
+	defaultRemoteIdent  = "weave:remote"  // Ident used for info obtained from mDNS
+	defaultPrivateIdent = "weave:private" // Ident used for local host data (we never export)
 )
 
 // +1 to also exclude a dot

--- a/nameserver/zone_lookup.go
+++ b/nameserver/zone_lookup.go
@@ -39,11 +39,15 @@ func (uzr *uniqZoneRecords) toSlice() []ZoneRecord {
 
 //////////////////////////////////////////////////////////////////////////////
 
+func (zone *ZoneDb) isExportableIdent(ident string) bool {
+	return (ident != defaultRemoteIdent) && (ident != defaultPrivateIdent)
+}
+
 // Lookup in the database for locally-introduced information
 func (zone *ZoneDb) lookup(target string, lfun func(ns *nameSet) []*recordEntry) (res []ZoneRecord, err error) {
 	uniq := newUniqZoneRecords()
 	for identName, nameset := range zone.idents {
-		if identName != defaultRemoteIdent {
+		if zone.isExportableIdent(identName) {
 			for _, ze := range lfun(nameset) {
 				uniq.add(ze)
 			}
@@ -134,7 +138,7 @@ func (zone *ZoneDb) DomainLookupName(name string) (res []ZoneRecord, err error) 
 				uniq.add(ze)
 			}
 		}
-		if identName != defaultRemoteIdent {
+		if zone.isExportableIdent(identName) {
 			nameset.touchName(name, now)
 		}
 	}
@@ -177,7 +181,7 @@ func (zone *ZoneDb) DomainLookupInaddr(inaddr string) (res []ZoneRecord, err err
 				nameset.deleteNameIP("", revIPv4.toNetIP())
 			} else {
 				uniq.add(ze)
-				if identName != defaultRemoteIdent {
+				if zone.isExportableIdent(identName) {
 					nameset.touchName(ze.Name(), now)
 				}
 			}

--- a/test/200_dns_test.sh
+++ b/test/200_dns_test.sh
@@ -5,15 +5,17 @@
 C1=10.2.0.78
 C2=10.2.0.34
 NAME=seetwo.weave.local
+DNS1=10.2.254.1
 
 start_suite "Resolve names on a single host"
 
-launch_dns_on $HOST1 10.2.254.1/24
+launch_dns_on $HOST1 $DNS1/24
 
 start_container          $HOST1 $C2/24 --name=c2 -h $NAME
 start_container_with_dns $HOST1 $C1/24 --name=c1
 
 assert_dns_record $HOST1 c1 $NAME $C2
+assert_dns_record $HOST1 c1 "dns.weave.local" $DNS1
 
 assert_raises "exec_on $HOST1 c1 dig MX $NAME | grep -q 'status: NXDOMAIN'"
 

--- a/weave
+++ b/weave
@@ -1039,6 +1039,8 @@ launch_dns() {
     ipam_cidrs_or_die $DNS_CONTAINER $CIDR_ARGS
     with_container_netns_or_die $DNS_CONTAINER attach $ALL_CIDRS
     populate_dns
+    # register "dns.weave.local." privately (not exported via mDNS)
+    put_dns_fqdn weave:private dns.$(dns_domain) $ALL_CIDRS
 }
 
 launch_proxy() {


### PR DESCRIPTION
Fixes #984 by registering `dns.weave.local.` in a private ident that is not exported via mDNS, so containers can query about `dns.weave.local.` and get the IP of the local WeaveDNS instance.