### PR TITLE
Upgrade smoke-tests to use 'overlay' storage and Ubuntu 15.04

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -14,10 +14,10 @@ require '../vagrant-common.rb'
 def configure_docker(host, hostname, ip)
   pkgs = %w(lxc-docker ethtool)
 
-  host.vm.box = "ubuntu/ubuntu-14.10-amd64"
-  host.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/utopic/current/utopic-server-cloudimg-amd64-vagrant-disk1.box"
+  host.vm.box = "ubuntu/ubuntu-15.04-amd64"
+  host.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/vivid/current/vivid-server-cloudimg-amd64-vagrant-disk1.box"
 
-  host.vm.hostname = hostname
+  host.vm.provision :shell, :inline => "hostnamectl set-hostname "+hostname
   host.vm.network "private_network", ip: ip
 
   host.vm.synced_folder ".", "/vagrant", disabled: true
@@ -29,8 +29,11 @@ def configure_docker(host, hostname, ip)
   host.vm.provision :shell, :inline => "usermod -a -G docker vagrant; "
 
   # Listen on the remote API
-  host.vm.provision :shell, :inline => "echo 'DOCKER_OPTS=\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375\"' >> /etc/default/docker"
-  host.vm.provision :shell, :inline => "service docker restart"
+  host.vm.provision :shell, :inline => "sed -i -e's%-H fd://%-H fd:// -H tcp://0.0.0.0:2375%' /lib/systemd/system/docker.service"
+  host.vm.provision :shell, :inline => "systemctl daemon-reload"
+
+  host.vm.provision :shell, :inline => "systemctl start docker"
+  host.vm.provision :shell, :inline => "systemctl enable docker"
   cleanup(host.vm)
 end
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -28,8 +28,8 @@ def configure_docker(host, hostname, ip)
   install_packages host.vm, pkgs
   host.vm.provision :shell, :inline => "usermod -a -G docker vagrant; "
 
-  # Listen on the remote API
-  host.vm.provision :shell, :inline => "sed -i -e's%-H fd://%-H fd:// -H tcp://0.0.0.0:2375%' /lib/systemd/system/docker.service"
+  # Listen on the remote API and use overlay storage driver
+  host.vm.provision :shell, :inline => "sed -i -e's%-H fd://%-H fd:// -H tcp://0.0.0.0:2375 -s overlay%' /lib/systemd/system/docker.service"
   host.vm.provision :shell, :inline => "systemctl daemon-reload"
 
   host.vm.provision :shell, :inline => "systemctl start docker"


### PR DESCRIPTION
The 'overlay' driver is [claimed](http://jpetazzo.github.io/assets/2015-03-03-not-so-deep-dive-into-docker-storage-drivers.html#57) to be the best choice right now, but requires Linux kernel 3.18.

You can feel the difference - using `vfs` (which our Vagrant set-up did because it didn't install the extra bits for `aufs`) the machine would bog down when tests were running, but with `overlay` you rarely notice this.

I will post some timings to illustrate the difference soon.