### PR TITLE
Upgrade base image of weaveworks/weave-build to ubuntu:15.04

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu
+FROM ubuntu:15.04
 
 RUN apt-get -y update && apt-get -y install --no-install-recommends ca-certificates apt-transport-https
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
-RUN apt-get -y update && apt-get -y install --no-install-recommends build-essential git lxc-docker-1.3.1 mercurial libpcap-dev curl make pkg-config gcc bison flex python-requests
+RUN apt-get -y update && apt-get -y install --no-install-recommends build-essential git lxc-docker-1.3.1 mercurial libpcap-dev curl make pkg-config gcc bison flex python-requests sudo
 
 # When doing a build in a container, "apt-get update" happens twice,
 # which can be a very significant overhead for incremental builds.


### PR DESCRIPTION
ubuntu:latest runs an old version of the Docker client for which "docker save"
fails when passed multiple images:

"sudo docker save weaveworks/weave:latest weaveworks/weaveexec:latest > weave.tar

Usage: docker save IMAGE

Save an image to a tar archive (streamed to stdout by default)

  -o, --output=""    Write to an file, instead of STDOUT"