### PR TITLE
Allow users to set dns listen address

### DIFF
--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -20,7 +20,7 @@ func TestTruncation(t *testing.T) {
 	peername, err := router.PeerNameFromString("00:00:00:02:00:00")
 	require.Nil(t, err)
 	nameserver := New(peername, nil, nil, "")
-	dnsserver, err := NewDNSServer(nameserver, "weave.local.", 0, 30, 5*time.Second)
+	dnsserver, err := NewDNSServer(nameserver, "weave.local.", "0.0.0.0:0", 30, 5*time.Second)
 	require.Nil(t, err)
 	udpPort := dnsserver.servers[0].PacketConn.LocalAddr().(*net.UDPAddr).Port
 	tcpPort := dnsserver.servers[1].Listener.Addr().(*net.TCPAddr).Port

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -57,7 +57,7 @@ func main() {
 		peers              []string
 		noDNS              bool
 		dnsDomain          string
-		dnsPort            int
+		dnsListenAddress   string
 		dnsTTL             int
 		dnsClientTimeout   time.Duration
 	)
@@ -83,7 +83,7 @@ func main() {
 	mflag.StringVar(&apiPath, []string{"#api", "-api"}, "unix:///var/run/docker.sock", "Path to Docker API socket")
 	mflag.BoolVar(&noDNS, []string{"-no-dns"}, false, "disable DNS server")
 	mflag.StringVar(&dnsDomain, []string{"-dns-domain"}, nameserver.DefaultDomain, "local domain to server requests for")
-	mflag.IntVar(&dnsPort, []string{"-dns-port"}, nameserver.DefaultPort, "port to listen on for DNS requests")
+	mflag.StringVar(&dnsListenAddress, []string{"-dns-listen-address"}, nameserver.DefaultListenAddress, "address to listen on for DNS requests")
 	mflag.IntVar(&dnsTTL, []string{"-dns-ttl"}, nameserver.DefaultTTL, "TTL for DNS request from our domain")
 	mflag.DurationVar(&dnsClientTimeout, []string{"-dns-fallback-timeout"}, nameserver.DefaultClientTimeout, "timeout for fallback DNS requests")
 
@@ -183,7 +183,7 @@ func main() {
 		}
 		ns.Start()
 		defer ns.Stop()
-		dnsserver, err = nameserver.NewDNSServer(ns, dnsDomain, dnsPort, uint32(dnsTTL), dnsClientTimeout)
+		dnsserver, err = nameserver.NewDNSServer(ns, dnsDomain, dnsListenAddress, uint32(dnsTTL), dnsClientTimeout)
 		if err != nil {
 			Log.Fatal("Unable to start dns server: ", err)
 		}


### PR DESCRIPTION
So we can run the weave router in the host net namespace.

In FDP the weave script will need to set ```--dns-listen-address=<docker bridge ip>:53```

Part of #1215 