### PR TITLE
Remove Docker dangling images in smoke-tests

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -12,6 +12,8 @@ echo "Copying weave images, scripts, and certificates to hosts, and"
 echo "  prefetch test images"
 for HOST in $HOSTS; do
     docker_on $HOST load -i ../weave.tar
+    DANGLING_IMAGES="$(docker_on $HOST images -q -f dangling=true)"
+    [ -n "$DANGLING_IMAGES" ] && docker_on $HOST rmi $DANGLING_IMAGES
     run_on $HOST mkdir -p bin
     upload_executable $HOST ../bin/docker-ns
     upload_executable $HOST ../weave


### PR DESCRIPTION
Each time we copy new images the old ones lie around unreferenced, and eventually fill up the disk.  
So this PR deletes the dangling ones.