### PR TITLE
Improve CI run time

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ dependencies:
         docker save weaveworks/weave-build >$WEAVE_BUILD;
       fi
   post:
-    - sudo apt-get install bc
+    - sudo apt-get install bc jq
     - pip install requests
     - curl https://sdk.cloud.google.com | bash
     - bin/setup-circleci-secrets "$SECRET_PASSWORD"

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -314,9 +314,9 @@ func TestAllocatorFuzz(t *testing.T) {
 	const (
 		firstpass    = 1000
 		secondpass   = 10000
-		nodes        = 10
+		nodes        = 5
 		maxAddresses = 1000
-		concurrency  = 30
+		concurrency  = 5
 		cidr         = "10.0.1.7/22"
 	)
 	allocs, _, subnet := makeNetworkOfAllocators(nodes, cidr)

--- a/test/gce.sh
+++ b/test/gce.sh
@@ -81,6 +81,12 @@ EOF
 	ssh -t $name sudo docker run --rm -v /usr/local/bin:/target jpetazzo/nsenter
 }
 
+function copy_hosts {
+	hostname=$1
+	hosts=$2
+	cat $hosts | ssh -t "$hostname" "sudo -- sh -c \"cat >>/etc/hosts\""
+}
+
 # Create new set of VMs
 function setup {
 	destroy
@@ -105,9 +111,10 @@ function setup {
 		sudo sh -c "echo \"$(external_ip $json $name) $hostname\" >>/etc/hosts"
 		try_connect $hostname
 
-		# Copy the /etc/hosts we built over
-		cat $hosts | ssh -t "$hostname" "sudo -- sh -c \"cat >>/etc/hosts\""
+		copy_hosts $hostname $hosts &
 	done
+
+	wait
 
 	rm $hosts $json
 }

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -10,7 +10,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 echo "Copying weave images, scripts, and certificates to hosts, and"
 echo "  prefetch test images"
-for HOST in $HOSTS; do
+
+setup_host() {
+    HOST=$1
     docker_on $HOST load -i ../weave.tar
     DANGLING_IMAGES="$(docker_on $HOST images -q -f dangling=true)"
     [ -n "$DANGLING_IMAGES" ] && docker_on $HOST rmi $DANGLING_IMAGES 1>/dev/null 2>&1 || true
@@ -21,4 +23,10 @@ for HOST in $HOSTS; do
     for IMG in $TEST_IMAGES ; do
         docker_on $HOST inspect --format=" " $IMG >/dev/null 2>&1 || docker_on $HOST pull $IMG
     done
+}
+
+for HOST in $HOSTS; do
+    setup_host $HOST &
 done
+
+wait


### PR DESCRIPTION
We're hovering around the 12:30 min mark on master.  This change brings it down to about 8:30:
- improve gce.sh so it only ssh's into the VMs once to copy over the /etc/hosts file, and does this in parallel.  Also minimise the number of calls to GCE, as they are slow.  Save 20-30secs
- improve setup.sh to copy and fetch images in parallel.  Saves ~1min
- reduce the parallelism in ipam tests, as this interacts particularly badly with the race detector.  Saves ~3.5min.  Fixes #1234 