### PR TITLE
introduce 'Proxy' as 'Docker API Proxy'

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ First start weave on $HOST1:
 
     host1$ weave launch && weave launch-dns && weave launch-proxy
 
-this runs the weave router, DNS and proxy, each in their own
-container. Next we configure our `DOCKER_HOST` environment variable to
-point to the proxy, so that containers launched via the docker command
-line are automatically attached to the weave network:
+this runs the weave router, DNS and Docker API proxy, each in their
+own container. Next we configure our `DOCKER_HOST` environment
+variable to point to the proxy, so that containers launched via the
+docker command line are automatically attached to the weave network:
 
     host1$ eval $(weave proxy-env)
 
@@ -92,11 +92,11 @@ available. Also, we can tell weave to connect to multiple peers by
 supplying multiple addresses, separated by spaces. And we can
 [add peers dynamically](http://docs.weave.works/weave/latest_release/features.html#dynamic-topologies).
 
-The router, DNS and proxy need to be started once per host. The
-relevant container images are pulled down on demand, but if you wish
-you can preload them by running `weave setup` - this is particularly
-useful for automated deployments, and ensures that there are no delays
-during later operations.
+The router, DNS and Docker API proxy need to be started once per
+host. The relevant container images are pulled down on demand, but if
+you wish you can preload them by running `weave setup` - this is
+particularly useful for automated deployments, and ensures that there
+are no delays during later operations.
 
 Now that we've got everything set up, let's see whether our containers
 can talk to each other...

--- a/site/features.md
+++ b/site/features.md
@@ -57,8 +57,10 @@ our data centre.
 
 ### <a name="docker"></a>Seamless Docker integration
 
-Weave includes a [proxy](proxy.html) so that containers launched via
-the Docker [command-line interface](https://docs.docker.com/reference/commandline/cli/) or
+Weave includes a [Docker API proxy](proxy.html) so that containers
+launched via the Docker
+[command-line interface](https://docs.docker.com/reference/commandline/cli/)
+or
 [remote API](https://docs.docker.com/reference/api/docker_remote_api/)
 are attached to the weave network before they begin execution.
 

--- a/site/how-it-works.md
+++ b/site/how-it-works.md
@@ -29,8 +29,9 @@ encrypted, which carry encapsulated network packets. These
 
 Weave creates a network bridge on the host. Each container is
 connected to that bridge via a veth pair, the container side of which
-is given the IP address & netmask supplied by the proxy. Also
-connected to the bridge is the weave router container.
+is given an IP address & netmask supplied either by the user or
+Weave's IP address allocator. Also connected to the bridge is the
+weave router container.
 
 A weave router captures Ethernet packets from its bridge-connected
 interface in promiscuous mode, using 'pcap'. This typically excludes

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -3,10 +3,10 @@ title: Weave Proxy
 layout: default
 ---
 
-# Weave Proxy
+# Weave Docker API Proxy
 
-The proxy automatically attaches containers to the weave network when
-they are started using the ordinary Docker
+The Docker API proxy automatically attaches containers to the weave
+network when they are started using the ordinary Docker
 [command-line interface](https://docs.docker.com/reference/commandline/cli/)
 or
 [remote API](https://docs.docker.com/reference/api/docker_remote_api/),

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -142,7 +142,7 @@ is waiting for a while before connecting again.
 There may also be further sections for the
 [IP address allocator](ipam.html#troubleshooting),
 [weaveDNS](weavedns.html#troubleshooting), and
-[proxy](proxy.html#troubleshooting).
+[Weave Docker API Proxy](proxy.html#troubleshooting).
 
 ### <a name="list-attached-containers"></a>List attached containers
 


### PR DESCRIPTION
in order to reduce potential confusion about its role.

Closes #1019.