### PR TITLE
test that large packets can be transmitted over weave

### DIFF
--- a/test/100_cross_hosts_test.sh
+++ b/test/100_cross_hosts_test.sh
@@ -27,4 +27,10 @@ start_container $HOST2 net:$SUBNET_2 --name=c6
 C6=$(container_ip $HOST2 c6)
 assert_raises "exec_on $HOST1 c5 $PING $C6"
 
+# check large packets get through. The first attempt typically fails,
+# since the PMTU hasn't been discovered yet. The 2nd attempt should
+# succeed.
+exec_on $HOST1 c1 $PING -s 65000 $C2 2>&1 1>/dev/null || true
+assert_raises "exec_on $HOST1 c1 $PING -s 65000 $C2"
+
 end_suite


### PR DESCRIPTION
change in coverage:
````patch
$ diff /tmp/coverage-before.txt /tmp/coverage-after.txt 
372c372
< github.com/weaveworks/weave/router/connection_maker.go:161:	queryLoop			87.5%
---
> github.com/weaveworks/weave/router/connection_maker.go:161:	queryLoop			100.0%
411c411
< github.com/weaveworks/weave/router/ethernet_decoder.go:33:	sendICMPFragNeeded		0.0%
---
> github.com/weaveworks/weave/router/ethernet_decoder.go:33:	sendICMPFragNeeded		88.9%
419c419
< github.com/weaveworks/weave/router/forwarder.go:78:		forward				57.9%
---
> github.com/weaveworks/weave/router/forwarder.go:78:		forward				63.2%
549c549
< github.com/weaveworks/weave/router/router.go:147:		handleCapturedPacket		81.5%
---
> github.com/weaveworks/weave/router/router.go:147:		handleCapturedPacket		85.2%
609c609
< total:								(statements)			82.2%
---
> total:								(statements)			82.5%
````
(the `connection_maker` improvement is just noise)