### PR TITLE
Multi hop tests

### DIFF
--- a/test/120_discovery_test.sh
+++ b/test/120_discovery_test.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+. ./config.sh
+
+C1=10.2.1.41
+C3=10.2.1.71
+
+launch_all() {
+    weave_on $HOST1 launch-router $1
+    weave_on $HOST2 launch-router $1 $HOST1
+    weave_on $HOST3 launch-router $1 $HOST2
+}
+
+start_suite "Peer discovery and multi-hop routing"
+
+launch_all
+
+start_container $HOST1 $C1/24 --name=c1
+start_container $HOST3 $C3/24 --name=c3
+
+assert_raises "exec_on $HOST1 c1 $PING $C3"
+stop_router_on $HOST2
+assert_raises "exec_on $HOST1 c1 $PING $C3"
+
+stop_router_on $HOST1
+stop_router_on $HOST3
+
+launch_all --no-discovery
+
+assert_raises "exec_on $HOST1 c1 $PING $C3"
+stop_router_on $HOST2
+assert_raises "exec_on $HOST1 c1 sh -c '! $PING $C3'"
+
+end_suite

--- a/test/120_discovery_test.sh
+++ b/test/120_discovery_test.sh
@@ -27,6 +27,8 @@ stop_router_on $HOST3
 
 launch_all --no-discovery
 
+sleep 5 # give topology gossip some time to propagate
+
 assert_raises "exec_on $HOST1 c1 $PING $C3"
 
 # this stalls if gossip forwarding doesn't work. We wait for slightly

--- a/test/120_discovery_test.sh
+++ b/test/120_discovery_test.sh
@@ -7,11 +7,11 @@ C3=10.2.1.71
 
 launch_all() {
     weave_on $HOST1 launch-router $1
-    weave_on $HOST2 launch-router $1 $HOST1
-    weave_on $HOST3 launch-router $1 $HOST2
+    weave_on $HOST2 launch-router $1 --ipalloc-range="" $HOST1
+    weave_on $HOST3 launch-router $1                    $HOST2
 }
 
-start_suite "Peer discovery and multi-hop routing"
+start_suite "Peer discovery, multi-hop routing and gossip forwarding"
 
 launch_all
 
@@ -28,6 +28,11 @@ stop_router_on $HOST3
 launch_all --no-discovery
 
 assert_raises "exec_on $HOST1 c1 $PING $C3"
+
+# this stalls if gossip forwarding doesn't work. We wait for slightly
+# longer than the gossip interval (30s) before giving up.
+assert_raises "timeout 40 cat <( start_container $HOST3 )"
+
 stop_router_on $HOST2
 assert_raises "exec_on $HOST1 c1 sh -c '! $PING $C3'"
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -5,7 +5,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">= 1.7.0"
 
 # these ought to match what is in config.sh
-n_machines = 2
+n_machines = 3
 ip_prefix = "192.168.48"
 ip_suffix_base = 10
 

--- a/test/config.sh
+++ b/test/config.sh
@@ -12,7 +12,7 @@ fi
 SOURCED_CONFIG_SH=true
 
 # these ought to match what is in Vagrantfile
-N_MACHINES=${N_MACHINES:-2}
+N_MACHINES=${N_MACHINES:-3}
 IP_PREFIX=${IP_PREFIX:-192.168.48}
 IP_SUFFIX_BASE=${IP_SUFFIX_BASE:-10}
 
@@ -26,6 +26,7 @@ fi
 # these are used by the tests
 HOST1=$(echo $HOSTS | cut -f 1 -d ' ')
 HOST2=$(echo $HOSTS | cut -f 2 -d ' ')
+HOST3=$(echo $HOSTS | cut -f 3 -d ' ')
 
 . "$DIR/assert.sh"
 

--- a/test/gce.sh
+++ b/test/gce.sh
@@ -13,7 +13,7 @@ PROJECT=${PROJECT:-positive-cocoa-90213}
 IMAGE=ubuntu-14-04
 TEMPLATE_NAME="test-template-2"
 ZONE=us-central1-a
