### PR TITLE
updating boot2docker docs for proxy

### DIFF
--- a/site/boot2docker.md
+++ b/site/boot2docker.md
@@ -7,23 +7,29 @@ layout: default
 
 If you are running Docker inside the Boot2Docker VM, e.g. because you
 are on a Mac, then the following changes are required to the weave
-instructions:
+instructions. First, we need to get Boot2Docker running:
+
+    host1$ boot2docker init
+    host1$ boot2docker start
+    host1$ eval "$(boot2docker shellinit)"
 
 Assuming you have fetched the 'weave' script via curl or similar, and
-it is in the current directory, transfer it to the Boot2Docker VM and
-make it executable like this:
+it is in the current directory, launch weave on the Boot2Docker VM and
+configure our shell. Because Boot2Docker uses TLS, we have to pass a
+few extra options when launching the docker API proxy:
 
-    host1$ boot2docker ssh "cat > weave" < weave
-    host1$ boot2docker ssh "chmod a+x weave"
+    host1$ ./weave launch
+    host1$ ./weave launch-dns
+    host1$ ./weave launch-proxy --tls \
+             --tlscacert /var/lib/boot2docker/tls/ca.pem \
+             --tlscert /var/lib/boot2docker/tls/server.pem \
+             --tlskey /var/lib/boot2docker/tls/serverkey.pem
+    host1$ eval "$(./weave proxy-env)"
 
-Then, if we were trying to create the same containers as in the first
-example above, the 'launch' command would be run like this:
+Now, we can use the docker command to run our containers, as shown in
+the [proxy documentation](proxy.html):
 
-    host1$ boot2docker ssh "sudo ./weave launch"
-
-and the 'run' command like this:
-
-    host1$ C=$(boot2docker ssh "sudo ./weave run 10.2.1.1/24 -t -i ubuntu")
+    host1$ docker run -it ubuntu
 
 For more information about how to access services running in
 Boot2Docker from the host or other machines (i.e. outside of the weave


### PR DESCRIPTION
The TLS options bit is quite gross. It goes away with [this branch](https://github.com/paulbellamy/weave/tree/1105-proxy-autoconfig), which auto-configures the proxy's tls based on the docker daemon (if we want to go that way).
The other option is to disable tls for boot2docker:
```
host1$ ./weave launch-proxy -H tcp://0.0.0.0:12375`
host1$ eval "$(./weave proxy-env)"
host1$ unset DOCKER_TLS_VERIFY
``` 

Fixes #975, but needs modifying for master