### PR TITLE
Correctly stop the test gossip router to prevent complaints of data races in subsequent tests.

### DIFF
--- a/nameserver/nameserver_test.go
+++ b/nameserver/nameserver_test.go
@@ -31,10 +31,11 @@ func makeNetwork(size int) ([]*Nameserver, *gossip.TestRouter) {
 	return nameservers, gossipRouter
 }
 
-func stopNetwork(nameservers []*Nameserver) {
+func stopNetwork(nameservers []*Nameserver, grouter *gossip.TestRouter) {
 	for _, nameserver := range nameservers {
 		nameserver.Stop()
 	}
+	grouter.Stop()
 }
 
 type pair struct {
@@ -74,7 +75,7 @@ func TestNameservers(t *testing.T) {
 
 	lookupTimeout := 20 // ms
 	nameservers, grouter := makeNetwork(50)
-	defer stopNetwork(nameservers)
+	defer stopNetwork(nameservers, grouter)
 	nameserversByName := map[router.PeerName]*Nameserver{}
 	for _, n := range nameservers {
 		nameserversByName[n.ourName] = n

--- a/testing/gossip/mocks.go
+++ b/testing/gossip/mocks.go
@@ -34,6 +34,12 @@ func NewTestRouter(loss float32) *TestRouter {
 	return &TestRouter{make(map[router.PeerName]chan interface{}, 100), loss}
 }
 
+func (grouter *TestRouter) Stop() {
+	for peer := range grouter.gossipChans {
+		grouter.RemovePeer(peer)
+	}
+}
+
 func (grouter *TestRouter) gossipBroadcast(sender router.PeerName, update router.GossipData) error {
 	for _, gossipChan := range grouter.gossipChans {
 		select {


### PR DESCRIPTION
Fixes #1181 