### PR TITLE
Basic performance test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ Vagrantfile.local
 test/tls/*.pem
 test/coverage
 test/coverage.*
+test/performance

--- a/bin/circleci/perf-tests
+++ b/bin/circleci/perf-tests
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+IN_DIR=$SRCDIR/test/performance
+OUT_DIR=$CIRCLE_ARTIFACTS/
+
+export PERFORMANCE=1
+
+###########################################################################
+
+log()   { echo "$1" >&2 ;            }
+abort() { log "ABORT: $1" ; exit 0 ; }
+fatal() { log "FATAL: $1" ; exit 1 ; }
+
+[ -n "$CIRCLE_NODE_INDEX"  ] || fatal "No CIRCLE_NODE_INDEX defined"
+[ $CIRCLE_NODE_INDEX -eq 0 ] || abort "Not executing in CircleCI node $CIRCLE_NODE_INDEX"
+
+case "$1" in
+	pre)
+		log "Installing dependencies..."
+		sudo pip install plotly
+		sudo pip install requests
+	;;
+
+    start)
+		[ -z "$SRCDIR" ] && abort "No SRCDIR defined"
+
+		cd $SRCDIR/test
+		eval $(./gce.sh hosts)
+		$SRCDIR/test/run_all.sh $SRCDIR/test/*_perf.sh
+    ;;
+
+    stop)
+    ;;
+
+    post)
+		[ -n "$CIRCLE_ARTIFACTS" ] || fatal "no artifacts folder in environment"
+		[ -n "$PLOTLY_USERNAME" ]  || fatal "no PlotLy user name in environment"
+		[ -n "$PLOTLY_API_KEY" ]   || fatal "no PlotLy API key in environment"
+		[ -d $IN_DIR ]             || abort "no performance directory found"
+		[ -d $OUT_DIR ]            || { log "creating $OUT_DIR" ; mkdir -p $OUT_DIR ; }
+
+		log "Processing performance logs in $IN_DIR"
+		for csv_file in $IN_DIR/*.csv ; do
+		    [ -f $csv_file ] || continue
+
+		    name=$(basename $csv_file .csv)
+		    name_wo_ext=$(basename $csv_file)
+
+		    log "Generating graph for $name_wo_ext [branch: $CIRCLE_BRANCH]"
+		    $SRCDIR/bin/circleci/do-perf-graphs.py \
+		        --branch $CIRCLE_BRANCH \
+		        --plot-username $PLOTLY_USERNAME \
+		        --plot-key $PLOTLY_API_KEY \
+		        --plot-name $name \
+		        --num $PERF_GRAPH_HISTORY \
+		        --log debug \
+		        --local-build-num $CIRCLE_BUILD_NUM \
+		        --plot-save-to $OUT_DIR/$name.png \
+		        --pattern $name_wo_ext \
+		        --num $PERF_GRAPH_HISTORY "$csv_file"
+
+		    log "Copying CSV file"
+		    cp $csv_file $OUT_DIR/
+		done
+    ;;
+esac
+
+exit 0
+

--- a/bin/circleci/perf-tests.py
+++ b/bin/circleci/perf-tests.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import logging
+from collections import namedtuple
+from fnmatch import fnmatch
+from urlparse import urljoin
+from urllib import urlopen
+import csv
+
+try:
+    import plotly
+    import plotly.plotly as py
+    from plotly.graph_objs import *
+except ImportError:
+    print "FATAL: you need to install plotly (try 'pip install plotly'"
+    sys.exit(1)
+    
+
+try:
+    import requests
+except ImportError:
+    print "FATAL: you need to install requests (try 'pip install requests'"
+    sys.exit(1)
+
+
+API_ROOT    = "https://circleci.com/api/v1"
+USERNAME    = "weaveworks"
+PROJECT     = "weave"
+BRANCH      = "master"
+TOKEN       = None
+BUILDS_NUM  = 10
+
+#######################################################################################
+
+def get_latest_builds(options, allow_failures=False):
+    filt = 'completed' if allow_failures else 'successful'
+    target = '{root}/project/{user}/{project}/tree/{branch}?limit={num}&filter={filt}'.format(
+                root=options.api_root,
+                user=options.username,
+                project=options.project,
+                branch=options.branch,
+                num=options.num_builds,
+                filt=filt)
+    if options.token is not None:
+        target += '&circle-token={}'.format(options.token)
+    data = requests.get(target, headers={'Accept': 'application/json'})
+    output = data.json()
+    if len(output) == 0:
+        raise ValueError('No matching builds.')
+    return [x['build_num'] for x in output]
+
+def get_artifact_list(options, build):
+    target = '{root}/project/{user}/{project}/{build}/artifacts'.format(
+                root=API_ROOT,
+                user=USERNAME,
+                project=PROJECT,
+                build=build)
+    if options.token is not None:
+        target += '?circle-token={}'.format(options.token)
+    data = requests.get(target, headers={'Accept': 'application/json'})
+    output = data.json()
+    return {x['pretty_path'][18:]: x['url'] for x in output}
+
+
+# iperf CSV output example:
+# 20140114124826,127.0.0.1,54402,127.0.0.1,5001,5,0.0-10.0,52551090176,42041052917
+# 20140114124826,127.0.0.1,5001,127.0.0.1,54402,4,0.0-10.0,52551090200,41999020136
+
+StatsLine = namedtuple('StatsLine',
+                       ['timestamp',
+                        'orig_ip',
+                        'orig_port',
+                        'dst_ip',
+                        'dst_port',
+                        'unknown',
+                        'time',
+                        'data',
+                        'throughput'])
+
+BuildStats = namedtuple('BuildStats',
+                       ['num',
+                        'file'])
+                       
+# parse a CSV log filename, returning a list of stats lines
+# @param: a read()'able file or data
+def parse_log(data):
+    return [StatsLine._make(line) for line in csv.reader(data)]
+
+# get an average throughtput for a  list of lines
+def average_throughtput(stat_lines):
+    return sum([int(l.throughput) for l in stat_lines])/len(stat_lines)
+
+def average_throughtput_mbps(stat_lines):
+    return average_throughtput(stat_lines) / (1024 * 1024)
+
+if __name__ == "__main__":
+    arguments = argparse.ArgumentParser(description="A CircleCI performance reports plotter")
+    arguments.add_argument('--api-root', type=str,
+                           help='API root for CircleCI', default=API_ROOT)
+    arguments.add_argument('--token', type=str,
+                           help='API key', nargs='?')
+    arguments.add_argument('--username', type=str,
+                           help='GitHub username', default=USERNAME)
+    arguments.add_argument('--project', type=str,
+                           help='GitHub project', default=PROJECT)
+    arguments.add_argument('--branch', type=str,
+                           help='Project branch', default=BRANCH)
+    arguments.add_argument('--plot-username', type=str, dest='plot_username',
+                           help='Ploty username', required=True)
+    arguments.add_argument('--plot-key', type=str, dest='plot_key',
+                           help='Ploty API key', required=True)
+    arguments.add_argument('--plot-name', type=str, dest='plot_name',
+                           help='Ploty plot name', default=None)
+    arguments.add_argument('--plot-description', type=str, dest='plot_desc',
+                           help='Ploty plot description', default="Throughput")
+    arguments.add_argument('--plot-save-to', dest='plot_save_to',
+                           help='Save the Ploty plot to a local PNG file',
+                           type=argparse.FileType('w'), default=None)
+    arguments.add_argument('--num', type=int, dest='num_builds',
+                           default=BUILDS_NUM, help='Number of builds to retrieve')
+    arguments.add_argument('--local-build-num', type=int, dest='local_num',
+                           default=0, help='Build number to use for local files')
+    arguments.add_argument('--pattern', type=str,
+                           help='Artifact pattern (or exact name) to get',
+                           nargs='*', default=['*.csv'])
+    arguments.add_argument('--log', type=str, dest='loglevel',
+                           help='Log level', default="info")
+    arguments.add_argument('infile', nargs='*',
+                           help="a local iperf CSV file",
+                           type=argparse.FileType('r'), default=[])
+    args = arguments.parse_args()
+
+    numeric_level = getattr(logging, args.loglevel.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: %s' % loglevel)
+    logging.basicConfig(level=numeric_level)
+
+    plotly.tools.set_credentials_file(username = args.plot_username,
+                                      api_key = args.plot_key)
+    
+    fs = []
+    if args.num_builds == 0:
+        logging.info('Skipping CircleCI builds')
+    else:
+        for build_num in get_latest_builds(args):
+            artifacts = get_artifact_list(args, build_num)
+            for name, url in artifacts.items():
+                if any(fnmatch(name, pattern) for pattern in args.pattern):
+                    logging.info('Retrieving {build_num}:{name}...'.format(
+                        name=name, build_num=build_num))
+                    stats = BuildStats(num=int(build_num), file=urlopen(url))
+                    fs.append(stats)
+                else:
+                    logging.debug('Skipping {name}'.format(name=name))
+
+    if len(args.infile) > 0:
+        try:
+            first_local_num = fs[-1].num
+        except IndexError:
+            n = int(args.local_num)
+            logging.info('Local files from build_num={}'.format(n))
+            first_local_num = n
+        last_local_build = first_local_num + len(args.infile)
+        local_range = range(first_local_num, last_local_build)
+        fs += [BuildStats(x[0], x[1]) for x in zip(local_range, args.infile)]
+    
+    try:
+        throughputs = [(f.num, average_throughtput_mbps(parse_log(f.file))) for f in fs]
+        logging.debug("Obtained {} throughputs values".format(len(throughputs)))
+    except TypeError, e:
+        logging.critical("could not parse file {name}: {e}".format(name=f, e=e))
+        sys.exit(1)
+        
+    if len(throughputs) == 0:
+        logging.warning("no performance data obtained")
+        sys.exit(1)
+    else:
+        build_nums, throughputs = zip(*throughputs)
+        trace0 = Scatter(x = build_nums,
+                        y = throughputs,
+                        mode = 'lines+markers',
+                        name = args.plot_desc,
+                        line = Line(
+                            shape='linear'
+                        ))
+        data = Data([trace0])
+        layout = Layout(
+            xaxis = XAxis(
+                title = 'Build number',
+                autotick = False,
+            ),
+            yaxis = YAxis(
+                title = 'Throughput (MBps)',
+            ),
+            legend = Legend(
+                y = 0.5,
+                traceorder = 'reversed',
+                font = Font(
+                    size=16
+                ),
+                yref='paper'
+            )
+        )
+        fig = Figure(data=data, layout=layout)
+
+        logging.info("Plotting to plotly...")
+        unique_url = py.plot(fig, filename = args.branch + "/" + args.plot_name)
+        logging.info("Plot can be found at {}".format(unique_url))
+        if args.plot_save_to:
+            logging.info("Saving PNG to {}".format(args.plot_save_to))
+            args.plot_save_to.write(requests.get("{}.png".format(unique_url)).content)
+
+

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,11 @@ machine:
     PATH: $PATH:$HOME/.local/bin:$HOME/google-cloud-sdk/bin/
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     WEAVE_TEST: $HOME/docker/weave-test.tar
+    # performance graphs parameters (TODO: move the API key to some better place...)
+    PLOTLY_USERNAME: inercia
+    PLOTLY_API_KEY: agdnvosyjk
+    # performance graph: the number of previous builds to use
+    PERF_GRAPH_HISTORY: 10
 
 dependencies:
   cache_directories:
@@ -36,6 +41,8 @@ dependencies:
     - cp -r $(pwd)/ $SRCDIR
     - cd $SRCDIR/test; ./gce.sh make_template:
         parallel: false
+    - $SRCDIR/bin/circleci/perf-tests pre:
+        parallel: true
 
 test:
   override:
@@ -50,6 +57,9 @@ test:
     - cd $SRCDIR/test; eval $(./gce.sh hosts); ./setup.sh:
         parallel: true
     - cd $SRCDIR/test; eval $(./gce.sh hosts); export COVERAGE=true; ./run_all.sh:
+        parallel: true
+        timeout: 300
+    - $SRCDIR/bin/circleci/perf-tests start:
         parallel: true
         timeout: 300
     - cd $SRCDIR; make clean-bin:
@@ -67,6 +77,8 @@ teardown:
     - test "$CIRCLE_NODE_INDEX" != "0" || (go get github.com/mattn/goveralls && goveralls -repotoken $COVERALLS_REPO_TOKEN -coverprofile=$SRCDIR/test/profile.cov -service=circleci || true):
         parallel: true
     - test "$CIRCLE_NODE_INDEX" != "0" || (cd $SRCDIR/test; cp coverage.* $CIRCLE_ARTIFACTS):
+        parallel: true
+    - $SRCDIR/bin/circleci/perf-tests post:
         parallel: true
 
 deployment:

--- a/test/900_cross_host_2_perf.sh
+++ b/test/900_cross_host_2_perf.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. ./perf.sh
 
 [ -n "$PERFORMANCE" ] || exit 0
 

--- a/test/900_cross_host_perf.sh
+++ b/test/900_cross_host_perf.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+. ./config.sh
+
+[ -n "$PERFORMANCE" ] || exit 0
+
+C1=10.2.2.4
+C2=10.2.2.7
+UNIVERSE=10.2.0.0/16
+
+start_perf_suite "Iperf over cross-host weave network"
+
+weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE 
+weave_on $HOST2 launch-router --ipalloc-range $UNIVERSE $HOST1
+
+start_iperf_server $HOST1 ip:$C1/24
+start_iperf_client $HOST2 ip:$C2/24 "iperf_cross" -t10
+
+end_perf_suite

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -1,0 +1,47 @@
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$DIR/config.sh"
+
+IPERF_IMAGE="inercia/iperf"
+
+################################
+# performance utils
+################################
+
+start_perf_suite() {
+    start_suite $@
+    [ -d $DIR/performance ] || mkdir $DIR/performance
+}
+
+end_perf_suite() {
+    for host in $HOSTS; do
+        docker_on $host stop iperf_server 1>/dev/null 2>&1 || true
+        docker_on $host stop iperf_client 1>/dev/null 2>&1 || true
+    done
+    end_suite $@
+}
+
+# start an iperf server
+start_iperf_server() {
+    host=$1
+    addr=$2
+    shift 2
+    weave_on $host run $addr --name=iperf_server -t $IPERF_IMAGE "$@"
+}
+
+# start and wait for an iperf client
+start_iperf_client() {
+    host=$1
+    addr=$2
+    name=$3
+    shift 3
+
+    C=$(weave_on $host run $addr --name=iperf_client -t $IPERF_IMAGE -c iperf_server -y C -i1 "$@")
+    docker_on $host wait $C 1>/dev/null 2>&1
+
+    # collect the stats and leave them in the performance/ dir
+    rm -f $DIR/performance/$name
+    docker_on $host logs $C > $DIR/performance/$name.csv
+    echo $C
+}
+

--- a/testing/runner/runner.go
+++ b/testing/runner/runner.go
@@ -167,7 +167,9 @@ func getTests(testNames []string) (tests, error) {
 	}
 	tests := tests{}
 	for _, name := range testNames {
-		parts := strings.Split(strings.TrimSuffix(name, "_test.sh"), "_")
+		n := strings.TrimSuffix(name, "_test.sh")
+		n = strings.TrimSuffix(name, "_perf.sh")
+		parts := strings.Split(n, "_")
 		numHosts, err := strconv.Atoi(parts[len(parts)-1])
 		if err != nil {
 			numHosts = 1


### PR DESCRIPTION
Fixes #1119 

This PR adds an initial performance test that runs `iperf` between two hosts. It generates a iperf log that is stored in `test/performance/*.log`. Performance tests can be run with the rest of the integration test by doing a `PERFORMANCE=1 ./run_all.sh`

The underlying objective of this PR is to determine how to deal with performance tests: to determine what we really need, what to do with the results, etc...

How it works:
- Performance tests generate `*.csv` files that are archieved with the rest of the artifacts.
- A Python script tries to get the `*.csv` files from the last _n_ builds for each performance tests from CircleCI.
- The Python script generates a peformance graph with the `*.csv`s
- In contrast with other CI systems like Jenkins, CircleCI cannot provide a constant URL for accessing the latest build (and its artifacts), so we have to store the performance graph in an external service. In this case, perfomance graphs are plotted with the help of [Plotly](www.plotly.com) and stored [here](https://plot.ly/~inercia)

TODO:
- [x] Include the performance tests in the CircleCI builds
- [x] Archive the artifacts (test/performance/*.log)
- [x] Generate some graphs and link them from some place in our docs
- [ ] Create a _weaveworks_ user in Plotly for generating performance graphs. Remove @inercia's credentials (will do this once this is merged in master)
- [ ] Skip branches other than master (will do this once this is merged in master)
