### PR TITLE
Change default IP allocation range from 10.128/10 to 10.32/12

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ can talk to each other...
 In the container started on `$HOST1`...
 
     root@a1:/# ping -c 1 -q a2
-    PING a2.weave.local (10.160.0.2) 56(84) bytes of data.
+    PING a2.weave.local (10.40.0.2) 56(84) bytes of data.
     --- a2.weave.local ping statistics ---
     1 packets transmitted, 1 received, 0% packet loss, time 0ms
     rtt min/avg/max/mdev = 0.341/0.341/0.341/0.000 ms
@@ -125,7 +125,7 @@ In the container started on `$HOST1`...
 Similarly, in the container started on `$HOST2`...
 
     root@a2:/# ping -c 1 -q a1
-    PING a1.weave.local (10.128.0.2) 56(84) bytes of data.
+    PING a1.weave.local (10.32.0.2) 56(84) bytes of data.
     --- a1.weave.local ping statistics ---
     1 packets transmitted, 1 received, 0% packet loss, time 0ms
     rtt min/avg/max/mdev = 0.366/0.366/0.366/0.000 ms

--- a/site/features.md
+++ b/site/features.md
@@ -71,7 +71,7 @@ across the weave network. You can see which address was allocated with
 [`weave ps`](troubleshooting.html#list-attached-containers):
 
     host1$ weave ps a1
-    a7aee7233393 7a:44:d3:11:10:70 10.128.0.2/10
+    a7aee7233393 7a:44:d3:11:10:70 10.32.0.2/12
 
 Weave detects when a container has exited and releases its
 automatically allocated addresses so they can be re-used.

--- a/site/ipam.md
+++ b/site/ipam.md
@@ -87,7 +87,7 @@ would be safe wrt weave's startup quorum:
 
 ## <a name="range"></a>Choosing an allocation range
 
-By default, weave will allocate IP addresses in the 10.128.0.0/10
+By default, weave will allocate IP addresses in the 10.32.0.0/12
 range. This can be overridden with the `-iprange` option, e.g.
 
     host1$ weave launch -iprange 10.2.0.0/16

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -103,7 +103,7 @@ special environment variables or other options*.
 
 To use a specific subnet, we pass a `WEAVE_CIDR` to the container, e.g.
 
-    host1$ docker run -ti -e WEAVE_CIDR=net:10.128.0.0/24 ubuntu
+    host1$ docker run -ti -e WEAVE_CIDR=net:10.32.2.0/24 ubuntu
 
 To start a container without connecting it to the weave network, pass
 `WEAVE_CIDR=none`, e.g.

--- a/site/weavedns.md
+++ b/site/weavedns.md
@@ -132,16 +132,16 @@ host2$ eval $(weave env)
 host2$ docker run -dti --name=pingme ubuntu
 
 root@ubuntu:/# ping -nq -c 1 pingme
-PING pingme.weave.local (10.128.0.2) 56(84) bytes of data.
+PING pingme.weave.local (10.32.0.2) 56(84) bytes of data.
 ...
 root@ubuntu:/# ping -nq -c 1 pingme
-PING pingme.weave.local (10.160.0.1) 56(84) bytes of data.
+PING pingme.weave.local (10.40.0.1) 56(84) bytes of data.
 ...
 root@ubuntu:/# ping -nq -c 1 pingme
-PING pingme.weave.local (10.160.0.1) 56(84) bytes of data.
+PING pingme.weave.local (10.40.0.1) 56(84) bytes of data.
 ...
 root@ubuntu:/# ping -nq -c 1 pingme
-PING pingme.weave.local (10.128.0.2) 56(84) bytes of data.
+PING pingme.weave.local (10.32.0.2) 56(84) bytes of data.
 ...
 ```
 
@@ -272,9 +272,9 @@ Fallback DNS config &{[10.0.2.3] [] 53 1 5 2}
 Local domain weave.local.
 Interface &{74 65535 ethwe 82:0c:92:84:0e:88 up|broadcast|multicast}
 Zone database:
-144b75a9b873: pingme.weave.local.[10.160.0.1]/OBS:1
-74a5510a91ad: ubuntu.weave.local.[10.160.0.2]
-weave:remote: pingme.weave.local.[10.128.0.2]/TTL:30
+144b75a9b873: pingme.weave.local.[10.40.0.1]/OBS:1
+74a5510a91ad: ubuntu.weave.local.[10.40.0.2]
+weave:remote: pingme.weave.local.[10.32.0.2]/TTL:30
 
 ...
 ````

--- a/weave
+++ b/weave
@@ -986,7 +986,7 @@ launch_router() {
     done
     eval "set -- $ARGS"
     if [ -z "$IPRANGE_SPECIFIED" ] ; then
-        IPRANGE="10.128.0.0/10"
+        IPRANGE="10.32.0.0/12"
         if command_exists netcheck && ! netcheck $IPRANGE ; then
             echo "Default -iprange $IPRANGE overlaps with existing route on host." >&2
             echo "Please pick another range and set it on all hosts." >&2


### PR DESCRIPTION
To avoid clashing with Digital Ocean's and GCE's default private networks.
Fixes #1036 

(note this PR is raised against master; will re-raise if it was supposed to be against 1.0)