### PR TITLE
WIP peer discovery using swarm discovery backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,12 +36,11 @@ prog/weaveproxy/weaveproxy
 prog/sigproxy/sigproxy
 prog/weavewait/weavewait
 prog/netcheck/netcheck
+prog/weavediscovery/weavediscovery
 tools/bin
 tools/build
 releases
-.weaver.uptodate
-.weavedns.uptodate
-.weaveexec.uptodate
+*.uptodate
 weave.tar
 prog/weaveexec/weave
 prog/weaveexec/weaveproxy

--- a/prog/weavediscovery/Dockerfile
+++ b/prog/weavediscovery/Dockerfile
@@ -1,0 +1,6 @@
+FROM scratch
+MAINTAINER Weaveworks Inc <help@weave.works>
+WORKDIR /home/weave
+ADD ./weavediscovery /home/weave/
+EXPOSE 6789/tcp
+ENTRYPOINT ["/home/weave/weavediscovery"]

--- a/prog/weavediscovery/http.go
+++ b/prog/weavediscovery/http.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+	. "github.com/weaveworks/weave/common"
+	weavenet "github.com/weaveworks/weave/net"
+)
+
+const (
+	defaultHTTPPort = 6789                    // default port for the Discovery API
+	defaultWeaveURL = "http://127.0.0.1:6784" // default URL for the router API
+)
+
+type WeaveClient struct {
+	url url.URL
+}
+
+// Create a new Weave API client
+func NewWeaveClient(u string) (*WeaveClient, error) {
+	fullURL, err := url.Parse(u)
+	if err != nil {
+		Log.Error(err)
+		return nil, err
+	}
+
+	Log.Printf("[client] Starting Weave client: API at %s", fullURL)
+	cli := WeaveClient{
+		url: *fullURL,
+	}
+
+	return &cli, nil
+}
+
+// Join a new peer
+func (w *WeaveClient) Join(host, port string) {
+	connectURL := w.url
+	connectURL.Path = "/connect"
+
+	Log.Printf("[client] Notifying about '%s' (API: '%s')", host, connectURL.String())
+	_, err := http.PostForm(connectURL.String(), url.Values{"peer": {host}})
+	if err != nil {
+		Log.Warningf("[client] Could not notify about '%s': %s", host, err)
+	}
+}
+
+// Forget about a peer
+func (w *WeaveClient) Forget(host, port string) {
+	forgetURL := w.url
+	forgetURL.Path = "/forget"
+
+	Log.Printf("[client] Forgetting about '%s' (API: '%s')", host, forgetURL.String())
+	_, err := http.PostForm(forgetURL.String(), url.Values{"peer": {host}})
+	if err != nil {
+		Log.Warningf("[client] Could not forget about '%s': %s", host, err)
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+
+type DiscoveryHTTPConfig struct {
+	Manager   *DiscoveryManager
+	Iface     string
+	Port      int
+	Wait      int
+	Heartbeat time.Duration
+	TTL       time.Duration
+}
+
+type DiscoveryHTTP struct {
+	dm         *DiscoveryManager
+	defaultHb  time.Duration
+	defaultTTL time.Duration
+	listener   net.Listener
+}
+
+func NewDiscoveryHTTP(config DiscoveryHTTPConfig) *DiscoveryHTTP {
+	var httpIP string
+	if config.Iface == "" {
+		httpIP = "0.0.0.0"
+	} else {
+		Log.Infoln("[http] Waiting for HTTP interface", config.Iface, "to come up")
+		httpIface, err := weavenet.EnsureInterface(config.Iface, config.Wait)
+		if err != nil {
+			Log.Fatal(err)
+		}
+		Log.Infoln("[http] Interface", config.Iface, "is up")
+
+		addrs, err := httpIface.Addrs()
+		if err != nil {
+			Log.Fatal(err)
+		}
+
+		if len(addrs) == 0 {
+			Log.Fatal("[http] No addresses on HTTP interface")
+		}
+
+		ip, _, err := net.ParseCIDR(addrs[0].String())
+		if err != nil {
+			Log.Fatal(err)
+		}
+
+		httpIP = ip.String()
+
+	}
+	httpAddr := net.JoinHostPort(httpIP, strconv.Itoa(config.Port))
+
+	httpListener, err := net.Listen("tcp", httpAddr)
+	if err != nil {
+		Log.Fatal("[http] Unable to create HTTP listener: ", err)
+	}
+	Log.Infoln("[http] HTTP API listening on", httpAddr)
+
+	return &DiscoveryHTTP{
+		dm:         config.Manager,
+		listener:   httpListener,
+		defaultHb:  config.Heartbeat,
+		defaultTTL: config.TTL,
+	}
+}
+
+// Start the HTTP API
+func (dh *DiscoveryHTTP) Start() {
+	httpErrorAndLog := func(w http.ResponseWriter, msg string, status int, logmsg string, logargs ...interface{}) {
+		http.Error(w, msg, status)
+		Log.Warningf("[http] "+logmsg, logargs...)
+	}
+
+	go func() {
+		muxRouter := mux.NewRouter()
+
+		// Join a endpoint.
+		// Parameters provided in the form: "url", "hb", "ttl"
+		muxRouter.Methods("PUT").Path("/endpoint").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqError := func(msg string, logmsg string, logargs ...interface{}) {
+				httpErrorAndLog(w, msg, http.StatusBadRequest, logmsg, logargs...)
+			}
+
+			var err error
+
+			hb := dh.defaultHb
+			hbParam := r.FormValue("hb")
+			if hbParam != "" {
+				if hb, err = time.ParseDuration(hbParam); err != nil {
+					reqError("Invalid heartbeat", "Invalid heartbeat: %v", err)
+					return
+				}
+			}
+			if hb < 1*time.Second {
+				reqError("Invalid heartbeat", "Heartbeat should be at least one second")
+				return
+			}
+
+			ttl := dh.defaultTTL
+			ttlParam := r.FormValue("ttl")
+			if ttlParam != "" {
+				if ttl, err = time.ParseDuration(ttlParam); err != nil {
+					reqError("Invalid TTL", "Invalid TTL: %v", err)
+					return
+				}
+			}
+			if ttl <= hb {
+				reqError("Invalid TTL", "TTL must be strictly superior to the heartbeat value")
+				return
+			}
+
+			urlParam := r.FormValue("url")
+			if urlParam == "" {
+				reqError("Invalid URL", "Invalid URL in request: %s, %s", r.URL, r.Form)
+				return
+			}
+
+			err = dh.dm.Join(urlParam, hb, ttl)
+			if err != nil {
+				Log.Warning(err)
+			}
+		})
+
+		// Leave a endpoint.
+		// Parameters provided in the form: "url"
+		muxRouter.Methods("DELETE").Path("/endpoint").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqError := func(msg string, logmsg string, logargs ...interface{}) {
+				httpErrorAndLog(w, msg, http.StatusBadRequest, logmsg, logargs...)
+			}
+
+			urlParam := r.FormValue("url")
+			if urlParam == "" {
+				reqError("Invalid URL", "Invalid URL in request: %s, %s", r.URL, r.Form)
+				return
+			}
+
+			err := dh.dm.Leave(urlParam)
+			if err != nil {
+				Log.Warning(err)
+			}
+		})
+
+		// Report status
+		muxRouter.Methods("GET").Path("/status").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "weave Discovery", version)
+			fmt.Fprint(w, dh.Status())
+			fmt.Fprint(w, dh.dm.Status())
+		})
+
+		http.Handle("/", muxRouter)
+		if err := http.Serve(dh.listener, nil); err != nil {
+			Log.Fatal("[http] Unable to serve http: ", err)
+		}
+	}()
+
+}
+
+func (dh *DiscoveryHTTP) Stop() error {
+	Log.Debugf("[http] Stopping HTTP API")
+	dh.listener.Close()
+	return nil
+}
+
+func (dh *DiscoveryHTTP) Status() string {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, "Listen address", dh.listener.Addr())
+	return buf.String()
+}

