### PR TITLE
More helpful error message when --ip-alloc-range mismatched

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -613,6 +613,10 @@ func (alloc *Allocator) update(sender router.PeerName, msg []byte) error {
 	// shouldn't get updates for a empty Ring. But tolerate
 	// them just in case.
 	if data.Ring != nil {
+		if data.Ring.Range() != alloc.universe {
+			return fmt.Errorf("Incompatible IP allocation range %s; ours is %s",
+				data.Ring.Range().AsCIDRString(), alloc.universe.AsCIDRString())
+		}
 		err = alloc.ring.Merge(*data.Ring)
 		if !alloc.ring.Empty() {
 			alloc.pruneNicknames()

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -64,7 +64,7 @@ func NewAllocator(ourName router.PeerName, ourUID router.PeerUID, ourNickname st
 	return &Allocator{
 		ourName:   ourName,
 		universe:  universe,
-		ring:      ring.New(universe.Start, address.Add(universe.Start, universe.Size()), ourName),
+		ring:      ring.New(universe.Start, universe.End, ourName),
 		owned:     make(map[string][]address.Address),
 		paxos:     paxos.NewNode(ourName, ourUID, quorum),
 		nicknames: map[router.PeerName]string{ourName: ourNickname},

--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -92,6 +92,10 @@ func New(start, end address.Address, peer router.PeerName) *Ring {
 	return ring
 }
 
+func (r *Ring) Range() address.Range {
+	return address.Range{Start: r.Start, End: r.End}
+}
+
 // Returns the distance between two tokens on this ring, dealing
 // with ranges which cross the origin
 func (r *Ring) distance(start, end address.Address) address.Offset {

--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -33,16 +33,16 @@ func (r *Ring) assertInvariants() {
 
 // Errors returned by Merge
 var (
-	ErrNotSorted        = errors.New("Ring not sorted")
-	ErrTokenRepeated    = errors.New("Token appears twice in ring")
-	ErrTokenOutOfRange  = errors.New("Token is out of range")
-	ErrDifferentSubnets = errors.New("IP Allocator with different subnet detected")
-	ErrNewerVersion     = errors.New("Received new version for entry I own!")
-	ErrInvalidEntry     = errors.New("Received invalid state update!")
-	ErrEntryInMyRange   = errors.New("Received new entry in my range!")
-	ErrNoFreeSpace      = errors.New("No free space found!")
-	ErrInvalidTimeout   = errors.New("dt must be greater than 0")
-	ErrNotFound         = errors.New("No entries for peer found")
+	ErrNotSorted       = errors.New("Ring not sorted")
+	ErrTokenRepeated   = errors.New("Token appears twice in ring")
+	ErrTokenOutOfRange = errors.New("Token is out of range")
+	ErrDifferentRange  = errors.New("Received range differs from ours!")
+	ErrNewerVersion    = errors.New("Received new version for entry I own!")
+	ErrInvalidEntry    = errors.New("Received invalid state update!")
+	ErrEntryInMyRange  = errors.New("Received new entry in my range!")
+	ErrNoFreeSpace     = errors.New("No free space found!")
+	ErrInvalidTimeout  = errors.New("dt must be greater than 0")
+	ErrNotFound        = errors.New("No entries for peer found")
 )
 
 func (r *Ring) checkInvariants() error {
@@ -191,7 +191,7 @@ func (r *Ring) Merge(gossip Ring) error {
 	}
 
 	if r.Start != gossip.Start || r.End != gossip.End {
-		return ErrDifferentSubnets
+		return ErrDifferentRange
 	}
 
 	// Now merge their ring with yours, in a temporary ring.

--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -40,8 +40,6 @@ var (
 	ErrNewerVersion    = errors.New("Received new version for entry I own!")
 	ErrInvalidEntry    = errors.New("Received invalid state update!")
 	ErrEntryInMyRange  = errors.New("Received new entry in my range!")
-	ErrNoFreeSpace     = errors.New("No free space found!")
-	ErrInvalidTimeout  = errors.New("dt must be greater than 0")
 	ErrNotFound        = errors.New("No entries for peer found")
 )
 

--- a/ipam/ring/ring_test.go
+++ b/ipam/ring/ring_test.go
@@ -212,7 +212,7 @@ func TestMergeErrors(t *testing.T) {
 	// Should Merge two rings for different ranges
 	ring2 = New(start, middle, peer2name)
 	ring2.Entries = []*entry{}
-	require.True(t, ring1.Merge(*ring2) == ErrDifferentSubnets, "Expected ErrDifferentSubnets")
+	require.True(t, ring1.Merge(*ring2) == ErrDifferentRange, "Expected ErrDifferentRange")
 
 	// Cannot Merge newer version of entry I own
 	ring2 = New(start, end, peer2name)

--- a/net/address/address.go
+++ b/net/address/address.go
@@ -23,6 +23,17 @@ func (r Range) String() string             { return fmt.Sprintf("[%s-%s)", r.Sta
 func (r Range) Overlaps(or Range) bool     { return !(r.Start >= or.End || r.End <= or.Start) }
 func (r Range) Contains(addr Address) bool { return addr >= r.Start && addr < r.End }
 
+func (r Range) AsCIDRString() string {
+	prefixLen := 32
+	for size := r.Size(); size > 1; size = size / 2 {
+		if size%2 != 0 { // Size not a power of two; cannot be expressed as a CIDR.
+			return r.String()
+		}
+		prefixLen--
+	}
+	return CIDR{Start: r.Start, PrefixLen: prefixLen}.String()
+}
+
 type CIDR struct {
 	Start     Address
 	PrefixLen int


### PR DESCRIPTION
Fixes #1128

I did an additional check at the `Allocator` level rather than modifying the check inside `Ring`, to keep the latter unaware of why `Merge` has been called.