### PR TITLE
Use Boostrap styles for warnings in docs

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -19,7 +19,7 @@
 
      <!-- CSS
        –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-    <link rel="stylesheet" type="text/css" href="assets/custom.css">
+    <link rel="stylesheet" type="text/css" href="assets/custom.css?v=1">
 
      <!-- Favicon
        –––––––––––––––––––––––––––––––––––––––––––––––––– -->

--- a/site/assets/custom.css
+++ b/site/assets/custom.css
@@ -5489,6 +5489,40 @@ p {
 pre {
   padding: 30px;
 }
+/* making this more look like a note, as opposed to a quote */
+blockquote {
+  padding: 15px;
+  margin-bottom: 17pt;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+  color: #8a6d3b;
+  font-size: inherit;
+}
+blockquote h4 {
+  margin-top: 0;
+  color: inherit;
+}
+blockquote .alert-link {
+  font-weight: bold;
+}
+blockquote > p,
+blockquote > ul {
+  margin-bottom: 0;
+}
+blockquote > p + p {
+  margin-top: 5px;
+}
+blockquote hr {
+  border-top-color: #f7e1b5;
+}
+blockquote .alert-link {
+  color: #66512c;
+}
+blockquote p {
+  margin-top: 0;
+}
 .navbar {
   padding-top: 15px;
 }


### PR DESCRIPTION
Instead of using `> ` for warnings in the docs, we'll use 
```html
<div class="alert alert-warning">
Crazy stuff happening...
</div>
```

Fixes #1061 