### PR TITLE
[proxy] add --rewrite-inspect flag

### DIFF
--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -52,6 +52,7 @@ func main() {
 	ListVar(&c.ListenAddrs, []string{"H"}, nil, "addresses on which to listen")
 	mflag.StringVar(&c.HostnameMatch, []string{"-hostname-match"}, "(.*)", "Regexp pattern to apply on container names (e.g. '^aws-[0-9]+-(.*)$')")
 	mflag.StringVar(&c.HostnameReplacement, []string{"-hostname-replacement"}, "$1", "Expression to generate hostnames based on matches from --hostname-match (e.g. 'my-app-$1')")
+	mflag.BoolVar(&c.RewriteInspect, []string{"-rewrite-inspect"}, false, "Rewrite inspect calls to return the weave IP (if attached)")
 	mflag.BoolVar(&c.NoDefaultIPAM, []string{"#-no-default-ipam", "-no-default-ipalloc"}, false, "do not automatically allocate addresses for containers without a WEAVE_CIDR")
 	mflag.BoolVar(&c.NoRewriteHosts, []string{"no-rewrite-hosts"}, false, "do not automatically rewrite /etc/hosts. Use if you need the docker IP to remain in /etc/hosts")
 	mflag.StringVar(&c.TLSConfig.CACert, []string{"#tlscacert", "-tlscacert"}, "", "Trust certs signed only by this CA")

--- a/proxy/inspect_container_interceptor.go
+++ b/proxy/inspect_container_interceptor.go
@@ -1,0 +1,81 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/weaveworks/weave/common"
+)
+
+type inspectContainerInterceptor struct{ proxy *Proxy }
+
+func (i *inspectContainerInterceptor) InterceptRequest(r *http.Request) error {
+	return nil
+}
+
+func (i *inspectContainerInterceptor) InterceptResponse(r *http.Response) error {
+	if !i.proxy.RewriteInspect {
+		return nil
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+
+	container := &docker.Container{}
+	if err := json.Unmarshal(body, container); err != nil {
+		return err
+	}
+
+	if err := updateContainerNetworkSettings(container); err != nil {
+		Log.Warningf("Inspecting container %s failed: %s", container.ID, err)
+	}
+
+	newBody, err := json.Marshal(container)
+	if err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
+	r.ContentLength = int64(len(newBody))
+	r.TransferEncoding = nil // Stop it being chunked, because that hangs
+
+	return nil
+}
+
+func updateContainerNetworkSettings(container *docker.Container) error {
+	stdout, stderr, err := callWeave("ps", container.ID)
+	if err != nil || len(stderr) > 0 {
+		return errors.New(string(stderr))
+	}
+	if len(stdout) <= 0 {
+		return nil
+	}
+
+	fields := strings.Fields(string(stdout))
+	if len(fields) <= 2 {
+		return nil
+	}
+
+	ipParts := strings.SplitN(fields[2], "/", 2)
+	if len(ipParts) <= 1 {
+		return nil
+	}
+
+	mask, err := strconv.ParseInt(ipParts[1], 10, 0)
+	if err != nil {
+		return err
+	}
+
+	container.NetworkSettings.MacAddress = fields[1]
+	container.NetworkSettings.IPAddress = ipParts[0]
+	container.NetworkSettings.IPPrefixLen = int(mask)
+	return nil
+}

--- a/proxy/inspect_exec_interceptor.go
+++ b/proxy/inspect_exec_interceptor.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/weaveworks/weave/common"
+)
+
+type inspectExecInterceptor struct{ proxy *Proxy }
+
+func (i *inspectExecInterceptor) InterceptRequest(r *http.Request) error {
+	return nil
+}
+
+func (i *inspectExecInterceptor) InterceptResponse(r *http.Response) error {
+	if !i.proxy.RewriteInspect {
+		return nil
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+
+	exec := &docker.ExecInspect{}
+	if err := json.Unmarshal(body, exec); err != nil {
+		return err
+	}
+
+	if err := updateContainerNetworkSettings(&exec.Container); err != nil {
+		Log.Warningf("Inspecting exec %s failed: %s", exec.ID, err)
+	}
+
+	newBody, err := json.Marshal(exec)
+	if err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
+	r.ContentLength = int64(len(newBody))
+	r.TransferEncoding = nil // Stop it being chunked, because that hangs
+
+	return nil
+}

--- a/test/605_proxy_inspect_test.sh
+++ b/test/605_proxy_inspect_test.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Check that docker inspect returns the weave IP"
+
+weave_on $HOST1 launch-router
+weave_on $HOST1 launch-proxy --rewrite-inspect
+
+proxy docker_on $HOST1 run -dt --name c1 $SMALL_IMAGE /bin/sh
+inspect_format="{{.Name}} {{.NetworkSettings.MacAddress}} {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}"
+expected="/$(weave_on $HOST1 ps c1)"
+
+assert "proxy docker_on $HOST1 inspect --format='$inspect_format' c1" "$expected"
+
+end_suite

--- a/weave
+++ b/weave
@@ -40,6 +40,7 @@ weave launch-proxy  [-H <endpoint>] [--with-dns | --without-dns]
                       [--no-default-ipalloc] [--no-rewrite-hosts]
                       [--hostname-match <regexp>]
                       [--hostname-replacement <replacement>]
+                      [--rewrite-inspect]
 weave connect       [--replace] [<peer> ...]
 weave forget        <peer> ...
 weave run           [--with-dns | --without-dns] [<addr> ...]


### PR DESCRIPTION
To return the weave ip/mac for docker inspect calls.

~~Blocked on a pr to go-dockerclient being merged: https://github.com/fsouza/go-dockerclient/pull/336~~

@errordeveloper, Could you see if this works for you?

Possibly, fixes #1199?