### PR TITLE
Disable hostname derivation when container name is too long

### DIFF
--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -13,6 +13,8 @@ import (
 	"github.com/weaveworks/weave/nameserver"
 )
 
+const MaxDockerHostname = 64
+
 type createContainerInterceptor struct{ proxy *Proxy }
 
 type createContainerRequestBody struct {
@@ -110,9 +112,14 @@ func (i *createContainerInterceptor) setWeaveDNS(container *createContainerReque
 
 	name := r.URL.Query().Get("name")
 	if container.Hostname == "" && name != "" {
-		container.Hostname = name
 		// Strip trailing period because it's unusual to see it used on the end of a host name
-		container.Domainname = strings.TrimSuffix(dnsDomain, ".")
+		trimmedDNSDomain := strings.TrimSuffix(dnsDomain, ".")
+		if len(name)+1+len(trimmedDNSDomain) > MaxDockerHostname {
+			Warning.Printf("Container name [%s] too long to be used as hostname", name)
+		} else {
+			container.Hostname = name
+			container.Domainname = trimmedDNSDomain
+		}
 	}
 
 	if len(container.HostConfig.DNSSearch) == 0 {

--- a/test/270_use_name_as_hostname_test.sh
+++ b/test/270_use_name_as_hostname_test.sh
@@ -33,4 +33,8 @@ assert_expected_fqdn "$HOSTNAME"     -h $HOSTNAME         --name=$NAME
 assert_expected_fqdn "$HOSTNAME"     --hostname=$HOSTNAME --name=$NAME
 assert_expected_fqdn "$HOSTNAME"     --hostname $HOSTNAME --name=$NAME
 
+# Ensure we can launch a container with a name that is too long for hostname derivation
+SIXTY_FIVE_CHARS=01234567890123456789012345678901234567890123456789012345678901234
+assert_raises "start_container $HOST1 --name=$SIXTY_FIVE_CHARS"
+
 end_suite

--- a/weave
+++ b/weave
@@ -693,8 +693,13 @@ dns_args() {
     DNS_ARGS="--dns $DOCKER_BRIDGE_IP"
     if [ -n "$NAME_ARG" -a -z "$HOSTNAME_SPECIFIED" ] ; then
         DOMAIN=$(dns_domain)
-        DNS_ARGS="$DNS_ARGS --hostname=$NAME_ARG.${DOMAIN%.}"
-        HOSTNAME_SPECIFIED=1
+        HOSTNAME="$NAME_ARG.${DOMAIN%.}"
+        if [ ${#HOSTNAME} -gt 64 ] ; then
+            echo "Container name too long to be used as hostname" >&2
+        else
+            DNS_ARGS="$DNS_ARGS --hostname=$HOSTNAME"
+            HOSTNAME_SPECIFIED=1
+        fi
     fi
     if [ -z "$DNS_SEARCH_SPECIFIED" ] ; then
       if [ -z "$HOSTNAME_SPECIFIED" ] ; then


### PR DESCRIPTION
Rebased version of #1038. Fixes #1006.