### PR TITLE
Consistent option naming

### DIFF
--- a/bin/multiweave
+++ b/bin/multiweave
@@ -30,7 +30,7 @@ case "$1" in
     launch)
         shift 1
         for i in $(seq $START $FINISH); do
-            WEAVE_CONTAINER_NAME=weave$i WEAVE_PORT=$((5000+i)) $weavedir/weave launch-router -iface '' -name $(random_mac) -nickname weave$i -port $PORT "$@"
+            WEAVE_CONTAINER_NAME=weave$i WEAVE_PORT=$((5000+i)) $weavedir/weave launch-router --iface '' --name $(random_mac) --nickname weave$i --port $PORT "$@"
         done
         if [ $START -ne 1 ] ; then
             status=$(docker inspect --format='{{.State.Running}} {{.NetworkSettings.IPAddress}}' weave$((START-1)))

--- a/docs/dockerless.txt
+++ b/docs/dockerless.txt
@@ -125,8 +125,8 @@ VM2> nc 192.168.122.2 6783
 If all is well, you should now be able to launch weave on VM1
 then on VM2:
 
-VM1> weaver -iface veth6 -name vm1
-VM2> weaver -iface veth6 -name vm2 192.168.122.2
+VM1> weaver --iface veth6 --name vm1
+VM2> weaver --iface veth6 --name vm2 192.168.122.2
 
 Once the connection is up and running, you should be able to connect
 from VM1/ns2 to VM2/ns2 and vice versa:

--- a/prog/weavedns/main.go
+++ b/prog/weavedns/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"net"
 	"os"
 	"strconv"
 
+	"github.com/docker/docker/pkg/mflag"
 	"github.com/miekg/dns"
 	. "github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/common/docker"
@@ -42,28 +42,28 @@ func main() {
 		err             error
 	)
 
-	flag.BoolVar(&justVersion, "version", false, "print version and exit")
-	flag.StringVar(&ifaceName, "iface", "", "name of interface to use for multicast")
-	flag.StringVar(&apiPath, "api", "unix:///var/run/docker.sock", "path to Docker API socket")
-	flag.StringVar(&domain, "domain", weavedns.DefaultLocalDomain, "local domain (ie, 'weave.local.')")
-	flag.IntVar(&wait, "wait", -1, "number of seconds to wait for interfaces to come up (0=don't wait, -1=wait forever)")
-	flag.IntVar(&dnsPort, "dnsport", weavedns.DefaultServerPort, "port to listen to DNS requests")
-	flag.StringVar(&httpIfaceName, "httpiface", "", "interface on which to listen for HTTP requests (defaults to empty string which listens on all interfaces)")
-	flag.IntVar(&httpPort, "httpport", weavedns.DefaultHTTPPort, "port to listen to HTTP requests")
-	flag.IntVar(&cacheLen, "cache", weavedns.DefaultCacheLen, "cache length")
-	flag.IntVar(&ttl, "ttl", weavedns.DefaultLocalTTL, "TTL (in secs) for responses for local names")
-	flag.BoolVar(&watch, "watch", true, "watch the docker socket for container events")
-	flag.StringVar(&logLevel, "log-level", "info", "logging level (debug, info, warning, error)")
+	mflag.BoolVar(&justVersion, []string{"#version", "-version"}, false, "print version and exit")
+	mflag.StringVar(&ifaceName, []string{"#iface", "-iface"}, "", "name of interface to use for multicast")
+	mflag.StringVar(&apiPath, []string{"#api", "-api"}, "unix:///var/run/docker.sock", "path to Docker API socket")
+	mflag.StringVar(&domain, []string{"#domain", "-domain"}, weavedns.DefaultLocalDomain, "local domain (ie, 'weave.local.')")
+	mflag.IntVar(&wait, []string{"#wait", "-wait"}, -1, "number of seconds to wait for interfaces to come up (0=don't wait, -1=wait forever)")
+	mflag.IntVar(&dnsPort, []string{"#dnsport", "#-dnsport", "-dns-port"}, weavedns.DefaultServerPort, "port to listen to DNS requests")
+	mflag.StringVar(&httpIfaceName, []string{"#httpiface", "#-httpiface", "-http-iface"}, "", "interface on which to listen for HTTP requests (empty string means listen on all interfaces)")
+	mflag.IntVar(&httpPort, []string{"#httpport", "#-httpport", "-http-port"}, weavedns.DefaultHTTPPort, "port to listen to HTTP requests")
+	mflag.IntVar(&cacheLen, []string{"#cache", "-cache"}, weavedns.DefaultCacheLen, "cache length")
+	mflag.IntVar(&ttl, []string{"#ttl", "-ttl"}, weavedns.DefaultLocalTTL, "TTL (in secs) for responses for local names")
+	mflag.BoolVar(&watch, []string{"#watch", "-watch"}, true, "watch the docker socket for container events")
+	mflag.StringVar(&logLevel, []string{"-log-level"}, "info", "logging level (debug, info, warning, error)")
 	// advanced options