--- a/prog/weavediscovery/main.go
+++ b/prog/weavediscovery/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/weaveworks/weave/common"
+)
+
+var version = "(unreleased version)"
+
+const (
+	defaultHeartbeat = "30s"
+	defaultTTL       = "60s"
+)
+
+func main() {
+	var (
+		justVersion   bool
+		routerURL     string
+		httpIfaceName string
+		httpPort      int
+		localAddr     string
+		wait          int
+		hb            string
+		ttl           string
+		logLevel      string
+		verbose       bool
+	)
+
+	flag.BoolVar(&justVersion, "version", false, "print version and exit")
+	flag.StringVar(&routerURL, "weave", defaultWeaveURL, "weave API URL")
+	flag.StringVar(&localAddr, "local", "", "local address announced to other peers")
+	flag.IntVar(&wait, "wait", -1, "number of seconds to wait for interfaces to come up (0=don't wait, -1=wait forever)")
+	flag.StringVar(&hb, "hb", defaultHeartbeat, "heartbeat (with units)")
+	flag.StringVar(&ttl, "ttl", defaultTTL, "TTL (with units)")
+	flag.StringVar(&httpIfaceName, "http-iface", "", "interface on which to listen for HTTP requests (defaults to empty string which listens on all interfaces)")
+	flag.IntVar(&httpPort, "http-port", defaultHTTPPort, "port for the Discovery HTTP API")
+	flag.StringVar(&logLevel, "log-level", "info", "logging level (debug, info, warning, error)")
+	flag.BoolVar(&verbose, "v", false, "enable verbose mode (debug logging level)")
+
+	flag.Parse()
+
+	if justVersion {
+		fmt.Printf("weave Discovery %s\n", version)
+		os.Exit(0)
+	}
+	if verbose {
+		logLevel = "debug"
+	}
+	hbDur, err := time.ParseDuration(hb)
+	if err != nil {
+		Log.Fatalf("[main] Could not parse heartbeat '%s': %s", hb, err)
+	}
+	ttlDur, err := time.ParseDuration(ttl)
+	if err != nil {
+		Log.Fatalf("[main] Could not parse TTL '%s': %s", ttl, err)
+	}
+
+	SetLogLevel(logLevel)
+	Log.Infof("[main] WeaveDiscovery version %s", version) // first thing in log: the version
+
+	if len(localAddr) == 0 {
+		Log.Fatalf("[main] Local address not provided")
+	}
+	Log.Infof("[main] Will announce local address '%s'", localAddr)
+
+	weaveCli, err := NewWeaveClient(routerURL)
+	if err != nil {
+		Log.Fatalf("[main] Could not initialize the weave router client: %s", err)
+	}
+	manager := NewDiscoveryManager(localAddr, weaveCli)
+	httpServer := NewDiscoveryHTTP(DiscoveryHTTPConfig{
+		Manager:   manager,
+		Iface:     httpIfaceName,
+		Port:      httpPort,
+		Wait:      wait,
+		Heartbeat: hbDur,
+		TTL:       ttlDur,
+	})
+
+	manager.Start()
+	httpServer.Start()
+
+	// join any additional endpoint provided in command line, using the heartbeat and TTL arguments
+	numEps := len(flag.Args())
+	if numEps > 0 {
+		Log.Debugf("[main] %d endpoints provided in arguments", numEps)
+		for _, ep := range flag.Args() {
+			if err = manager.Join(ep, hbDur, ttlDur); err != nil {
+				Log.Fatalf("[main] Could not join '%s': %s", ep, err)
+			}
+		}
+	} else {
+		Log.Debugf("[main] No endpoints provided in arguments")
+	}
+
+	SignalHandlerLoop(httpServer, manager)
+}