-NUM_HOSTS=2
+NUM_HOSTS=3
 SUFFIX=""
 if [ -n "$CIRCLECI" ]; then
 	SUFFIX="-${CIRCLE_BUILD_NUM}-$CIRCLE_NODE_INDEX"


### PR DESCRIPTION
test peer discovery, multi-hop routing and gossip forwarding.

increases code coverage as follows:
````patch
$ diff /tmp/coverage-before.txt /tmp/coverage-after.txt 
59c59
< github.com/weaveworks/weave/ipam/allocator.go:454:		actorLoop			90.9%
---
> github.com/weaveworks/weave/ipam/allocator.go:454:		actorLoop			100.0%
86,87c86,87
< github.com/weaveworks/weave/ipam/http.go:14:			badRequest			0.0%
< github.com/weaveworks/weave/ipam/http.go:20:			HandleHTTP			54.5%
---
> github.com/weaveworks/weave/ipam/http.go:14:			badRequest			100.0%
> github.com/weaveworks/weave/ipam/http.go:20:			HandleHTTP			56.8%
340c340
< github.com/weaveworks/weave/router/connection.go:125:		BreakTie			0.0%
---
> github.com/weaveworks/weave/router/connection.go:125:		BreakTie			66.7%
351,352c351,352
< github.com/weaveworks/weave/router/connection.go:279:		run				80.0%
< github.com/weaveworks/weave/router/connection.go:359:		registerRemote			60.0%
---
> github.com/weaveworks/weave/router/connection.go:279:		run				85.0%
> github.com/weaveworks/weave/router/connection.go:359:		registerRemote			80.0%
354c354
< github.com/weaveworks/weave/router/connection.go:391:		actorLoop			62.5%
---
> github.com/weaveworks/weave/router/connection.go:391:		actorLoop			75.0%
372c372
< github.com/weaveworks/weave/router/connection_maker.go:161:	queryLoop			87.5%
---
> github.com/weaveworks/weave/router/connection_maker.go:161:	queryLoop			100.0%
375c375
< github.com/weaveworks/weave/router/connection_maker.go:249:	addPeerTargets			46.2%
---
> github.com/weaveworks/weave/router/connection_maker.go:249:	addPeerTargets			100.0%
450c450
< github.com/weaveworks/weave/router/gossip_channel.go:57:	deliverUnicast			54.5%
---
> github.com/weaveworks/weave/router/gossip_channel.go:57:	deliverUnicast			72.7%
489c489
< github.com/weaveworks/weave/router/local_peer.go:183:		handleAddConnection		50.0%
---
> github.com/weaveworks/weave/router/local_peer.go:183:		handleAddConnection		61.5%
526c526
< github.com/weaveworks/weave/router/peers.go:81:			FetchAndAddRef			0.0%
---
> github.com/weaveworks/weave/router/peers.go:81:			FetchAndAddRef			100.0%
554c554
< github.com/weaveworks/weave/router/router.go:282:		handleUDPPacketFunc		71.9%
---
> github.com/weaveworks/weave/router/router.go:282:		handleUDPPacketFunc		87.5%
583c583
< github.com/weaveworks/weave/router/surrogate_gossiper.go:31:	Gossip				0.0%
---
> github.com/weaveworks/weave/router/surrogate_gossiper.go:31:	Gossip				100.0%
609c609
< total:								(statements)			82.0%
---
> total:								(statements)			83.0%
````

The difference in `/ipam/http.go` is weird. It is hitting the `badRequest(w, fmt.Errorf("Unable to allocate: %s", err))` case in `router.Methods("POST").Path("/ip/{id}/{ip}/{prefixlen}")`, which isn't exercised by the new test , so it must be something coming from another test.

The increased `connection.BreakTie` coverage, and related to that the increased `local_peer.handleAddConnection` coverage, I think is just down to luck, though it is possible that the new test increases the probability of tie breaks occurring.