### PR TITLE
Proxy autoconfig

### DIFF
--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -11,8 +11,7 @@ import (
 )
 
 var (
-	version            = "(unreleased version)"
-	defaultListenAddrs = []string{"tcp://0.0.0.0:12375", "unix:///var/run/weave.sock"}
+	version = "(unreleased version)"
 )
 
 type listOpts struct {
@@ -50,7 +49,7 @@ func main() {
 
 	mflag.BoolVar(&justVersion, []string{"#version", "-version"}, false, "print version and exit")
 	mflag.StringVar(&logLevel, []string{"-log-level"}, "info", "logging level (debug, info, warning, error)")
-	ListVar(&c.ListenAddrs, []string{"H"}, defaultListenAddrs, "addresses on which to listen")
+	ListVar(&c.ListenAddrs, []string{"H"}, nil, "addresses on which to listen")
 	mflag.StringVar(&c.HostnameMatch, []string{"-hostname-match"}, "(.*)", "Regexp pattern to apply on container names (e.g. '^aws-[0-9]+-(.*)$')")
 	mflag.StringVar(&c.HostnameReplacement, []string{"-hostname-replacement"}, "$1", "Expression to generate hostnames based on matches from --hostname-match (e.g. 'my-app-$1')")
 	mflag.BoolVar(&c.NoDefaultIPAM, []string{"#-no-default-ipam", "-no-default-ipalloc"}, false, "do not automatically allocate addresses for containers without a WEAVE_CIDR")

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -36,14 +36,21 @@ The first form is more convenient, however you can only pass proxy
 related configuration arguments to `launch-proxy` so if you need to
 modify the default behaviour you will have to use the latter.
 
-By default, the proxy listens on /var/run/weave.sock and port 12375, on
-all network interfaces. This can be adjusted with the `-H` argument, e.g.
+By default, the proxy decides where to listen based on how the
+launching client connects to docker. If the launching client connected
+over a unix socket, the proxy will listen on /var/run/weave.sock. If
+the launching client connected over TCP, the proxy will listen on port
+12375, on all network interfaces. This can be adjusted with the `-H`
+argument, e.g.
 
     host1$ weave launch-proxy -H tcp://127.0.0.1:9999
 
-Multiple -H arguments can be specified. If you are working with a remote
-docker daemon, then any firewalls inbetween need to be configured to permit
-access to the proxy port.
+When launching the proxy via TLS, `-H` and/or [TLS options](#tls) are
+required.
+
+Multiple `-H` arguments can be specified. If you are working with a
+remote docker daemon, then any firewalls inbetween need to be
+configured to permit access to the proxy port.
 
 All docker commands can be run via the proxy, so it is safe to adjust
 your `DOCKER_HOST` to point at the proxy. Weave provides a convenient

--- a/test/690_proxy_autoconfig_test.sh
+++ b/test/690_proxy_autoconfig_test.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Boot the proxy should only listen on client's interface"
+
+# Booting it over unix socket listens on unix socket
+run_on $HOST1 sudo weave launch-proxy
+assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave.sock ps"
+assert_raises "proxy docker_on $HOST1 ps" 1
+weave_on $HOST1 stop-proxy
+
+# Booting it over tcp listens on tcp
+weave_on $HOST1 launch-proxy
+assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave.sock ps" 1
+assert_raises "proxy docker_on $HOST1 ps"
+weave_on $HOST1 stop-proxy
+
+# Booting it over tcp (no prefix) listens on tcp
+DOCKER_CLIENT_ARGS="-H $HOST1:$DOCKER_PORT" $WEAVE launch-proxy
+assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave.sock ps" 1
+assert_raises "proxy docker_on $HOST1 ps"
+weave_on $HOST1 stop-proxy
+
+
+# Booting it over tls errors
+assert_raises "DOCKER_CLIENT_ARGS='--tls' weave_on $HOST1 launch-proxy" 1
+assert_raises "DOCKER_CERT_PATH='./tls' DOCKER_TLS_VERIFY=1 weave_on $HOST1 launch-proxy" 1
+
+# Booting it with a specific -H overrides defaults
+weave_on $HOST1 launch-proxy -H unix:///var/run/weave2.sock
+assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave2.sock ps"
+assert_raises "proxy docker_on $HOST1 ps" 1
+weave_on $HOST1 stop-proxy
+
+end_suite

--- a/weave
+++ b/weave
@@ -17,6 +17,8 @@ BASE_EXEC_IMAGE=$DOCKERHUB_USER/weaveexec
 EXEC_IMAGE=$BASE_EXEC_IMAGE:$IMAGE_VERSION
 PROXY_HOST=${PROXY_HOST:-$(echo "${DOCKER_HOST#tcp://}" | cut -s -d: -f1)}
 PROXY_HOST=${PROXY_HOST:-127.0.0.1}
+DOCKER_CLIENT_HOST=${DOCKER_CLIENT_HOST:-$DOCKER_HOST}
+DOCKER_CLIENT_TLS_VERIFY=${DOCKER_CLIENT_TLS_VERIFY:-$DOCKER_TLS_VERIFY}
 
 # Define some regular expressions for matching addresses.
 # The regexp here is far from precise, but good enough.
@@ -84,6 +86,9 @@ exec_remote() {
         -e WEAVE_PORT \
         -e WEAVE_CONTAINER_NAME \
         -e DOCKER_BRIDGE \
+        -e DOCKER_CLIENT_HOST="$DOCKER_CLIENT_HOST" \
+        -e DOCKER_CLIENT_TLS_VERIFY="$DOCKER_CLIENT_TLS_VERIFY" \
+        -e DOCKER_CLIENT_ARGS \
         -e PROXY_HOST="$PROXY_HOST" \
         -e WEAVE_CIDR=none \
         -e COVERAGE \
@@ -895,6 +900,25 @@ show_addrs() {
 # weave proxy helpers
 ######################################################################
 
+docker_client_args() {
+    CLIENT_TLS_ENABLED=""
+    [ -z "$DOCKER_CLIENT_TLS_VERIFY" ] || CLIENT_TLS_ENABLED=1
+    while [ $# -gt 0 ]; do
+        case "$1" in
+          -H|--host)
+            DOCKER_CLIENT_HOST="$2"
+            shift
+            ;;
+          -H=*|--host=*)
+            DOCKER_CLIENT_HOST="${1#*=}"
+            ;;
+          -tls|--tls|-tlsverify|--tlsverify)
+            CLIENT_TLS_ENABLED=1
+            ;;
+        esac
+        shift
+    done
+}
 
 # TODO: Handle relative paths for args
 # TODO: Handle args with spaces
@@ -906,8 +930,23 @@ tls_arg() {
 proxy_args() {
     PROXY_VOLUMES=""
     PROXY_ARGS=""
+    PROXY_TLS_ENABLED=""
+    PROXY_HOST=""
     while [ $# -gt 0 ]; do
         case "$1" in
+          -H)
+            PROXY_HOST="$2"
+            PROXY_ARGS="$PROXY_ARGS $1 $2"
+            shift
+            ;;
+          -H=*)
+            PROXY_HOST="${1#*=}"
+            PROXY_ARGS="$PROXY_ARGS $1"
+            ;;
+          -tls|--tls|-tlsverify|--tlsverify)
+            PROXY_TLS_ENABLED=1
+            PROXY_ARGS="$PROXY_ARGS $1"
+            ;;
           --tlscacert)
             tls_arg "$1" "$2" ca
             shift
@@ -935,6 +974,22 @@ proxy_args() {
         esac
         shift
     done
+
+    if [ -z "$PROXY_HOST" -a -n "$CLIENT_TLS_ENABLED" -a -z "$PROXY_TLS_ENABLED" ]; then
+      echo "When launching the proxy via TLS, -H and/or TLS options are required." >&2
+      exit 1
+    fi
+    if [ -z "$PROXY_HOST" ]; then
+      case "$DOCKER_CLIENT_HOST" in
+        ""|unix://*)
+          PROXY_HOST="unix:///var/run/weave.sock"
+          ;;
+        *)
+          PROXY_HOST="tcp://0.0.0.0:12375"
+          ;;
+      esac
+      PROXY_ARGS="$PROXY_ARGS -H $PROXY_HOST"
+    fi
 }
 
 proxy_addr() {
@@ -1057,6 +1112,7 @@ launch_proxy() {
     # Set WEAVEPROXY_DOCKER_ARGS in the environment in order to supply
     # additional parameters, such as resource limits, to docker
     # when launching the weaveproxy container.
+    docker_client_args $DOCKER_CLIENT_ARGS
     proxy_args "$@"
     PROXY_CONTAINER=$(docker run --privileged -d --name=$PROXY_CONTAINER_NAME --net=host \
         $PROXY_VOLUMES \


### PR DESCRIPTION
Use the docker daemon's `-H` flags as the proxy's default.

No support for auto-configuring TLS. For that we would have to do the procfs and flag parsing in the weave script (so that we could mount the certs into the proxy container).

This is possibly a bit linux-specific, as the layout of procfs is not standardized.

Fixes #1055