### PR TITLE
Re-arrange weaveexec Dockerfile to improve download times

### DIFF
--- a/prog/weaveexec/Dockerfile
+++ b/prog/weaveexec/Dockerfile
@@ -2,6 +2,10 @@ FROM gliderlabs/alpine
 
 MAINTAINER Weaveworks Inc <help@weave.works>
 
+WORKDIR /home/weave
+VOLUME /w
+ENTRYPOINT ["/home/weave/sigproxy", "/home/weave/weave"]
+
 RUN apk add --update \
     curl \
     ethtool \
@@ -12,15 +16,7 @@ RUN apk add --update \
     bind-tools \
   && rm -rf /var/cache/apk/*
 
-WORKDIR /home/weave
-
-ADD ./weave /home/weave/
-ADD ./sigproxy /home/weave/
-ADD ./weaveproxy /home/weave/
+ADD ./weave ./sigproxy ./weaveproxy /home/weave/
 ADD ./netcheck /usr/bin/
 ADD ./weavewait /w/w
 ADD ./docker.tgz /
-
-VOLUME /w
-
-ENTRYPOINT ["/home/weave/sigproxy", "/home/weave/weave"]


### PR DESCRIPTION
Combining multiple ADDs on the same line reduces the number of layers, and moving the stuff that doesn't change earlier in the file improves the chance it will re-use that layer from cache.

Empirically, the ADD lines are never cached, so they should come last.