-	flag.IntVar(&negTTL, "neg-ttl", 0, "negative TTL (in secs) for unanswered queries for local names (0=same value as -ttl")
-	flag.IntVar(&refreshInterval, "refresh", weavedns.DefaultRefreshInterval, "refresh interval (in secs) for local names (0=disable)")
-	flag.IntVar(&maxAnswers, "max-answers", weavedns.DefaultMaxAnswers, "maximum number of answers returned to clients (0=unlimited)")
-	flag.IntVar(&relevantTime, "relevant", weavedns.DefaultRelevantTime, "life time for info in the absence of queries (in secs)")
-	flag.IntVar(&udpbuf, "udpbuf", weavedns.DefaultUDPBuflen, "UDP buffer length")
-	flag.IntVar(&timeout, "timeout", weavedns.DefaultTimeout, "timeout for resolutions (in millisecs)")
-	flag.BoolVar(&cacheDisabled, "no-cache", false, "disable the cache")
-	flag.StringVar(&fallback, "fallback", "", "force a fallback server (ie, '8.8.8.8:53') (instead of /etc/resolv.conf values)")
-	flag.Parse()
+	mflag.IntVar(&negTTL, []string{"#neg-ttl", "-neg-ttl"}, 0, "negative TTL (in secs) for unanswered queries for local names (0=same value as --ttl")
+	mflag.IntVar(&refreshInterval, []string{"#refresh", "-refresh"}, weavedns.DefaultRefreshInterval, "refresh interval (in secs) for local names (0=disable)")
+	mflag.IntVar(&maxAnswers, []string{"#max-answers", "#-max-answers", "-dns-max-answers"}, weavedns.DefaultMaxAnswers, "maximum number of answers returned to clients (0=unlimited)")
+	mflag.IntVar(&relevantTime, []string{"#relevant", "-relevant"}, weavedns.DefaultRelevantTime, "life time for info in the absence of queries (in secs)")
+	mflag.IntVar(&udpbuf, []string{"#udpbuf", "#-udpbuf", "-dns-udpbuf"}, weavedns.DefaultUDPBuflen, "UDP buffer length for DNS")
+	mflag.IntVar(&timeout, []string{"#timeout", "#-timeout", "-dns-timeout"}, weavedns.DefaultTimeout, "timeout for resolutions (in millisecs)")
+	mflag.BoolVar(&cacheDisabled, []string{"#no-cache", "-no-cache"}, false, "disable the cache")
+	mflag.StringVar(&fallback, []string{"#fallback", "#-fallback", "-dns-fallback"}, "", "force a fallback server (ie, '8.8.8.8:53') (instead of /etc/resolv.conf values)")
+	mflag.Parse()
 
 	if justVersion {
 		fmt.Printf("weave DNS %s\n", version)

--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pborman/getopt"
+	"github.com/docker/docker/pkg/mflag"
 	. "github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/proxy"
 )
@@ -15,27 +15,51 @@ var (
 	defaultListenAddrs = []string{"tcp://0.0.0.0:12375", "unix:///var/run/weave.sock"}
 )
 
