### PR TITLE
Catch 'restart' command in proxy and retain IP address

### DIFF
--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -8,6 +8,7 @@ import (
 // An observer for container events
 type ContainerObserver interface {
 	ContainerDied(ident string)
+	ContainerDestroyed(ident string)
 }
 
 type Client struct {
@@ -44,6 +45,8 @@ func (c *Client) AddObserver(ob ContainerObserver) error {
 			case "die":
 				id := event.ID
 				ob.ContainerDied(id)
+			case "destroy":
+				ob.ContainerDestroyed(event.ID)
 			}
 		}
 	}()

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -103,6 +103,11 @@ func (alloc *Allocator) HandleHTTP(router *mux.Router, defaultSubnet address.CID
 		fmt.Fprintf(w, "%s/%d", newAddr, defaultSubnet.PrefixLen)
 	})
 
+	router.Methods("POST").Path("/ip/restarting/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ident := mux.Vars(r)["id"]
+		alloc.NotifyRestart(ident)
+	})
+
 	router.Methods("DELETE").Path("/ip/{id}/{ip}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		ident := vars["id"]

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -146,6 +146,9 @@ func (n *Nameserver) ContainerDied(ident string) {
 	}
 }
 
+func (n *Nameserver) ContainerDestroyed(ident string) {
+}
+
 func (n *Nameserver) PeerGone(peer *router.Peer) {
 	n.infof("peer gone %s", peer.String())
 	n.Lock()

--- a/proxy/start_container_interceptor.go
+++ b/proxy/start_container_interceptor.go
@@ -13,14 +13,21 @@ type startContainerInterceptor struct{ proxy *Proxy }
 
 func callWeaveAndLog(container *docker.Container, description string, args ...string) error {
 	if _, stderr, err := callWeave(args...); err != nil {
-		return fmt.Errorf("Failed: %s container %s: %s", description, container.ID, string(stderr))
+		return fmt.Errorf("Failed: %s: %s", fmt.Sprintf(description, container.ID), string(stderr))
 	} else if len(stderr) > 0 {
-		Log.Warningf("%s container %s: %s", description, container.ID, string(stderr))
+		Log.Warningf("%s: %s", fmt.Sprintf(description, container.ID), container.ID, string(stderr))
 	}
 	return nil
 }
 
 func (i *startContainerInterceptor) InterceptRequest(r *http.Request) error {
+	if strings.HasSuffix(r.URL.Path, "/restart") {
+		container, err := inspectContainerInPath(i.proxy.client, r.URL.Path)
+		if err != nil {
+			return err
+		}
+		return callWeaveAndLog(container, "Notifying weave of restart of container %s", "notify-restart", container.ID)
+	}
 	return nil
 }
 
@@ -39,7 +46,7 @@ func (i *startContainerInterceptor) InterceptResponse(r *http.Response) error {
 	args := []string{"attach"}
 	args = append(args, cidrs...)
 	args = append(args, "--or-die", container.ID)
-	if err := callWeaveAndLog(container, "Attaching to weave network", args...); err != nil {
+	if err := callWeaveAndLog(container, "Attaching container %s to weave network", args...); err != nil {
 		return err
 	}
 

--- a/proxy/start_container_interceptor.go
+++ b/proxy/start_container_interceptor.go
@@ -1,7 +1,7 @@
 package proxy
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -10,6 +10,15 @@ import (
 )
 
 type startContainerInterceptor struct{ proxy *Proxy }
+
+func callWeaveAndLog(container *docker.Container, description string, args ...string) error {
+	if _, stderr, err := callWeave(args...); err != nil {
+		return fmt.Errorf("Failed: %s container %s: %s", description, container.ID, string(stderr))
+	} else if len(stderr) > 0 {
+		Log.Warningf("%s container %s: %s", description, container.ID, string(stderr))
+	}
+	return nil
+}
 
 func (i *startContainerInterceptor) InterceptRequest(r *http.Request) error {
 	return nil
@@ -30,11 +39,8 @@ func (i *startContainerInterceptor) InterceptResponse(r *http.Response) error {
 	args := []string{"attach"}
 	args = append(args, cidrs...)
 	args = append(args, "--or-die", container.ID)
-	if _, stderr, err := callWeave(args...); err != nil {
-		Log.Warningf("Attaching container %s to weave network failed: %s", container.ID, string(stderr))
-		return errors.New(string(stderr))
-	} else if len(stderr) > 0 {
-		Log.Warningf("Attaching container %s to weave network: %s", container.ID, string(stderr))
+	if err := callWeaveAndLog(container, "Attaching to weave network", args...); err != nil {
+		return err
 	}
 
 	return i.proxy.client.KillContainer(docker.KillContainerOptions{ID: container.ID, Signal: docker.SIGUSR2})

--- a/site/features.md
+++ b/site/features.md
@@ -118,6 +118,25 @@ IP addresses of external services the hosts or containers need to
 connect to. The same IP range must be used everywhere, and the
 individual IP addresses must, of course, be unique.
 
+If you restart a container, it will retain the same IP addresses on
+the weave network:
+
+    host1$ docker run --name a1 -tdi ubuntu
+    f76b09a9fcfee04551dbb8d951d9a83e7e7d55126b02fd9f44f9f8a5f07d7c96
+    host1$ weave ps a1
+    a1 1e:dc:2a:db:ef:ff 10.32.0.3/12
+    host1$ docker restart a1
+    host1$ weave ps a1
+    a1 16:c0:6f:5d:c5:73 10.32.0.3/12
+
+There is also a `weave restart` command, if you are not using the
+weave Docker API proxy:
+
+    host1$ weave restart b1
+
+Note that if Docker restarts a container under a restart policy it
+will not be re-attached to the weave network.
+
 ### <a name="naming-and-discovery"></a>Naming and discovery
 
 Named containers are automatically registered in

--- a/test/100_cross_hosts_test.sh
+++ b/test/100_cross_hosts_test.sh
@@ -27,6 +27,10 @@ start_container $HOST2 net:$SUBNET_2 --name=c6
 C6=$(container_ip $HOST2 c6)
 assert_raises "exec_on $HOST1 c5 $PING $C6"
 
+# check that restart retains the same IP
+weave_on $HOST2 restart c6
+assert_raises "exec_on $HOST1 c5 $PING $C6"
+
 # check large packets get through. The first attempt typically fails,
 # since the PMTU hasn't been discovered yet. The 2nd attempt should
 # succeed.

--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -2,17 +2,16 @@
 
 . ./config.sh
 
-C1=10.2.0.78
-C2=10.2.0.34
 NAME=seetwo.weave.local
 
 start_suite "Proxy restart reattaches networking to containers"
 
 weave_on $HOST1 launch
-proxy docker_on $HOST1 run -e WEAVE_CIDR=$C2/24 -dt --name=c2 -h $NAME $SMALL_IMAGE /bin/sh
-proxy docker_on $HOST1 run -e WEAVE_CIDR=$C1/24 -dt --name=c1          $DNS_IMAGE   /bin/sh
+proxy docker_on $HOST1 run -dt --name=c2 -h $NAME $SMALL_IMAGE /bin/sh
+proxy docker_on $HOST1 run -dt --name=c1          $DNS_IMAGE   /bin/sh
 
-proxy docker_on $HOST1 restart c2
+C2=$(container_ip $HOST1 c2)
+proxy docker_on $HOST1 restart --time=1 c2
 assert_raises "proxy exec_on $HOST1 c2 $CHECK_ETHWE_UP"
 assert_dns_record $HOST1 c1 $NAME $C2
 

--- a/weave
+++ b/weave
@@ -47,6 +47,7 @@ weave run           [--with-dns | --without-dns] [<addr> ...]
 weave start         [<addr> ...] <container_id>
 weave attach        [<addr> ...] <container_id>
 weave detach        [<addr> ...] <container_id>
+weave restart       <container_id>
 weave dns-add       <ip_address> [<ip_address> ...] <container_id> [-h <fqdn>]
 weave dns-remove    <ip_address> [<ip_address> ...] <container_id> [-h <fqdn>]
 weave dns-lookup    <unqualified_name>
@@ -650,6 +651,10 @@ with_container_addresses() {
 
 echo_addresses() {
     echo $1 $2 $3
+}
+
+echo_just_ips() {
+    echo $3
 }
 
 peer_args() {
@@ -1361,6 +1366,16 @@ case "$COMMAND" in
             call_weave DELETE /ip/$CONTAINER/${CIDR%/*}
         done
         show_addrs $ALL_CIDRS
+        ;;
+    restart)
+        [ $# -ge 1 ] || usage
+        CONTAINER=$(container_id $1)
+        ALL_CIDRS=$(with_container_addresses echo_just_ips $CONTAINER)
+        call_weave POST /ip/restarting/$CONTAINER 2>/dev/null || true
+        RES=$(docker restart "$@")
+        with_container_netns_or_die $CONTAINER attach $ALL_CIDRS
+        when_weave_running with_container_fqdn $CONTAINER put_dns_fqdn $ALL_CIDRS
+        echo $RES
         ;;
     notify-restart)
         [ $# -eq 1 ] || usage

--- a/weave
+++ b/weave
@@ -1362,6 +1362,12 @@ case "$COMMAND" in
         done
         show_addrs $ALL_CIDRS
         ;;
+    notify-restart)
+        [ $# -eq 1 ] || usage
+        if CONTAINER=$(container_id $1) 2>/dev/null ; then
+            call_weave POST /ip/restarting/$CONTAINER 2>/dev/null || true
+        fi
+        ;;
     dns-add)
         collect_ip_args "$@"
         shift $IP_COUNT


### PR DESCRIPTION
Fixes #1047, when using the weave Docker API proxy.

When notified of an impending restart, we retain this information until we see a `die` or `destroy` event from Docker.

Note that Docker will do a 'restart' for a stopped container; we cannot do anything there because the IP address is lost when it stops, so we give up in `notify-restart` if `container_id` detects a problem.

Couple of other quiet changes in this PR:
 * avoid printing some proxy error messages twice in the logs
 * reduce time docker waits before killing container from 10 seconds to 1 in smoke-test 640