### PR TITLE
Mitigate entropy depletion

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -16,11 +16,17 @@ import (
 )
 
 const (
-	macMaxAge = 10 * time.Minute // [1]
+	macMaxAge        = 10 * time.Minute       // [1]
+	acceptMaxTokens  = 100                    // [2]
+	acceptTokenDelay = 100 * time.Millisecond // [3]
 )
 
 // [1] should be greater than typical ARP cache expiries, i.e. > 3/2 *
 // /proc/sys/net/ipv4_neigh/*/base_reachable_time_ms on Linux
+
+// [2] capacity of token bucket for rate limiting accepts
+
+// [3] control rate at which new tokens are added to the bucket
 
 type LogFrameFunc func(string, []byte, *layers.Ethernet)
 
@@ -45,6 +51,7 @@ type Router struct {
 	gossipChannels  GossipChannels
 	TopologyGossip  Gossip
 	UDPListener     *net.UDPConn
+	acceptLimiter   *TokenBucket
 }
 
 type PacketSource interface {
@@ -76,6 +83,7 @@ func NewRouter(config Config, name PeerName, nickName string) *Router {
 	router.Routes = NewRoutes(router.Ourself, router.Peers)
 	router.ConnectionMaker = NewConnectionMaker(router.Ourself, router.Peers, router.Port, router.PeerDiscovery)
 	router.TopologyGossip = router.NewGossip("topology", router)
+	router.acceptLimiter = NewTokenBucket(acceptMaxTokens, acceptTokenDelay)
 	return router
 }
 
@@ -207,6 +215,7 @@ func (router *Router) listenTCP(localPort int) {
 				continue
 			}
 			router.acceptTCP(tcpConn)
+			router.acceptLimiter.Wait()
 		}
 	}()
 }

--- a/router/router.go
+++ b/router/router.go
@@ -16,16 +16,11 @@ import (
 )
 
 const (
-	macMaxAge      = 10 * time.Minute     // [1]
-	tcpAcceptDelay = 1 * time.Millisecond // [2]
+	macMaxAge = 10 * time.Minute // [1]
 )
 
 // [1] should be greater than typical ARP cache expiries, i.e. > 3/2 *
 // /proc/sys/net/ipv4_neigh/*/base_reachable_time_ms on Linux
-
-// [2] time to wait between accepting tcp connections. This guards
-// against brute-force attacks on the password when encryption is in
-// use. It is also a basic DoS defence.
 
 type LogFrameFunc func(string, []byte, *layers.Ethernet)
 
@@ -212,7 +207,6 @@ func (router *Router) listenTCP(localPort int) {
 				continue
 			}
 			router.acceptTCP(tcpConn)
-			time.Sleep(tcpAcceptDelay)
 		}
 	}()
 }

--- a/router/token_bucket.go
+++ b/router/token_bucket.go
@@ -1,0 +1,42 @@
+package router
+
+import (
+	"time"
+)
+
+type TokenBucket struct {
+	capacity             int64         // Maximum capacity of bucket
+	tokenInterval        time.Duration // Token replenishment rate
+	refillDuration       time.Duration // Time to refill from empty
+	earliestUnspentToken time.Time
+}
+
+func NewTokenBucket(capacity int64, tokenInterval time.Duration) *TokenBucket {
+	tb := TokenBucket{
+		capacity:       capacity,
+		tokenInterval:  tokenInterval,
+		refillDuration: tokenInterval * time.Duration(capacity)}
+
+	tb.earliestUnspentToken = tb.capacityToken()
+
+	return &tb
+}
+
+func (tb *TokenBucket) Wait() {
+	// If earliest unspent token is in the future, sleep until then
+	time.Sleep(tb.earliestUnspentToken.Sub(time.Now()))
+
+	// Alternatively, enforce bucket capacity if necessary
+	capacityToken := tb.capacityToken()
+	if tb.earliestUnspentToken.Before(capacityToken) {
+		tb.earliestUnspentToken = capacityToken
+	}
+
+	// 'Remove' a token from the bucket
+	tb.earliestUnspentToken = tb.earliestUnspentToken.Add(tb.tokenInterval)
+}
+
+// Determine the historic token timestamp representing a full bucket
+func (tb *TokenBucket) capacityToken() time.Time {
+	return time.Now().Add(-tb.refillDuration).Truncate(tb.tokenInterval)
+}


### PR DESCRIPTION
This PR adds adaptive connection acceptance rate limiting in the form of a lazy token bucket implementation, replacing the constant 1ms sleep in use before. The bucket contains a maximum of 100 tokens, replenished at a rate of one every 100ms; this allows a burst of up to 100 connection attempts without any delay, limiting to 10 per second thereafter under sustained load. Quiescence allows the bucket to refill back to its maximum, the intended effect being that initial network formation and partition healing are not hindered at all, but a sustained denial of service will be.

Testing reveals that this does not address the reported issue entirely - even at the lower bound of 10 requests per second there may not be enough entropy gathered on a headless system to keep pace. Nevertheless, after careful investigation and research, we have concluded that of the two options available to us (the other being implementing and seeding our own CSPRNG in a similar fashion to OpenSSL) this is by far the safest. We have been convinced that the impact of such an attack is limited to slowing `/dev/random` readers, so we have recorded our rationale along with links to supporting expert opinion in our cryptography design document.

In closing, it is noteworthy that OpenSSH can be used to deplete entropy in exactly the same fashion, as each forked process consumes 256 bits from `/dev/urandom`.

Closes #1037.