--- a/prog/weavediscovery/manager.go
+++ b/prog/weavediscovery/manager.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/docker/machine/drivers/vmwarevsphere/errors"
+	"github.com/docker/swarm/discovery"
+	_ "github.com/docker/swarm/discovery/file"
+	_ "github.com/docker/swarm/discovery/kv"
+	_ "github.com/docker/swarm/discovery/nodes"
+	_ "github.com/docker/swarm/discovery/token"
+	. "github.com/weaveworks/weave/common"
+)
+
+var (
+	errInvalidEndpoint = errors.New("Invalid endpoint")
+)
+
+type discoveryEndpoint struct {
+	discovery.Discovery
+
+	url      string
+	stopChan chan struct{}
+
+	// stats
+	added        uint64
+	removed      uint64
+	lastRegister time.Time
+}
+
+// Create a new endpoint
+func newDiscoveryEndpoint(url, localAddr string, weaveCli *WeaveClient, heartbeat time.Duration, ttl time.Duration) (*discoveryEndpoint, error) {
+	d, err := discovery.New(url, heartbeat, ttl)
+	if err != nil {
+		return nil, err
+	}
+	stopChan := make(chan struct{})
+	ep := discoveryEndpoint{
+		Discovery: d,
+		url:       url,
+		stopChan:  stopChan,
+	}
+
+	entriesChan, errorsChan := d.Watch(stopChan)
+	ticker := time.NewTicker(heartbeat)
+	go func() {
+		register := func() {
+			Log.Debugf("[manager] Registering on '%s' we are at '%s' (%s period)...", url, localAddr, heartbeat)
+			if err := d.Register(localAddr); err != nil {
+				Log.Warningf("[manager] Registration failed: %s", err)
+			} else {
+				ep.lastRegister = time.Now()
+			}
+		}
+
+		register()
+		currentEntries := discovery.Entries{}
+		for {
+			select {
+			case reportedEntries := <-entriesChan:
+				added, removed := currentEntries.Diff(reportedEntries)
+
+				ep.added += uint64(len(added))
+				ep.removed += uint64(len(removed))
+
+				currentEntries = reportedEntries
+				Log.Printf("[manager] Updates from '%s': %d added, %d removed...", url, len(added), len(removed))
+				for _, e := range added {
+					weaveCli.Join(e.Host, e.Port)
+				}
+				for _, e := range removed {
+					weaveCli.Forget(e.Host, e.Port)
+				}
+			case reportedError := <-errorsChan:
+				Log.Warningf("[manager] Error from endpoint %s: %s...", url, reportedError)
+			case <-ticker.C:
+				register()
+			case <-stopChan:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return &ep, nil
+}
+
+func (d *discoveryEndpoint) Disconnect() {
+	close(d.stopChan)
+}
+
+func (d *discoveryEndpoint) String() string {
+	regStr := "!REGISTERED"
+	if !d.lastRegister.IsZero() {
+		regStr = fmt.Sprintf("register@%s", d.lastRegister.Format("15:04:05.99"))
+	}
+	return fmt.Sprintf("%s [%d++/%d--/%s]", d.url, d.added, d.removed, regStr)
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+type DiscoveryManager struct {
+	hb int
+
+	localAddr string
+	weaveCli  *WeaveClient
+	endpoints map[string]*discoveryEndpoint
+}
+
+func NewDiscoveryManager(localAddr string, weaveCli *WeaveClient) *DiscoveryManager {
+	dm := DiscoveryManager{
+		localAddr: localAddr,
+		weaveCli:  weaveCli,
+		endpoints: make(map[string]*discoveryEndpoint),
+	}
+	return &dm
+}
+
+// Start the discovery manager
+func (dm *DiscoveryManager) Start() {
+}
+
+// Stop the discovery manager
+func (dm *DiscoveryManager) Stop() error {
+	for _, d := range dm.endpoints {
+		d.Disconnect()
+	}
+	return nil
+}
+
+func (dm *DiscoveryManager) Status() string {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, "Endpoints:")
+	for _, v := range dm.endpoints {
+		fmt.Fprintln(&buf, " -", v)
+	}
+	return buf.String()
+}
+
+// Join a discovery endpoint
+func (dm *DiscoveryManager) Join(url string, heartbeat time.Duration, ttl time.Duration) error {
+	if _, found := dm.endpoints[url]; found {
+		Log.Debugf("[manager] Endpoint %s already joined: ignored", url)
+		return nil
+	}
+
+	Log.Debugf("[manager] Joining '%s'...", url)
+	d, err := newDiscoveryEndpoint(url, dm.localAddr, dm.weaveCli, heartbeat, ttl)
+	if err != nil {
+		return err
+	}
+	Log.Debugf("[manager] '%s' successfully joined", url)
+	dm.endpoints[url] = d
+	return nil
+}
+
+// Leave a discovery endpoint
+func (dm *DiscoveryManager) Leave(url string) error {
+	if d, found := dm.endpoints[url]; found {
+		Log.Debugf("[manager] Leaving %s", url)
+		d.Disconnect()
+		delete(dm.endpoints, url)
+		return nil
+	}
+	return errInvalidEndpoint
+}

--- a/weave
+++ b/weave
@@ -33,6 +33,7 @@ usage() {
     echo "                        [-iprange <cidr> [-ipsubnet <cidr>]]"
     echo "                        [-initpeercount <count>] <peer> ..."
     echo "weave launch-dns    [<addr>]"
+    echo "weave launch-discovery"
     echo "weave launch-proxy  [-H <endpoint>] [--with-dns | --without-dns]"
     echo "                        [--no-default-ipalloc]"
     echo "weave connect       [--replace] [<peer> ...]"
@@ -44,6 +45,8 @@ usage() {
     echo "weave detach        [<addr> ...] <container_id>"
     echo "weave dns-add       <ip_address> [<ip_address> ...] <container_id> [-h <fqdn>]"
     echo "weave dns-remove    <ip_address> [<ip_address> ...] <container_id> [-h <fqdn>]"
+    echo "weave join          <discovery_url>"
+    echo "weave leave         <discovery_url>"
     echo "weave expose        [<addr> ...] [-h <fqdn>]"
     echo "weave hide          [<addr> ...]"
     echo "weave ps            [<container_id> ...]"
@@ -161,13 +164,16 @@ shift 1
 
 BASE_IMAGE=$DOCKERHUB_USER/weave
 BASE_DNS_IMAGE=$DOCKERHUB_USER/weavedns
+BASE_DISCOVERY_IMAGE=$DOCKERHUB_USER/weavediscovery
 IMAGE=$BASE_IMAGE:$IMAGE_VERSION
 DNS_IMAGE=$BASE_DNS_IMAGE:$IMAGE_VERSION
+DISCOVERY_IMAGE=$BASE_DISCOVERY_IMAGE:$IMAGE_VERSION
 
 PROCFS=${PROCFS:-/proc}
 DOCKER_BRIDGE=${DOCKER_BRIDGE:-docker0}
 CONTAINER_NAME=${WEAVE_CONTAINER_NAME:-weave}
 DNS_CONTAINER_NAME=weavedns
+DISCOVERY_CONTAINER_NAME=weavediscovery
 BRIDGE=weave
 CONTAINER_IFNAME=ethwe
 MTU=65535
@@ -175,6 +181,8 @@ PORT=${WEAVE_PORT:-6783}
 HTTP_PORT=6784
 DNS_HTTP_PORT=6785
 DNS_HTTP_IFNAME=eth0
+DISCOVERY_HTTP_PORT=6789
+DISCOVERY_HTTP_IFNAME=eth0
 PROXY_PORT=12375
 PROXY_CONTAINER_NAME=weaveproxy
 
@@ -811,6 +819,26 @@ populate_dns() {
 }
 
 ######################################################################
+# Discovery helpers
+######################################################################
+
+call_discovery() {
+    http_call $DISCOVERY_CONTAINER_NAME $DISCOVERY_HTTP_PORT "$@"
+}
+
+put_discovery() {
+    for URL in "$@" ; do
+        call_discovery PUT /endpoint --data-urlencode url=$URL || true
+    done
+}
+
+delete_discovery() {
+    for URL in "$@" ; do
+        call_discovery DELETE /endpoint --data-urlencode url=$URL  || true
+    done
+}
+
+######################################################################
 # IP Allocation Management helpers
 ######################################################################
 
@@ -1041,6 +1069,19 @@ launch_dns() {
     populate_dns
 }
 
+launch_discovery() {
+    container_ip $CONTAINER_NAME || { echo "Error: could not determine router IP: router not running" ; exit 1 ; }
+    WEAVE_URL=http://$CONTAINER_IP:$HTTP_PORT
+    LOCAL_ADDR=$(/sbin/ip route | awk '/default/ { print $3 }')   # TODO: any better solution for guessing the local, reachable address?
+
+    # Set WEAVEDISCOVERY_DOCKER_ARGS in the environment in order to supply
+    # additional parameters, such as resource limits, to docker
+    # when launching the weave container.
+    DISCOVERY_CONTAINER=$(docker run -d --name=$DISCOVERY_CONTAINER_NAME \
+        -e WEAVE_CIDR=none \
+        $WEAVEDISCOVERY_DOCKER_ARGS $DISCOVERY_IMAGE -http-iface "$DISCOVERY_HTTP_IFNAME" -local $LOCAL_ADDR -weave "$WEAVE_URL" "$@")
+}
+
 launch_proxy() {
     # Set WEAVEPROXY_DOCKER_ARGS in the environment in order to supply
     # additional parameters, such as resource limits, to docker
@@ -1117,13 +1158,15 @@ case "$COMMAND" in
         create_bridge --without-ethtool
         ;;
     launch)
-        check_not_running $CONTAINER_NAME       $BASE_IMAGE
-        check_not_running $DNS_CONTAINER_NAME   $BASE_DNS_IMAGE
-        check_not_running $PROXY_CONTAINER_NAME $EXEC_IMAGE
+        check_not_running $CONTAINER_NAME           $BASE_IMAGE
+        check_not_running $DNS_CONTAINER_NAME       $BASE_DNS_IMAGE
+        check_not_running $DISCOVERY_CONTAINER_NAME $BASE_DISCOVERY_IMAGE
+        check_not_running $PROXY_CONTAINER_NAME     $EXEC_IMAGE
         COMMON_ARGS=$(common_launch_args "$@")
         launch_router "$@"
-        launch_dns    $COMMON_ARGS
-        launch_proxy  $COMMON_ARGS
+        launch_dns       $COMMON_ARGS
+        launch_discovery $COMMON_ARGS
+        launch_proxy     $COMMON_ARGS
         ;;
     launch-router)
         check_not_running $CONTAINER_NAME $BASE_IMAGE
@@ -1134,6 +1177,11 @@ case "$COMMAND" in
         check_not_running $DNS_CONTAINER_NAME $BASE_DNS_IMAGE
         launch_dns "$@"
         echo $DNS_CONTAINER
+        ;;
+    launch-discovery)
+        check_not_running $DISCOVERY_CONTAINER_NAME $BASE_DISCOVERY_IMAGE
+        launch_discovery "$@"
+        echo $DISCOVERY_CONTAINER
         ;;
     launch-proxy)
         check_not_running $PROXY_CONTAINER_NAME $EXEC_IMAGE
@@ -1275,6 +1323,14 @@ case "$COMMAND" in
             delete_dns_fqdn $CONTAINER "$3" $IP_ARGS
         fi
         ;;
+    join)
+        check_running $DISCOVERY_CONTAINER_NAME
+        put_discovery "$1"
+        ;;
+    leave)
+        check_running $DISCOVERY_CONTAINER_NAME
+        delete_discovery "$1"
+        ;;
     expose)
         collect_cidr_args "$@"
         shift $CIDR_ARG_COUNT
@@ -1332,6 +1388,10 @@ case "$COMMAND" in
     stop-dns)
         [ $# -eq 0 ] || usage
         stop $DNS_CONTAINER_NAME "WeaveDNS"
+        ;;
+    stop-discovery)
+        [ $# -eq 0 ] || usage
+        stop $DISCOVERY_CONTAINER_NAME "WeaveDiscovery"
         ;;
     stop-proxy)
         [ $# -eq 0 ] || usage


### PR DESCRIPTION
This PR implements a peers discovery mechanism for discovering peers by using Swarm's discovery backends. A new _weavediscovery_ container will monitor peers appearing and leaving the discovery endpoint, and will trigger the corresponding `/connect` and `/forget` in the router. We can join or leave discovery endpoints with the `weave join` and `weave leave` commands.

Note: the `file://` backend is not supported, as _weavediscovery_ does not have access to host files so far...

Closes #850 