### PR TITLE
Remove misleading comment and lowercase deniedBy

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -168,7 +168,7 @@ func (alloc *Allocator) spaceRequestDenied(sender router.PeerName, r address.Ran
 	for i := 0; i < len(alloc.pendingClaims); {
 		claim := alloc.pendingClaims[i].(*claim)
 		if r.Contains(claim.addr) {
-			claim.DeniedBy(alloc, sender)
+			claim.deniedBy(alloc, sender)
 			alloc.pendingClaims = append(alloc.pendingClaims[:i], alloc.pendingClaims[i+1:]...)
 			continue
 		}

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -45,7 +45,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 		// If our ring doesn't know, it must be empty.
 		if c.noErrorOnUnknown {
 			alloc.infof("Claim %s for %s: address allocator still initializing; will try later.", c.addr, c.ident)
-			c.sendResult(nil) // don't make the caller wait
+			c.sendResult(nil)
 		} else {
 			c.sendResult(fmt.Errorf("%s is in the range %s, but the allocator is not initialized yet", c.addr, alloc.universe.AsCIDRString()))
 		}
@@ -58,7 +58,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 				alloc.infof("Claim %s for %s: %s; will try later.", c.addr, c.ident, err)
 				c.sendResult(nil)
 			} else { // just tell the user they can't do this.
-				c.DeniedBy(alloc, owner)
+				c.deniedBy(alloc, owner)
 			}
 		}
 		return false
@@ -84,7 +84,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 	return true
 }
 
-func (c *claim) DeniedBy(alloc *Allocator, owner router.PeerName) {
+func (c *claim) deniedBy(alloc *Allocator, owner router.PeerName) {
 	name, found := alloc.nicknames[owner]
 	if found {
 		name = " (" + name + ")"


### PR DESCRIPTION
 * the comment "don't make the caller wait" applies to both branches
   of that if clause, and having it on one branch implies the other
   does make the caller wait
 * there's no reason for DeniedBy to start with a capital: it's a
   method on a private struct and it's not part of an interface.