### PR TITLE
Don't delete record of IP allocation immediately after container death

### DIFF
--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -14,6 +14,7 @@ import (
 type ContainerObserver interface {
 	ContainerStarted(ident string)
 	ContainerDied(ident string)
+	ContainerDestroyed(ident string)
 }
 
 type Client struct {
@@ -82,11 +83,11 @@ func (c *Client) AddObserver(ob ContainerObserver) error {
 		for event := range events {
 			switch event.Status {
 			case "start":
-				id := event.ID
-				ob.ContainerStarted(id)
+				ob.ContainerStarted(event.ID)
 			case "die":
-				id := event.ID
-				ob.ContainerDied(id)
+				ob.ContainerDied(event.ID)
+			case "destroy":
+				ob.ContainerDestroyed(event.ID)
 			}
 		}
 	}()

--- a/ipam/allocate.go
+++ b/ipam/allocate.go
@@ -26,6 +26,8 @@ func (g *allocate) Try(alloc *Allocator) bool {
 	}
 
 	if addr, found := alloc.lookupOwned(g.ident, g.r); found {
+		// If we had heard that this container died, resurrect it
+		delete(alloc.dead, g.ident) // delete is no-op if key not in map
 		g.resultChan <- allocateResult{addr, nil}
 		return true
 	}

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -23,7 +23,7 @@ const (
 
 	tickInterval         = time.Second * 5
 	MinSubnetSize        = 4 // first and last addresses are excluded, so 2 would be too small
-	containerDiedTimeout = time.Second * 5
+	containerDiedTimeout = time.Second * 30
 )
 
 // operation represents something which Allocator wants to do, but

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -239,6 +239,17 @@ func (alloc *Allocator) ContainerDied(ident string) {
 	}
 }
 
+// ContainerDestroyed called from the updater interface.  Async.
+func (alloc *Allocator) ContainerDestroyed(ident string) {
+	alloc.actionChan <- func() {
+		if _, found := alloc.lookupOwned(ident, alloc.universe); found {
+			alloc.debugln("Container", ident, "destroyed; removing addresses")
+			alloc.delete(ident)
+			delete(alloc.dead, ident)
+		}
+	}
+}
+
 func (alloc *Allocator) removeDeadContainers() {
 	cutoff := alloc.now().Add(-containerDiedTimeout)
 	for ident, timeOfDeath := range alloc.dead {

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -40,6 +40,9 @@ func (c *claim) Try(alloc *Allocator) bool {
 
 	alloc.establishRing()
 
+	// If we had heard that this container died, resurrect it
+	delete(alloc.dead, c.ident) // (delete is no-op if key not in map)
+
 	switch owner := alloc.ring.Owner(c.addr); owner {
 	case alloc.ourName:
 		// success
@@ -78,6 +81,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 		}
 	case c.ident:
 		// same identifier is claiming same address; that's OK
+		alloc.debugln("Re-Claimed", c.addr, "for", c.ident)
 		c.sendResult(nil)
 	default:
 		// Addr already owned by container on this machine

--- a/ipam/status.go
+++ b/ipam/status.go
@@ -36,7 +36,7 @@ func NewStatus(allocator *Allocator, defaultSubnet address.CIDR) *Status {
 	}
 
 	var paxosStatus *paxos.Status
-	if allocator.paxosTicker != nil {
+	if allocator.paxosActive {
 		paxosStatus = paxos.NewStatus(allocator.paxos)
 	}
 

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -121,7 +121,8 @@ func (n *Nameserver) ReverseLookup(ip address.Address) (string, error) {
 	return match.Hostname, nil
 }
 
-func (n *Nameserver) ContainerStarted(ident string) {}
+func (n *Nameserver) ContainerStarted(ident string)   {}
+func (n *Nameserver) ContainerDestroyed(ident string) {}
 
 func (n *Nameserver) ContainerDied(ident string) {
 	n.Lock()

--- a/plugin/net/watcher.go
+++ b/plugin/net/watcher.go
@@ -55,3 +55,5 @@ func (w *watcher) ContainerDied(id string) {
 	// don't need to do this as WeaveDNS removes names on container died anyway
 	// (note by the time we get this event we can't see the EndpointID)
 }
+
+func (w *watcher) ContainerDestroyed(id string) {}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -458,8 +458,8 @@ func (proxy *Proxy) waitForStartByIdent(ident string) error {
 	return nil
 }
 
-func (proxy *Proxy) ContainerDied(ident string) {
-}
+func (proxy *Proxy) ContainerDied(ident string)      {}
+func (proxy *Proxy) ContainerDestroyed(ident string) {}
 
 // Check if this container needs to be attached, and return nil on success or not needed.
 func (proxy *Proxy) attach(containerID string, orDie bool) error {

--- a/site/features.md
+++ b/site/features.md
@@ -156,6 +156,19 @@ connect to. The individual IP addresses given to containers must, of
 course, be unique - if you pick an address that the automatic
 allocator has already assigned you will receive a warning.
 
+If you restart a container, it will retain the same IP addresses on
+the weave network:
+
+    host1$ docker run --name a1 -tdi ubuntu
+    f76b09a9fcfee04551dbb8d951d9a83e7e7d55126b02fd9f44f9f8a5f07d7c96
+    host1$ weave ps a1
+    a1 1e:dc:2a:db:ef:ff 10.32.0.3/12
+    host1$ docker restart a1
+    host1$ weave ps a1
+    a1 16:c0:6f:5d:c5:73 10.32.0.3/12
+
+(note that the IP address is held for a limited time - currently five seconds)
+
 ### <a name="naming-and-discovery"></a>Naming and discovery
 
 Named containers are automatically registered in

--- a/site/features.md
+++ b/site/features.md
@@ -181,7 +181,7 @@ current IP addresses:
     host1$ weave restart b1
 
 (note that the IP addresses are held for a limited time - currently
-five seconds)
+30 seconds)
 
 ### <a name="naming-and-discovery"></a>Naming and discovery
 

--- a/site/features.md
+++ b/site/features.md
@@ -167,6 +167,11 @@ the weave network:
     host1$ weave ps a1
     a1 16:c0:6f:5d:c5:73 10.32.0.3/12
 
+There is also a `weave restart` command, if you are not using the
+weave Docker API proxy:
+
+    host1$ weave restart b1
+
 (note that the IP address is held for a limited time - currently five seconds)
 
 ### <a name="naming-and-discovery"></a>Naming and discovery

--- a/site/features.md
+++ b/site/features.md
@@ -167,12 +167,21 @@ the weave network:
     host1$ weave ps a1
     a1 16:c0:6f:5d:c5:73 10.32.0.3/12
 
-There is also a `weave restart` command, if you are not using the
-weave Docker API proxy:
+It works the same if you stop and immediately restart:
+
+    host1$ docker stop a1
+    host1$ docker start a1
+
+However, additional addresses added with the `weave attach` command
+will not be retained.
+
+There is also a `weave restart` command, which does re-attach all
+current IP addresses:
 
     host1$ weave restart b1
 
-(note that the IP address is held for a limited time - currently five seconds)
+(note that the IP addresses are held for a limited time - currently
+five seconds)
 
 ### <a name="naming-and-discovery"></a>Naming and discovery
 

--- a/test/100_cross_hosts_2_test.sh
+++ b/test/100_cross_hosts_2_test.sh
@@ -27,4 +27,12 @@ start_container $HOST2 net:$SUBNET_2 --name=c6
 C6=$(container_ip $HOST2 c6)
 assert_raises "exec_on $HOST1 c5 $PING $C6"
 
+# check that restart retains the same IP, and reclaims it in IPAM
+weave_on $HOST2 restart c6
+assert_raises "exec_on $HOST1 c5 $PING $C6"
+sleep 6 # past the IPAM timeout
+start_container $HOST2 net:$SUBNET_2 --name=c7
+C7=$(container_ip $HOST2 c7)
+assert_raises "[ $C6 != $C7 ]"
+
 end_suite

--- a/test/100_cross_hosts_2_test.sh
+++ b/test/100_cross_hosts_2_test.sh
@@ -30,7 +30,7 @@ assert_raises "exec_on $HOST1 c5 $PING $C6"
 # check that restart retains the same IP, and reclaims it in IPAM
 weave_on $HOST2 restart c6
 assert_raises "exec_on $HOST1 c5 $PING $C6"
-sleep 6 # past the IPAM timeout
+sleep 31 # past the IPAM timeout
 start_container $HOST2 net:$SUBNET_2 --name=c7
 C7=$(container_ip $HOST2 c7)
 assert_raises "[ $C6 != $C7 ]"

--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -2,8 +2,6 @@
 
 . ./config.sh
 
-C1=10.2.0.78
-C2=10.2.0.34
 NAME=seetwo.weave.local
 
 check_attached() {
@@ -26,8 +24,9 @@ wait_for_proxy() {
 start_suite "Proxy restart reattaches networking to containers"
 
 WEAVE_DOCKER_ARGS=--restart=always WEAVEPROXY_DOCKER_ARGS=--restart=always weave_on $HOST1 launch
-proxy_start_container          $HOST1 -e WEAVE_CIDR=$C2/24 -di --name=c2 --restart=always -h $NAME
-proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C1/24 -di --name=c1 --restart=always
+proxy_start_container          $HOST1 -di --name=c2 --restart=always -h $NAME
+proxy_start_container_with_dns $HOST1 -di --name=c1 --restart=always
+C2=$(container_ip $HOST1 c2)
 
 proxy docker_on $HOST1 restart -t=1 c2
 check_attached
@@ -42,11 +41,13 @@ run_on $HOST1 sudo kill -KILL $(docker_on $HOST1 inspect --format='{{.State.Pid}
 sleep 1
 check_attached
 
-# Disabled because Docker 1.8 often fails to restart weave or weaveproxy
 # Restart docker itself, using different commands for systemd- and upstart-managed.
-#run_on $HOST1 sh -c "command -v systemctl >/dev/null && sudo systemctl restart docker || sudo service docker restart"
-#wait_for_proxy $HOST1
-#check_attached
+run_on $HOST1 sh -c "command -v systemctl >/dev/null && sudo systemctl restart docker || sudo service docker restart"
+wait_for_proxy $HOST1
+sleep 5 # allow for re-tries of attach
+# Re-fetch the IP since it is not retained on docker restart
+C2=$(container_ip $HOST1 c2) || (echo "container c2 has no IP address" 2>&1; exit 1)
+check_attached
 
 # Restarting proxy shouldn't kill unattachable containers
 proxy_start_container $HOST1 -di --name=c3 --restart=always # Use ipam, so it won't be attachable w/o weave

--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -21,6 +21,16 @@ wait_for_proxy() {
     exit 1
 }
 
+N=50
+# Create and remove a lot of containers in a small subnet; the failure
+# mode is that this takes a long time as it has to wait for the old
+# ones to time out, so we run this function inside 'timeout'
+run_many() {
+    for i in $(seq $N); do
+        proxy docker_on $HOST1 run -e WEAVE_CIDR=net:10.32.4.0/28 --rm -t $SMALL_IMAGE /bin/true
+    done
+}
+
 start_suite "Proxy restart reattaches networking to containers"
 
 WEAVE_DOCKER_ARGS=--restart=always WEAVEPROXY_DOCKER_ARGS=--restart=always weave_on $HOST1 launch
@@ -48,6 +58,8 @@ sleep 5 # allow for re-tries of attach
 # Re-fetch the IP since it is not retained on docker restart
 C2=$(container_ip $HOST1 c2) || (echo "container c2 has no IP address" 2>&1; exit 1)
 check_attached
+
+assert_raises "timeout 90 cat <( run_many )"
 
 # Restarting proxy shouldn't kill unattachable containers
 proxy_start_container $HOST1 -di --name=c3 --restart=always # Use ipam, so it won't be attachable w/o weave

--- a/weave
+++ b/weave
@@ -2036,6 +2036,10 @@ EOF
         create_bridge
         ALL_CIDRS=$(with_container_addresses echo_cidrs $1)
         RES=$(docker restart "$1")
+        CONTAINER=$(container_id $1)
+        for CIDR in $ALL_CIDRS ; do
+            call_weave PUT /ip/$CONTAINER/${CIDR%/*}
+        done
         with_container_netns_or_die $1 attach $ALL_CIDRS
         when_weave_running with_container_fqdn $1 put_dns_fqdn $ALL_CIDRS
         echo $RES

--- a/weave
+++ b/weave
@@ -63,6 +63,7 @@ weave run           [--without-dns] [--no-rewrite-hosts] [--no-multicast-route]
       start         [<addr> ...] <container_id>
       attach        [<addr> ...] <container_id>
       detach        [<addr> ...] <container_id>
+      restart       <container_id>
 
 weave expose        [<addr> ...] [-h <fqdn>]
       hide          [<addr> ...]
@@ -1045,6 +1046,10 @@ echo_ips() {
     done
 }
 
+echo_cidrs() {
+    echo $3
+}
+
 peer_args() {
   res=''
   sep=''
@@ -2025,6 +2030,15 @@ EOF
             call_weave DELETE /ip/$CONTAINER/${CIDR%/*}
         done
         show_addrs $ALL_CIDRS
+        ;;
+    restart)
+        [ $# -ge 1 ] || usage
+        create_bridge
+        ALL_CIDRS=$(with_container_addresses echo_cidrs $1)
+        RES=$(docker restart "$1")
+        with_container_netns_or_die $1 attach $ALL_CIDRS
+        when_weave_running with_container_fqdn $1 put_dns_fqdn $ALL_CIDRS
+        echo $RES
         ;;
     dns-add)
         collect_dns_add_remove_args "$@"


### PR DESCRIPTION
This fixes #1047, without any special reference to the restart command, because the same container ID will get back the same address as long as you start/attach it within the timeout window of 5 seconds.

Perhaps the timeout should be configurable?