+type listOpts struct {
+	value      *[]string
+	hasBeenSet bool
+}
+
+func ListVar(p *[]string, names []string, value []string, usage string) {
+	*p = value
+	mflag.Var(&listOpts{p, false}, names, usage)
+}
+
+func (opts *listOpts) Set(value string) error {
+	if opts.hasBeenSet {
+		(*opts.value) = append((*opts.value), value)
+	} else {
+		(*opts.value) = []string{value}
+		opts.hasBeenSet = true
+	}
+	return nil
+}
+
+func (opts *listOpts) String() string {
+	return fmt.Sprintf("%v", []string(*opts.value))
+}
+
 func main() {
 	var (
 		justVersion bool
 		logLevel    = "info"
-		c           = proxy.Config{ListenAddrs: defaultListenAddrs}
+		c           = proxy.Config{ListenAddrs: []string{}}
 	)
 
 	c.Version = version
-	getopt.BoolVarLong(&justVersion, "version", 0, "print version and exit")
-	getopt.StringVarLong(&logLevel, "log-level", 0, "logging level (debug, info, warning, error)", "info")
-	getopt.ListVar(&c.ListenAddrs, 'H', fmt.Sprintf("address on which to listen (default %s)", defaultListenAddrs))
-	getopt.BoolVarLong(&c.NoDefaultIPAM, "no-default-ipalloc", 0, "do not automatically allocate addresses for containers without a WEAVE_CIDR")
-	getopt.BoolVarLong(&c.NoDefaultIPAM, "no-default-ipam", 0, "do not automatically allocate addresses for containers without a WEAVE_CIDR (deprecated; please use --no-default-ipalloc")
-	getopt.StringVarLong(&c.TLSConfig.CACert, "tlscacert", 0, "Trust certs signed only by this CA")
-	getopt.StringVarLong(&c.TLSConfig.Cert, "tlscert", 0, "Path to TLS certificate file")
-	getopt.BoolVarLong(&c.TLSConfig.Enabled, "tls", 0, "Use TLS; implied by --tlsverify")
-	getopt.StringVarLong(&c.TLSConfig.Key, "tlskey", 0, "Path to TLS key file")
-	getopt.BoolVarLong(&c.TLSConfig.Verify, "tlsverify", 0, "Use TLS and verify the remote")
-	getopt.BoolVarLong(&c.WithDNS, "with-dns", 'w', "instruct created containers to always use weaveDNS as their nameserver")
-	getopt.BoolVarLong(&c.WithoutDNS, "without-dns", 0, "instruct created containers to never use weaveDNS as their nameserver")
-	getopt.Parse()
+
+	mflag.BoolVar(&justVersion, []string{"#version", "-version"}, false, "print version and exit")
+	mflag.StringVar(&logLevel, []string{"-log-level"}, "info", "logging level (debug, info, warning, error)")
+	ListVar(&c.ListenAddrs, []string{"H"}, defaultListenAddrs, "addresses on which to listen")
+	mflag.BoolVar(&c.NoDefaultIPAM, []string{"#-no-default-ipam", "-no-default-ipalloc"}, false, "do not automatically allocate addresses for containers without a WEAVE_CIDR")
+	mflag.StringVar(&c.TLSConfig.CACert, []string{"#tlscacert", "-tlscacert"}, "", "Trust certs signed only by this CA")
+	mflag.StringVar(&c.TLSConfig.Cert, []string{"#tlscert", "-tlscert"}, "", "Path to TLS certificate file")
+	mflag.BoolVar(&c.TLSConfig.Enabled, []string{"#tls", "-tls"}, false, "Use TLS; implied by --tls-verify")
+	mflag.StringVar(&c.TLSConfig.Key, []string{"#tlskey", "-tlskey"}, "", "Path to TLS key file")
+	mflag.BoolVar(&c.TLSConfig.Verify, []string{"#tlsverify", "-tlsverify"}, false, "Use TLS and verify the remote")
+	mflag.BoolVar(&c.WithDNS, []string{"-with-dns", "w"}, false, "instruct created containers to always use weaveDNS as their nameserver")
+	mflag.BoolVar(&c.WithoutDNS, []string{"-without-dns"}, false, "instruct created containers to never use weaveDNS as their nameserver")
+	mflag.Parse()
 
 	if justVersion {
 		fmt.Printf("weave proxy %s\n", version)

--- a/site/features.md
+++ b/site/features.md
@@ -142,9 +142,9 @@ To accomplish that, we assign each application a different subnet.
 Let's begin by configuring weave's allocator to manage multiple
 subnets:
 
-    host1$ weave launch -iprange 10.2.0.0/16 -ipsubnet 10.2.1.0/24
+    host1$ weave launch --ipalloc-range 10.2.0.0/16 --ipalloc-default-subnet 10.2.1.0/24
     host1$ eval $(weave env)
-    host2$ weave launch -iprange 10.2.0.0/16 -ipsubnet 10.2.1.0/24 $HOST1
+    host2$ weave launch --ipalloc-range 10.2.0.0/16 --ipalloc-default-subnet 10.2.1.0/24 $HOST1
     host2$ eval $(weave env)
 
 This delegates the entire 10.2.0.0/16 subnet to weave, and instructs
@@ -251,10 +251,10 @@ invocation:
 ### <a name="security"></a>Security
 
 In order to connect containers across untrusted networks, weave peers
-can be told to encrypt traffic by supplying a `-password` option or
+can be told to encrypt traffic by supplying a `--password` option or
 `WEAVE_PASSWORD` environment variable when launching weave, e.g.
 
-    host1$ weave launch -password wEaVe
+    host1$ weave launch --password wEaVe
 
 or
 
@@ -496,9 +496,9 @@ and the new hosts will be added, when one runs
     host# weave connect --replace $NEW_HOST1 $NEW_HOST2
 
 For complete control over the peer topology, automatic discovery can
-be disabled with the `-nodiscovery` option to `weave launch`. In this
-mode, weave will only connect to the addresses specified at launch
-time and with `weave connect`.
+be disabled with the `--no-discovery` option to `weave launch`. In
+this mode, weave will only connect to the addresses specified at
+launch time and with `weave connect`.
 
 ### <a name="container-mobility"></a>Container mobility
 

--- a/site/ipam.md
+++ b/site/ipam.md
@@ -26,8 +26,8 @@ in the whole network, weave needs a majority of peers to be present in
 order to avoid formation of isolated groups, which could lead to
 inconsistency, i.e. the same IP address being allocated to two
 different containers. Therefore, you must either supply the list of
-all peers in the network to `weave launch` or add the `-initpeercount`
-flag to specify how many peers there will be.
+all peers in the network to `weave launch` or add the
+`--init-peer-count` flag to specify how many peers there will be.
 
 To illustrate, suppose you have three hosts, accessible to each other
 as `$HOST1`, `$HOST2` and `$HOST3`. You can start weave on those three
@@ -42,13 +42,13 @@ hosts with these three commands:
 Or, if it is not convenient to name all the other hosts at launch
 time, you can give the number of peers like this:
 
-    host1$ weave launch -initpeercount 3
+    host1$ weave launch --init-peer-count 3
 
-    host2$ weave launch -initpeercount 3 $HOST3
+    host2$ weave launch --init-peer-count 3 $HOST3
 
-    host3$ weave launch -initpeercount 3 $HOST2
+    host3$ weave launch --init-peer-count 3 $HOST2
 
-### More on `-initpeercount`
+### More on `--init-peer-count`
 
 TL;DR: it isn't a problem to over-estimate by a bit, but if you supply
 a number that is too small then multiple independent groups may form.
@@ -88,9 +88,9 @@ would be safe wrt weave's startup quorum:
 ## <a name="range"></a>Choosing an allocation range
 
 By default, weave will allocate IP addresses in the 10.32.0.0/12
-range. This can be overridden with the `-iprange` option, e.g.
+range. This can be overridden with the `--ipalloc-range` option, e.g.
 
-    host1$ weave launch -iprange 10.2.0.0/16
+    host1$ weave launch --ipalloc-range 10.2.0.0/16
 
 and must be the same on every host.
 
@@ -135,13 +135,13 @@ for instance:
 When working with multiple subnets in this way, it is usually
 desirable to constrain the default subnet - i.e. the one chosen by the
 allocator when no subnet is supplied - so that it does not overlap
-with others. One can specify that with `-ipsubnet`:
+with others. One can specify that with `--ipalloc-default-subnet`:
 
-    host1$ weave launch -iprange 10.2.0.0/16 -ipsubnet 10.2.3.0/24
+    host1$ weave launch --ipalloc-range 10.2.0.0/16 --ipalloc-default-subnet 10.2.3.0/24
 
-`-iprange` should cover the entire range that you will ever use for
-allocation, and `-ipsubnet` is the subnet that will be used when you
-don't explicitly specify one.
+`--ipalloc-range` should cover the entire range that you will ever use
+for allocation, and `--ipalloc-default-subnet` is the subnet that will
+be used when you don't explicitly specify one.
 
 When specifying addresses, the default subnet can be denoted
 symbolically with `net:default`.
@@ -151,10 +151,10 @@ symbolically with `net:default`.
 If you want to start containers with a mixture of
 automatically-allocated addresses and manually-chosen addresses, *and
 have the containers communicate with each other*, you can choose a
-`-iprange` that is smaller than `-ipsubnet`, For example, if you
-launch weave with:
+`--ipalloc-range` that is smaller than `--ip-default-subnet`, For
+example, if you launch weave with:
 
-    host1$ weave launch -iprange 10.9.0.0/17 -ipsubnet 10.9.0.0/16
+    host1$ weave launch --ipalloc-range 10.9.0.0/17 --ipalloc-default-subnet 10.9.0.0/16
 
 then you can run all containers in the 10.9.0.0/16 subnet, with
 automatic allocation using the lower half, leaving the upper half free
@@ -213,8 +213,8 @@ The first section covers the router; see the [troubleshooting
 guide](troubleshooting.html#status-report) for full details.
 
 The 'Allocator' section, which is only present if weave has been
-started with the `-iprange` option, summarises the overall position and
-lists which address ranges have been assigned to which peer. Each
-range begins at the address shown and ends just before the next
-address, or wraps around at the end of the subnet. The 'v' number
+started with the `--ipalloc-range` option, summarises the overall
+position and lists which address ranges have been assigned to which
+peer. Each range begins at the address shown and ends just before the
+next address, or wraps around at the end of the subnet. The 'v' number
 denotes how many times that entry has been updated.

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -140,8 +140,8 @@ TLS-related command-line flags as supplied to the docker daemon. For
 example, if you have generated your certificates and keys into the
 docker host's `/tls` directory, we can launch the proxy with:
 
-    host1$ weave launch-proxy --tlsverify --tlscacert=/tls/ca.pem \
-             --tlscert=/tls/server-cert.pem --tlskey=/tls/server-key.pem
+    host1$ weave launch-proxy --tls-verify --tls-cacert=/tls/ca.pem \
+             --tls-cert=/tls/server-cert.pem --tls-key=/tls/server-key.pem
 
 The paths to your certificates and key must be provided as absolute
 paths which exist on the docker host.
@@ -157,8 +157,8 @@ for an example.
 With the proxy running over TLS, we can configure our regular docker
 client to use TLS on a per-invocation basis with
 
-    $ docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem \
-         --tlskey=key.pem -H=tcp://host1:12375 version
+    $ docker --tls-verify --tls-cacert=ca.pem --tls-cert=cert.pem \
+         --tls-key=key.pem -H=tcp://host1:12375 version
     ...
 
 or,

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -22,8 +22,8 @@ A reasonable amount of information, and all errors, get logged there.
 
 The log verbosity can be increased by supplying the
 `--log-level=debug` option when launching weave. To log information on
-a per-packet basis use `-pktdebug` - be warned, this can produce a lot
-of output.
+a per-packet basis use `--pktdebug` - be warned, this can produce a
+lot of output.
 
 Another useful debugging technique is to attach standard packet
 capture and analysis tools, such as tcpdump and wireshark, to the
@@ -96,7 +96,7 @@ The 'Our name' line identifies the local weave router as a peer in the
 weave network, displaying the peer name followed by the peer's nickname
 in parenthesis. The nickname defaults to the name of the host on which
 the weave container was launched; if desired it can be overriden by
-supplying the `-nickname` argument to `weave launch`.
+supplying the `--nickname` argument to `weave launch`.
 
 The 'Sniffing traffic' line shows details of the virtual ethernet
 interface that weave is using to receive packets on the local

--- a/test/100_cross_hosts_test.sh
+++ b/test/100_cross_hosts_test.sh
@@ -10,8 +10,8 @@ SUBNET_2=10.2.3.0/24
 
 start_suite "Ping over cross-host weave network (with and without IPAM)"
 
-weave_on $HOST1 launch -iprange $UNIVERSE -ipsubnet $SUBNET_1
-weave_on $HOST2 launch -iprange $UNIVERSE -ipsubnet $SUBNET_1 $HOST1
+weave_on $HOST1 launch --ipalloc-range $UNIVERSE --ipalloc-default-subnet $SUBNET_1
+weave_on $HOST2 launch --ipalloc-range $UNIVERSE --ipalloc-default-subnet $SUBNET_1 $HOST1
 
 start_container $HOST1    $C1/24     --name=c1
 start_container $HOST2 ip:$C2/24     --name=c2

--- a/test/110_encryption_test.sh
+++ b/test/110_encryption_test.sh
@@ -7,8 +7,8 @@ C2=10.2.1.7
 
 start_suite "Ping over encrypted cross-host weave network"
 
-weave_on $HOST1 launch -password notverysecure
-weave_on $HOST2 launch -password notverysecure $HOST1
+weave_on $HOST1 launch --password notverysecure
+weave_on $HOST2 launch --password notverysecure $HOST1
 
 start_container $HOST1 $C1/24 --name=c1
 start_container $HOST2 $C2/24 --name=c2

--- a/test/130_expose_test.sh
+++ b/test/130_expose_test.sh
@@ -40,7 +40,7 @@ run_on1   "  $PING $EXP"
 weave_on1 "hide    $EXP/24"
 run_on1   "! $PING $EXP"
 
-weave_on $HOST1 launch -iprange $UNIVERSE
+weave_on $HOST1 launch --ipalloc-range $UNIVERSE
 
 start_container $HOST1 $C1/24 --name=c1
 start_container $HOST1 $C2/24 --name=c2

--- a/test/140_weave_local_test.sh
+++ b/test/140_weave_local_test.sh
@@ -6,7 +6,7 @@ start_suite "Run weave with --local"
 
 run_on $HOST1 sudo weave --local reset
 
-run_on $HOST1 sudo weave --local launch -iprange 10.2.5.0/24
+run_on $HOST1 sudo weave --local launch --ipalloc-range 10.2.5.0/24
 assert_raises "docker_on $HOST1 ps | grep weave"
 
 run_on $HOST1 sudo weave --local run 10.2.6.5/24 -ti --name=c1 $SMALL_IMAGE /bin/sh

--- a/test/210_dns_multicast_test.sh
+++ b/test/210_dns_multicast_test.sh
@@ -29,8 +29,8 @@ check() {
 
 start_suite "Resolve names across hosts (with and without IPAM), and repopulate on restart"
 
-weave_on $HOST1 launch-router -iprange $UNIVERSE
-weave_on $HOST2 launch-router -iprange $UNIVERSE $HOST1
+weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE
+weave_on $HOST2 launch-router --ipalloc-range $UNIVERSE $HOST1
 
 start_container          $HOST2 $C2/24 --name=c2 -h $NAME2
 start_container_with_dns $HOST1 $C1/24 --name=c1

--- a/test/270_use_name_as_hostname_test.sh
+++ b/test/270_use_name_as_hostname_test.sh
@@ -22,7 +22,7 @@ assert_expected_fqdn() {
 
 start_suite "Use container name as hostname"
 
-weave_on $HOST1 launch -iprange 10.2.0.0/24
+weave_on $HOST1 launch --ipalloc-range 10.2.0.0/24
 
 assert_expected_fqdn "$NAME.$DOMAIN" --name=$NAME
 assert_expected_fqdn "$NAME.$DOMAIN" --name $NAME

--- a/test/500_weave_multi_cidr_test.sh
+++ b/test/500_weave_multi_cidr_test.sh
@@ -73,7 +73,7 @@ start_suite "Weave run/start/attach/detach/expose/hide with multiple cidr argume
 # specific address, i.e. we are assuming that IPAM always returns the
 # lowest available address in the subnet
 
-weave_on $HOST1 launch-router -iprange 10.2.3.0/24
+weave_on $HOST1 launch-router --ipalloc-range 10.2.3.0/24
 launch_dns_on $HOST1 10.254.254.254/24
 
 # Run container with three cidrs

--- a/test/620_proxy_entrypoint_command_test.sh
+++ b/test/620_proxy_entrypoint_command_test.sh
@@ -26,7 +26,7 @@ run_container "grep ^1$ /sys/class/net/ethwe/carrier"
 build_image false '["/bin/false"]' ''
 run_container "--entrypoint='grep' false ^1$ /sys/class/net/ethwe/carrier"
 
-weave_on $HOST1 launch-router -iprange 10.2.2.0/24
+weave_on $HOST1 launch-router --ipalloc-range 10.2.2.0/24
 docker_on $HOST1 kill weaveproxy
 weave_on $HOST1 launch-proxy
 

--- a/test/660_proxy_ipam_test.sh
+++ b/test/660_proxy_ipam_test.sh
@@ -17,8 +17,8 @@ assert_no_ethwe() {
 
 start_suite "Ping proxied containers over cross-host weave network (with IPAM)"
 
-weave_on $HOST1 launch-router -iprange $UNIVERSE
-weave_on $HOST2 launch-router -iprange $UNIVERSE $HOST1
+weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE
+weave_on $HOST2 launch-router --ipalloc-range $UNIVERSE $HOST1
 weave_on $HOST1 launch-proxy
 weave_on $HOST2 launch-proxy --no-default-ipalloc
 

--- a/weave
+++ b/weave
@@ -890,9 +890,8 @@ show_addrs() {
 # TODO: Handle relative paths for args
 # TODO: Handle args with spaces
 tls_arg() {
-    filename=${3:-$2}
-    PROXY_VOLUMES="$PROXY_VOLUMES -v $1:/home/weave/tls/$filename.pem"
-    PROXY_ARGS="$PROXY_ARGS --tls$2 /home/weave/tls/$filename.pem"
+    PROXY_VOLUMES="$PROXY_VOLUMES -v $2:/home/weave/tls/$3.pem"
+    PROXY_ARGS="$PROXY_ARGS $1 /home/weave/tls/$3.pem"
 }
 
 proxy_args() {
@@ -901,25 +900,25 @@ proxy_args() {
     while [ $# -gt 0 ]; do
         case "$1" in
           --tlscacert)
+            tls_arg "$1" "$2" ca
             shift
-            tls_arg "$1" cacert ca
             ;;
           --tlscacert=*)
-            tls_arg "${1#*=}" cacert ca
+            tls_arg "${1%%=*}" "${1#*=}" ca
             ;;
           --tlscert)
+            tls_arg "$1" "$2" cert
             shift
-            tls_arg "$1" cert
             ;;
           --tlscert=*)
-            tls_arg "${1#*=}" cert
+            tls_arg "${1%%=*}" "${1#*=}" cert
             ;;
           --tlskey)
+            tls_arg "$1" "$2" key
             shift
-            tls_arg "$1" key
             ;;
           --tlskey=*)
-            tls_arg "${1#*=}" key
+            tls_arg "${1%%=*}" "${1#*=}" key
             ;;
           *)
             PROXY_ARGS="$PROXY_ARGS $1"
@@ -973,18 +972,18 @@ launch_router() {
     IPRANGE_SPECIFIED=
     while [ $# -gt 0 ] ; do
         case "$1" in
-            -password)
+            -password|--password)
                 [ $# -gt 1 ] || usage
                 WEAVE_PASSWORD="$2"
                 export WEAVE_PASSWORD
                 shift 2
                 ;;
-            -port)
+            -port|--port)
                 [ $# -gt 1 ] || usage
                 CONTAINER_PORT="$2"
                 shift 2
                 ;;
-            -iprange)
+            -iprange|--iprange|--ipalloc-range)
                 [ $# -gt 1 ] || usage
                 IPRANGE="$2"
                 IPRANGE_SPECIFIED=1
@@ -1000,7 +999,7 @@ launch_router() {
     if [ -z "$IPRANGE_SPECIFIED" ] ; then
         IPRANGE="10.32.0.0/12"
         if command_exists netcheck && ! netcheck $IPRANGE ; then
-            echo "Default -iprange $IPRANGE overlaps with existing route on host." >&2
+            echo "Default --ipalloc-range $IPRANGE overlaps with existing route on host." >&2
             echo "Please pick another range and set it on all hosts." >&2
             exit 1
         fi
@@ -1013,7 +1012,7 @@ launch_router() {
         -v /var/run/docker.sock:/var/run/docker.sock \
         -e WEAVE_PASSWORD \
         -e WEAVE_CIDR=none \
-        $WEAVE_DOCKER_ARGS $IMAGE -iface $CONTAINER_IFNAME -port $CONTAINER_PORT -name "$PEERNAME" -nickname "$(hostname)" -iprange "$IPRANGE" "$@")
+        $WEAVE_DOCKER_ARGS $IMAGE --iface $CONTAINER_IFNAME --port $CONTAINER_PORT --name "$PEERNAME" --nickname "$(hostname)" --ipalloc-range "$IPRANGE" "$@")
     with_container_netns_or_die $CONTAINER launch
     wait_for_status $CONTAINER_NAME $HTTP_PORT
     if [ -n "$IPRANGE" ] ; then
@@ -1035,7 +1034,7 @@ launch_dns() {
         -p $DOCKER_BRIDGE_IP:53:53/udp \
         -e WEAVE_CIDR=none \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        $WEAVEDNS_DOCKER_ARGS $DNS_IMAGE -iface $CONTAINER_IFNAME -httpiface "$DNS_HTTP_IFNAME" "$@")
+        $WEAVEDNS_DOCKER_ARGS $DNS_IMAGE --iface $CONTAINER_IFNAME --http-iface "$DNS_HTTP_IFNAME" "$@")
     ipam_cidrs_or_die $DNS_CONTAINER $CIDR_ARGS
     with_container_netns_or_die $DNS_CONTAINER attach $ALL_CIDRS
     populate_dns

--- a/weave
+++ b/weave
@@ -1148,30 +1148,6 @@ deprecation_warnings() {
             -no-default-ipam|--no-default-ipam)
                 deprecation_warning $1 "--no-default-ipalloc"
                 ;;
-            --tlscacert|--tlscacert=*)
-                deprecation_warning "--tlscacert" "--tls-cacert"
-                [ "$1" == "--tlscacert" ] && shift
-                ;;
-            --tls-cacert)
-                shift
-                ;;
-            --tlscert|--tlscert=*)
-                deprecation_warning "--tlscert" "--tls-cert"
-                [ "$1" == "--tlscert" ] && shift
-                ;;
-            --tls-cert)
-                shift
-                ;;
-            --tlskey|--tlskey=*)
-                deprecation_warning "--tlskey" "--tls-key"
-                [ "$1" == "--tlskey" ] && shift
-                ;;
-            --tls-key)
-                shift
-                ;;
-            --tlsverify)
-                deprecation_warning "--tlsverify" "--tls-verify"
-                ;;
         esac
         shift
     done

