### PR TITLE
Don't wait to claim addresses from IPAM

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -202,10 +202,9 @@ func (alloc *Allocator) Lookup(ident string, r address.Range) (address.Address, 
 }
 
 // Claim an address that we think we should own (Sync)
-func (alloc *Allocator) Claim(ident string, addr address.Address, cancelChan <-chan bool) error {
+func (alloc *Allocator) Claim(ident string, addr address.Address) error {
 	resultChan := make(chan error)
-	op := &claim{resultChan: resultChan, ident: ident, addr: addr,
-		hasBeenCancelled: hasBeenCancelled(cancelChan)}
+	op := &claim{resultChan: resultChan, ident: ident, addr: addr}
 	alloc.doOperation(op, &alloc.pendingClaims)
 	return <-resultChan
 }

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -143,7 +143,7 @@ func TestAllocatorClaim(t *testing.T) {
 	alloc.claimRingForTesting()
 	addr1, _ := address.ParseIP(testAddr1)
 
-	err := alloc.Claim(container3, addr1, nil)
+	err := alloc.Claim(container3, addr1)
 	wt.AssertNoErr(t, err)
 	// Check we get this address back if we try an allocate
 	addr3, _ := alloc.Allocate(container3, subnet, nil)

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -9,10 +9,9 @@ import (
 )
 
 type claim struct {
-	resultChan       chan<- error
-	ident            string
-	addr             address.Address
-	hasBeenCancelled func() bool
+	resultChan chan<- error
+	ident      string
+	addr       address.Address
 }
 
 func (c *claim) sendResult(result error) {
@@ -29,11 +28,6 @@ func (c *claim) sendResult(result error) {
 
 // Try returns true for success (or failure), false if we need to try again later
 func (c *claim) Try(alloc *Allocator) bool {
-	if (c.hasBeenCancelled)() {
-		c.Cancel()
-		return true
-	}
-
 	if !alloc.ring.Contains(c.addr) {
 		// Address not within our universe; assume user knows what they are doing
 		alloc.infof("Ignored address %s claimed by %s - not in our universe\n", c.addr, c.ident)

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -19,14 +19,13 @@ func badRequest(w http.ResponseWriter, err error) {
 // HandleHTTP wires up ipams HTTP endpoints to the provided mux.
 func (alloc *Allocator) HandleHTTP(router *mux.Router, defaultSubnet address.CIDR, dockerCli *docker.Client) {
 	router.Methods("PUT").Path("/ip/{id}/{ip}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		closedChan := w.(http.CloseNotifier).CloseNotify()
 		vars := mux.Vars(r)
 		ident := vars["id"]
 		ipStr := vars["ip"]
 		if ip, err := address.ParseIP(ipStr); err != nil {
 			badRequest(w, err)
 			return
-		} else if err := alloc.Claim(ident, ip, closedChan); err != nil {
+		} else if err := alloc.Claim(ident, ip); err != nil {
 			badRequest(w, fmt.Errorf("Unable to claim: %s", err))
 			return
 		}


### PR DESCRIPTION
If an error is immediately apparent, e.g. we have already allocated that address on this host, or we have been told via gossip that another host owns that range, then it will go back to the caller.
If an error is possible but not detectable yet, then the claim is left pending and the caller is told it's ok (nil error return).

Another change in behaviour is that we stop tracking whether the caller has closed the http socket before we managed to reply properly; since this happens naturally on the first 'nil' return and we don't expect to be processing the request very long anyway.

Fixes #1083
