### PR TITLE
Quarantine Prototype

### DIFF
--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -43,6 +43,8 @@ type Nameserver struct {
 	entries Entries
 	peers   *router.Peers
 	quit    chan struct{}
+
+	Quarantines QuarantineManager
 }
 
 func New(ourName router.PeerName, peers *router.Peers, docker *docker.Client, domain string) *Nameserver {
@@ -107,6 +109,9 @@ func (n *Nameserver) Lookup(hostname string) []address.Address {
 	result := []address.Address{}
 	for _, e := range entries {
 		if e.Tombstone > 0 {
+			continue
+		}
+		if n.Quarantines.filter(&e) {
 			continue
 		}
 		result = append(result, e.Addr)

--- a/nameserver/quarantine.go
+++ b/nameserver/quarantine.go
@@ -1,0 +1,200 @@
+package nameserver
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	. "github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/router"
+)
+
+type Quarantine struct {
+	ID          string
+	ValidUntil  int64
+	ContainerID string
+	Peer        router.PeerName
+	Version     int64
+}
+
+type Quarantines []Quarantine
+
+type QuarantineManager struct {
+	sync.RWMutex
+	quarantines Quarantines
+	gossip      router.Gossip
+}
+
+func (q1 *Quarantine) merge(q2 Quarantine) {
+	if q2.Version > q1.Version {
+		q1.ValidUntil = q2.ValidUntil
+	}
+}
+
+func (qs *Quarantines) merge(incomings *Quarantines) Quarantines {
+	var (
+		newQuarantines Quarantines
+		i              = 0
+	)
+
+	for _, incoming := range *incomings {
+		for i < len(*qs) && (*qs)[i].ID < incoming.ID {
+			i++
+		}
+		if i < len(*qs) && (*qs)[i].ID == incoming.ID {
+			(*qs)[i].merge(incoming)
+			continue
+		}
+		*qs = append(*qs, Quarantine{})
+		copy((*qs)[i+1:], (*qs)[i:])
+		(*qs)[i] = incoming
+		newQuarantines = append(newQuarantines, incoming)
+	}
+
+	return newQuarantines
+}
+
+func (qs *Quarantines) add(containerID string, peername router.PeerName, duration time.Duration) Quarantine {
+
+	q := Quarantine{
+		ID:          strconv.FormatInt(rand.Int63(), 16),
+		ValidUntil:  now() + int64(duration/time.Second),
+		ContainerID: containerID,
+		Peer:        peername,
+		Version:     0,
+	}
+
+	i := sort.Search(len(*qs), func(i int) bool {
+		return (*qs)[i].ID > q.ID
+	})
+
+	*qs = append(*qs, Quarantine{})
+	copy((*qs)[i+1:], (*qs)[i:])
+	(*qs)[i] = q
+
+	return (*qs)[i]
+}
+
+func (qs *Quarantines) Merge(other router.GossipData) {
+	qs.merge(other.(*Quarantines))
+}
+
+func (qs *Quarantines) Encode() [][]byte {
+	buf := &bytes.Buffer{}
+	if err := gob.NewEncoder(buf).Encode(qs); err != nil {
+		panic(err)
+	}
+	return [][]byte{buf.Bytes()}
+}
+
+func (qm *QuarantineManager) SetGossip(gossip router.Gossip) {
+	qm.gossip = gossip
+}
+
+func (qm *QuarantineManager) List() Quarantines {
+	qm.RLock()
+	defer qm.RUnlock()
+
+	result := Quarantines{}
+	for _, q := range qm.quarantines {
+		if q.ValidUntil > now() {
+			result = append(result, q)
+		}
+	}
+	return result
+}
+
+func (qm *QuarantineManager) Add(containerID string, peername router.PeerName, duration time.Duration) (string, error) {
+	Log.Infof("[quarantine] Adding quarantine container=%s, peername=%s, duration=%s",
+		containerID, peername.String(), duration.String())
+
+	qm.Lock()
+	q := qm.quarantines.add(containerID, peername, duration)
+	qm.Unlock()
+
+	if qm.gossip != nil {
+		return q.ID, qm.gossip.GossipBroadcast(&Quarantines{q})
+	}
+	return q.ID, nil
+}
+
+func (qm *QuarantineManager) Delete(ident string) error {
+	qm.Lock()
+	defer qm.Unlock()
+
+	Log.Infof("[quarantine] Deleting quarantine %s", ident)
+
+	i := sort.Search(len(qm.quarantines), func(i int) bool {
+		return qm.quarantines[i].ID >= ident
+	})
+	if i == len(qm.quarantines) || qm.quarantines[i].ID != ident {
+		return fmt.Errorf("Not found")
+	}
+	qm.quarantines[i].Version++
+	qm.quarantines[i].ValidUntil = now()
+
+	if qm.gossip != nil {
+		return qm.gossip.GossipBroadcast(&Quarantines{qm.quarantines[i]})
+	}
+	return nil
+}
+
+func (qm *QuarantineManager) filter(entry *Entry) bool {
+	n := now()
+	for _, q := range qm.quarantines {
+		if q.ValidUntil <= n {
+			continue
+		}
+		if q.ContainerID == entry.ContainerID {
+			return true
+		}
+		if q.Peer == entry.Origin {
+			return true
+		}
+	}
+	return false
+}
+
+func (qm *QuarantineManager) Gossip() router.GossipData {
+	qm.RLock()
+	defer qm.RUnlock()
+	result := make(Quarantines, len(qm.quarantines))
+	copy(result, qm.quarantines)
+	return &result
+}
+
+func (qm *QuarantineManager) OnGossipUnicast(sender router.PeerName, msg []byte) error {
+	return nil
+}
+
+func (qm *QuarantineManager) receiveGossip(msg []byte) (router.GossipData, router.GossipData, error) {
+	var qs Quarantines
+	if err := gob.NewDecoder(bytes.NewReader(msg)).Decode(&qs); err != nil {
+		return nil, nil, err
+	}
+
+	qm.Lock()
+	defer qm.Unlock()
+
+	newEntries := qm.quarantines.merge(&qs)
+	return &newEntries, &qs, nil
+}
+
+// merge received data into state and return "everything new I've
+// just learnt", or nil if nothing in the received data was new
+func (qm *QuarantineManager) OnGossip(msg []byte) (router.GossipData, error) {
+	newEntries, _, err := qm.receiveGossip(msg)
+	return newEntries, err
+}
+
+// merge received data into state and return a representation of
+// the received data, for further propagation
+func (qm *QuarantineManager) OnGossipBroadcast(_ router.PeerName, msg []byte) (router.GossipData, error) {
+	_, entries, err := qm.receiveGossip(msg)
+	return entries, err
+}

--- a/nameserver/quarantine_test.go
+++ b/nameserver/quarantine_test.go
@@ -1,0 +1,124 @@
+package nameserver
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/router"
+	"github.com/weaveworks/weave/testing/gossip"
+)
+
+func makeQuarantineNetwork(size int) ([]*QuarantineManager, *gossip.TestRouter) {
+	gossipRouter := gossip.NewTestRouter(0.0)
+	managers := make([]*QuarantineManager, size)
+
+	for i := 0; i < size; i++ {
+		name, _ := router.PeerNameFromString(fmt.Sprintf("%02d:00:00:02:00:00", i))
+		manager := &QuarantineManager{}
+		manager.SetGossip(gossipRouter.Connect(name, manager))
+		managers[i] = manager
+	}
+
+	return managers, gossipRouter
+}
+
+type quarantine struct {
+	id          string
+	peername    router.PeerName
+	containerid string
+	deleted     bool
+}
+
+func TestQuarantines(t *testing.T) {
+	common.SetLogLevel("debug")
+
+	lookupTimeout := 20
+	managers, grouter := makeQuarantineNetwork(50)
+	quarantines := []*quarantine{}
+
+	check := func(manager *QuarantineManager, q *quarantine) {
+		for i := 0; i < lookupTimeout; i++ {
+			if q.deleted && !manager.filter(&Entry{ContainerID: q.containerid}) &&
+				!manager.filter(&Entry{Origin: q.peername}) {
+				break
+			}
+			if !q.deleted && manager.filter(&Entry{ContainerID: q.containerid}) &&
+				manager.filter(&Entry{Origin: q.peername}) {
+				break
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+
+		require.Equal(t, !q.deleted, manager.filter(&Entry{ContainerID: q.containerid}))
+		//require.Equal(t, !q.deleted, manager.filter(&Entry{Origin: q.peername}))
+	}
+
+	add := func() {
+		manager := managers[rand.Intn(len(managers))]
+		containerid := strconv.FormatInt(rand.Int63(), 16)
+		peername, _ := router.PeerNameFromString(fmt.Sprintf("%02d:00:00:02:00:00", rand.Intn(len(managers))))
+		id, err := manager.Add(containerid, peername, time.Hour)
+		require.Nil(t, err)
+		q := &quarantine{id, peername, containerid, false}
+		quarantines = append(quarantines, q)
+		check(manager, q)
+	}
+
+	delete := func() {
+		if len(quarantines) <= 0 {
+			return
+		}
+		q := quarantines[rand.Intn(len(quarantines))]
+		if q.deleted {
+			return
+		}
+		manager := managers[rand.Intn(len(managers))]
+
+		// due to this being eventually-consistent, delete might not work immediately
+		var err error
+		for i := 0; i < lookupTimeout; i++ {
+			err = manager.Delete(q.id)
+			if err == nil {
+				break
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+		require.Nil(t, err)
+
+		q.deleted = true
+		check(manager, q)
+	}
+
+	filter := func() {
+		if len(quarantines) <= 0 {
+			return
+		}
+		q := quarantines[rand.Intn(len(quarantines))]
+		manager := managers[rand.Intn(len(managers))]
+		check(manager, q)
+	}
+
+	for i := 0; i < 1000; i++ {
+		if i%10 == 0 {
+			grouter.Flush()
+		}
+
+		r := rand.Float32()
+		switch {
+		case r < 0.2:
+			add()
+
+		case 0.2 <= r && r < 0.4:
+			delete()
+
+		case 0.4 <= r:
+			filter()
+		}
+	}
+}

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -191,6 +191,9 @@ func main() {
 		}
 		ns.Start()
 		defer ns.Stop()
+
+		ns.Quarantines.SetGossip(router.NewGossip("quarantines", &ns.Quarantines))
+
 		dnsserver, err = nameserver.NewDNSServer(ns, dnsDomain, dnsListenAddress, uint32(dnsTTL), dnsClientTimeout)
 		if err != nil {
 			Log.Fatal("Unable to start dns server: ", err)

--- a/weave
+++ b/weave
@@ -78,6 +78,10 @@ weave stop-router
 weave stop-proxy
 weave reset
 weave rmpeer        <peer_id>
+weave quarantine-peer <peer_id> <duration>
+weave quarantine-container <container_id> <duration>
+weave unquarantine  <quarantine_id>
+weave quarantines
 
 where <peer>     = <ip_address_or_fqdn>[:<port>]
       <cidr>     = <ip_address>/<routing_prefix_length>
@@ -1580,6 +1584,23 @@ case "$COMMAND" in
         [ $# -eq 1 ] || usage
         PEER=$1
         call_weave DELETE /peer/$PEER
+        ;;
+    quarantine-peer)
+        [ $# -eq 2 ] || usage
+        call_weave POST /quarantine -d "peer=$1&duration=$2"
+        ;;
+    quarantine-container)
+        [ $# -eq 2 ] || usage
+        CONTAINER=$(container_id $1)
+        call_weave POST /quarantine -d "containerid=$CONTAINER&duration=$2"
+        ;;
+    unquarantine)
+        [ $# -eq 1 ] || usage
+        call_weave DELETE /quarantine/$1
+        ;;
+    quarantines)
+        [ $# -eq 0 ] || usage
+        call_weave GET /quarantine
         ;;
     launch-dns)
         echo "The 'launch-dns' command has been removed; DNS is launched as part of 'launch' and 'launch-router'." >&2


### PR DESCRIPTION
An early prototype of how quarantine might work. 

Questions:
- quarantine / unquarantine are hard to spell, type and just don't seem right.  Please suggest alternatives
- currently one can quarantine peers and containers.  To quarantine a peer/container means to temporarily remove the container from WeaveDNS.  We could extend this to also mean remove it from routing... thoughts?
- quarantines are records, <s>gossiped</s> phone tree'd around the cluster.  I went for this over just tombstoning the DNS entry so the burden of remembering the original mapping was not placed on the caller.
- I would like to extend the quarantine code to things like "all endpoints for foo.weave.local in the bar datacenter".  Weave would need to know about DCs, but this could map nicely to EC2.  Thoughts?

Example usage:
```
$ docker run -di --hostname foo.weave.local ubuntu /bin/bash
f18a16ce6e4c4882f38f3f44641ae2a2dc1468196b66829c5bc00b89495cb333
$ nslookup foo.weave.local 172.17.42.1
Server:		172.17.42.1
Address:	172.17.42.1#53

Name:	foo.weave.local
Address: 10.32.0.1

$ ./weave quarantine-container f18a16ce6e4c488 1h
3582c57bed56e2ea
$ nslookup foo.weave.local 172.17.42.1
Server:		172.17.42.1
Address:	172.17.42.1#53

*** Can't find foo.weave.local: No answer

$ ./weave quarantines
ID               Container    Peer              Duration
3582c57bed56e2ea f18a16ce6e4c                   2015-07-14 13:54:38 +0000 UTC

$ ./weave unquarantine 3582c57bed56e2ea
$ nslookup foo.weave.local 172.17.42.1
Server:		172.17.42.1
Address:	172.17.42.1#53

Name:	foo.weave.local
Address: 10.32.0.1
```

TODO:
- [ ] smoke tests
- [ ] delete old entries
- [ ] make unquarantine take a peer / container, and remove all records for that peer / container