--- a/weave
+++ b/weave
@@ -26,19 +26,19 @@ CIDR_REGEXP="$IP_REGEXP/[0-9]{1,2}"
 usage() {
     echo "Usage:"
     echo "weave setup"
-    echo "weave launch        [-password <password>] [-nickname <nickname>] [-nodiscovery]"
-    echo "                        [-iprange <cidr> [-ipsubnet <cidr>]]"
-    echo "                        [-initpeercount <count>] <peer> ..."
-    echo "weave launch-router [-password <password>] [-nickname <nickname>] [-nodiscovery]"
-    echo "                        [-iprange <cidr> [-ipsubnet <cidr>]]"
-    echo "                        [-initpeercount <count>] <peer> ..."
+    echo "weave launch        [--password <password>] [--nickname <nickname>]"
+    echo "                      [--ipalloc-range <cidr> [--ipalloc-default-subnet <cidr>]]"
+    echo "                      [--no-discovery] [--init-peer-count <count>] <peer> ..."
+    echo "weave launch-router [--password <password>] [--nickname <nickname>]"
+    echo "                      [--ipalloc-range <cidr> [--ipalloc-default-subnet <cidr>]]"
+    echo "                      [--no-discovery] [--init-peer-count <count>] <peer> ..."
     echo "weave launch-dns    [<addr>]"
     echo "weave launch-proxy  [-H <endpoint>] [--with-dns | --without-dns]"
-    echo "                        [--no-default-ipalloc]"
+    echo "                      [--no-default-ipalloc]"
     echo "weave connect       [--replace] [<peer> ...]"
     echo "weave forget        <peer> ..."
     echo "weave run           [--with-dns | --without-dns] [<addr> ...]"
-    echo "                        <docker run args> ..."
+    echo "                      <docker run args> ..."
     echo "weave start         [<addr> ...] <container_id>"
     echo "weave attach        [<addr> ...] <container_id>"
     echo "weave detach        [<addr> ...] <container_id>"
@@ -1100,6 +1100,83 @@ DOCKER_VERSION_MAJOR=$(echo "$DOCKER_VERSION" | cut -d. -f 1)
 DOCKER_VERSION_MINOR=$(echo "$DOCKER_VERSION" | cut -d. -f 2)
 DOCKER_VERSION_PATCH=$(echo "$DOCKER_VERSION" | cut -d. -f 3)
 
+deprecation_warning() {
+    echo "Warning: ${1%=*} is deprecated; please use $2" >&2
+}
+
+deprecation_warnings() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -password|-password=*)
+                deprecation_warning $1 "--password"
+                [ "$1" == "-password" ] && shift
+                ;;
+            --password)
+                shift
+                ;;
+            -nickname|-nickname=*)
+                deprecation_warning $1 "--nickname"
+                [ "$1" == "-nickname" ] && shift
+                ;;
+            --nickname)
+                shift
+                ;;
+            -nodiscovery|--nodiscovery)
+                deprecation_warning $1 "--no-discovery"
+                ;;
+            -iprange|--iprange|-iprange=*|--iprange=*)
+                deprecation_warning $1 "--ipalloc-range"
+                [ ${1#--} == "iprange" ] && shift
+                ;;
+            --ipalloc-range)
+                shift
+                ;;
+            -ipsubnet|--ipsubnet|-ipsubnet=*|--ipsubnet=*)
+                deprecation_warning $1 "--ipalloc-default-subnet"
+                [ ${1#--} == "ipsubnet" ] && shift
+                ;;
+            --ipalloc-default-subnet)
+                shift
+                ;;
+            -initpeercount|--initpeercount|-initpeercount=*|--initpeercount=*)
+                deprecation_warning $1 "--init-peer-count"
+                [ ${1#--} == "initpeercount" ] && shift
+                ;;
+            --init-peer-count)
+                shift
+                ;;
+            -no-default-ipam|--no-default-ipam)
+                deprecation_warning $1 "--no-default-ipalloc"
+                ;;
+            --tlscacert|--tlscacert=*)
+                deprecation_warning "--tlscacert" "--tls-cacert"
+                [ "$1" == "--tlscacert" ] && shift
+                ;;
+            --tls-cacert)
+                shift
+                ;;
+            --tlscert|--tlscert=*)
+                deprecation_warning "--tlscert" "--tls-cert"
+                [ "$1" == "--tlscert" ] && shift
+                ;;
+            --tls-cert)
+                shift
+                ;;
+            --tlskey|--tlskey=*)
+                deprecation_warning "--tlskey" "--tls-key"
+                [ "$1" == "--tlskey" ] && shift
+                ;;
+            --tls-key)
+                shift
+                ;;
+            --tlsverify)
+                deprecation_warning "--tlsverify" "--tls-verify"
+                ;;
+        esac
+        shift
+    done
+}
+
 [ $# -gt 0 ] || usage
 COMMAND=$1
 shift 1
@@ -1116,6 +1193,7 @@ case "$COMMAND" in
         create_bridge --without-ethtool
         ;;
     launch)
