### PR TITLE
rename proxy-(env|config) to (env|config)

### DIFF
--- a/site/features.md
+++ b/site/features.md
@@ -143,9 +143,9 @@ Let's begin by configuring weave's allocator to manage multiple
 subnets:
 
     host1$ weave launch -iprange 10.2.0.0/16 -ipsubnet 10.2.1.0/24
-    host1$ eval $(weave proxy-env)
+    host1$ eval $(weave env)
     host2$ weave launch -iprange 10.2.0.0/16 -ipsubnet 10.2.1.0/24 $HOST1
-    host2$ eval $(weave proxy-env)
+    host2$ eval $(weave env)
 
 This delegates the entire 10.2.0.0/16 subnet to weave, and instructs
 it to allocate from 10.2.1.0/24 within that if no specific subnet is

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -49,13 +49,13 @@ All docker commands can be run via the proxy, so it is safe to adjust
 your `DOCKER_HOST` to point at the proxy. Weave provides a convenient
 command for this:
 
-    host1$ eval "$(weave proxy-env)"
+    host1$ eval "$(weave env)"
     host1$ docker ps
     ...
 
 Alternatively, the proxy host can be set on a per-command basis with
 
-    host1$ docker $(weave proxy-config) ps
+    host1$ docker $(weave config) ps
 
 The proxy can be stopped independently with
 
@@ -167,7 +167,7 @@ with
 
     $ mkdir -pv ~/.docker
     $ cp -v {ca,cert,key}.pem ~/.docker
-    $ eval "$(weave proxy-env)"
+    $ eval "$(weave env)"
     $ export DOCKER_TLS_VERIFY=1
     $ docker version
     ...

--- a/site/weavedns.md
+++ b/site/weavedns.md
@@ -33,13 +33,13 @@ Weave Docker API proxy via `launch`:
 
 ```bash
 host1$ weave launch
-host1$ eval $(weave proxy-env)
+host1$ eval $(weave env)
 ```
 or independently via `launch-dns`:
 
 ```bash
 host1$ weave launch-router && weave launch-dns && weave launch-proxy
-host1$ eval $(weave proxy-env)
+host1$ eval $(weave env)
 ```
 
 The first form is more convenient, however you can only pass weaveDNS
@@ -128,7 +128,7 @@ container, this time on the 2nd host, and then run some ping tests...
 
 ```bash
 host2$ weave launch
-host2$ eval $(weave proxy-env)
+host2$ eval $(weave env)
 host2$ docker run -dti --name=pingme ubuntu
 
 root@ubuntu:/# ping -nq -c 1 pingme

--- a/test/650_proxy_env_test.sh
+++ b/test/650_proxy_env_test.sh
@@ -4,15 +4,19 @@
 
 start_suite "Configure the docker daemon for the proxy"
 
+# No output when nothing running
+assert "weave_on $HOST1 env" ""
+assert "weave_on $HOST1 config" ""
+
 weave_on $HOST1 launch-proxy
 
 CMD="run -e WEAVE_CIDR=10.2.1.4/24 $SMALL_IMAGE $CHECK_ETHWE_UP"
-assert_raises "eval '$(weave_on $HOST1 proxy-env)' ; docker $CMD"
-assert_raises "docker $(weave_on $HOST1 proxy-config) $CMD"
+assert_raises "eval '$(weave_on $HOST1 env)' ; docker $CMD"
+assert_raises "docker $(weave_on $HOST1 config) $CMD"
 
 # Check we can use the weave script through the proxy
-assert_raises "eval '$(weave_on $HOST1 proxy-env)' ; $WEAVE version"
-assert_raises "eval '$(weave_on $HOST1 proxy-env)' ; $WEAVE ps"
-assert_raises "eval '$(weave_on $HOST1 proxy-env)' ; $WEAVE launch-router"
+assert_raises "eval '$(weave_on $HOST1 env)' ; $WEAVE version"
+assert_raises "eval '$(weave_on $HOST1 env)' ; $WEAVE ps"
+assert_raises "eval '$(weave_on $HOST1 env)' ; $WEAVE launch-router"
 
 end_suite

--- a/weave
+++ b/weave
@@ -48,8 +48,8 @@ usage() {
     echo "weave hide          [<addr> ...]"
     echo "weave ps            [<container_id> ...]"
     echo "weave status"
-    echo "weave proxy-env"
-    echo "weave proxy-config"
+    echo "weave env"
+    echo "weave config"
     echo "weave version"
     echo "weave stop"
     echo "weave stop-router"
@@ -932,10 +932,9 @@ proxy_args() {
 proxy_addr() {
     if addr=$(docker logs $PROXY_CONTAINER_NAME 2>&1 | head -n3 | grep -oE "proxy listening on .*"); then
       echo "${1}${addr##* }" | sed "s/0.0.0.0/$PROXY_HOST/g"
-      return 0
+    else
+      echo  "$PROXY_CONTAINER_NAME container is not present. Have you launched it?" >&2
     fi
-    echo  "$PROXY_CONTAINER_NAME container is not present. Have you launched it?" >&2
-    return 1
 }
 
 ######################################################################
@@ -1128,10 +1127,12 @@ case "$COMMAND" in
         launch_proxy "$@"
         echo $PROXY_CONTAINER
         ;;
-    proxy-env)
+    env|proxy-env)
+        [ "$COMMAND" = "env" ] || echo "$COMMAND is deprecated, please use 'weave env'" >&2
         proxy_addr "export DOCKER_HOST="
         ;;
-    proxy-config)
+    config|proxy-config)
+        [ "$COMMAND" = "config" ] || echo "$COMMAND is deprecated, please use 'weave config'" >&2
         proxy_addr "-H="
         ;;
     connect)


### PR DESCRIPTION
Keep error message to stderr, as the proxy should be launched with
'weave launch'. Or would you rather have no output at all?

Fixes #1014