### PR TITLE
Handle --option=value as well as --option value

### DIFF
--- a/weave
+++ b/weave
@@ -944,8 +944,14 @@ common_launch_args() {
     args=""
     while [ $# -gt 0 ] ; do
         case "$1" in
+            --log-level)
+                [ $# -gt 1 ] || usage
+                args="$args $1 $2"
+                shift
+                ;;
             --log-level=*)
                 args="$args $1"
+                ;;
         esac
         shift
     done
@@ -978,16 +984,30 @@ launch_router() {
                 export WEAVE_PASSWORD
                 shift 2
                 ;;
+            --password=*)
+                WEAVE_PASSWORD="${1#*=}"
+                export WEAVE_PASSWORD
+                shift
+                ;;
             -port|--port)
                 [ $# -gt 1 ] || usage
                 CONTAINER_PORT="$2"
                 shift 2
+                ;;
+            --port=*)
+                CONTAINER_PORT="${1#*=}"
+                shift
                 ;;
             -iprange|--iprange|--ipalloc-range)
                 [ $# -gt 1 ] || usage
                 IPRANGE="$2"
                 IPRANGE_SPECIFIED=1
                 shift 2
+                ;;
+            --ipalloc-range=*)
+                IPRANGE="${1#*=}"
+                IPRANGE_SPECIFIED=1
+                shift
                 ;;
             *)
                 ARGS="$ARGS '$(echo "$1" | sed "s|'|'\"'\"'|g")'"


### PR DESCRIPTION
In any place we munge options, treat the form with an equals the same
as the form without.

The exes ultimately invoked by the script handle both forms, so unless
we need to do something with the option in the script, we can just let
options fall through.

Fixes #1087.