+        deprecation_warnings "$@"
         check_not_running $CONTAINER_NAME       $BASE_IMAGE
         check_not_running $DNS_CONTAINER_NAME   $BASE_DNS_IMAGE
         check_not_running $PROXY_CONTAINER_NAME $EXEC_IMAGE
@@ -1125,6 +1203,7 @@ case "$COMMAND" in
         launch_proxy  $COMMON_ARGS
         ;;
     launch-router)
+        deprecation_warnings "$@"
         check_not_running $CONTAINER_NAME $BASE_IMAGE
         launch_router "$@"
         echo $CONTAINER
@@ -1135,16 +1214,17 @@ case "$COMMAND" in
         echo $DNS_CONTAINER
         ;;
     launch-proxy)
+        deprecation_warnings "$@"
         check_not_running $PROXY_CONTAINER_NAME $EXEC_IMAGE
         launch_proxy "$@"
         echo $PROXY_CONTAINER
         ;;
     env|proxy-env)
-        [ "$COMMAND" = "env" ] || echo "$COMMAND is deprecated, please use 'weave env'" >&2
+        [ "$COMMAND" = "env" ] || deprecation_warning "$COMMAND" "'weave env'"
         proxy_addr "export DOCKER_HOST="
         ;;
     config|proxy-config)
-        [ "$COMMAND" = "config" ] || echo "$COMMAND is deprecated, please use 'weave config'" >&2
+        [ "$COMMAND" = "config" ] || deprecation_warning "$COMMAND" "'weave config'"
         proxy_addr "-H="
         ;;
     connect)


### PR DESCRIPTION
Namely:

 * long options get two hyphens at the start; e.g., `--password`; and,
 * options made from multiple whole words are hyphenated; e.g., `--no-discovery`; and,
 * some options that are applied to DNS but sound universal have `dns` prepended, e.g., `--dns-port`.

There are exceptions; "ipalloc" is treated as one word for hyphenation; the `--tls*` options are left as-is since they correspond to Docker options; some niche options don't get hyphenated e.g., `--bufsz`; some options that are likely to disappear are left alone.

In all cases, the old version of an option will work, while outputting a deprecation warning. Mostly these will end up in container logs. Renamed options that are mentioned in the script usage, or otherwise specially-treated in the script, have a deprecation notice output to the console.

Closes #602 and closes #1035.