### PR TITLE
add test for PMTU discovery and packet fragmentation

### DIFF
--- a/test/100_cross_hosts_2_test.sh
+++ b/test/100_cross_hosts_2_test.sh
@@ -27,10 +27,4 @@ start_container $HOST2 net:$SUBNET_2 --name=c6
 C6=$(container_ip $HOST2 c6)
 assert_raises "exec_on $HOST1 c5 $PING $C6"
 
-# check large packets get through. The first attempt typically fails,
-# since the PMTU hasn't been discovered yet. The 2nd attempt should
-# succeed.
-exec_on $HOST1 c1 $PING -s 65000 $C2 2>&1 1>/dev/null || true
-assert_raises "exec_on $HOST1 c1 $PING -s 65000 $C2"
-
 end_suite

--- a/test/105_frag_2_test.sh
+++ b/test/105_frag_2_test.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+. ./config.sh
+
+C1=10.2.1.41
+C2=10.2.1.71
+
+# 700 = Linux's minimum PMTU (552) + weave framing overheads
+# (currently about 60, but we leave some margin). That way the PMTUs
+# seen by containers is still >= 552.
+drop_large_udp_packets="FORWARD -p udp --destination-port 6783 -m length '!' --length 0:700 -j DROP"
+
+start_suite "PMTU discovery and packet fragmentation"
+
+weave_on $HOST1 launch
+weave_on $HOST2 launch
+
+start_container $HOST1 $C1/24 --name=c1
+start_container $HOST2 $C2/24 --name=c2
+
+run_on $HOST2 "sudo iptables -I $drop_large_udp_packets"
+assert_raises "weave_on $HOST2 connect $HOST1"
+sleep 35 # give weave time to discover the PMTU
+
+# Check large packets get through. The first attempt typically fails,
+# since the sending container hasn't discovered the PMTU yet. The 2nd
+# attempt should succeed.
+exec_on $HOST2 c2 $PING -s 10000 $C1 2>&1 1>/dev/null || true
+assert_raises "exec_on $HOST2 c2 $PING -s 10000 $C1"
+
+run_on $HOST2 "sudo iptables -D $drop_large_udp_packets"
+
+end_suite


### PR DESCRIPTION
All credit goes to @dpw for figuring out how to break the kernel's packet fragmentation:

> 'man iptables' documets a --fragment option, which looks ideal for this purpose: It matches non-initial fragments.
>
>But if you try to use this, you will find that, mysteriously, a rule using --fragment never seems to trigger.
>
>The reason is that if the conntrack module is loaded, then iptables always reassembles packets before evaluating iptables rules (even rules that don't involve conntrack in any way).  So the rules never see any fragments.  And of course, if you have started docker, you have conntrack loaded.
>
>So that rules out dropping non-initial fragments with iptables.  But it is possible to get a similar effect by crafting an iptables rule that drops any UDP packet larger than the MTU:
>
> `iptables -I FORWARD -m length -p udp '!' --length 0:$[1500-28] -j DROP`
>
>(The --length argument is the size range of the UDP payload.  So 1500 is the MTU, and 28 is the IP+UDP header size.)

Coverage increases as follows:

````diff
$ diff test/cover-before/coverage.txt test/cover-after/coverage.txt
371c371
< github.com/weaveworks/weave/router/forwarder.go:78:			forward				60.0%
---
> github.com/weaveworks/weave/router/forwarder.go:78:			forward				80.0%
373c373
< github.com/weaveworks/weave/router/forwarder.go:140:			fragment			0.0%
---
> github.com/weaveworks/weave/router/forwarder.go:140:			fragment			90.9%
379c379
< github.com/weaveworks/weave/router/forwarder.go:253:			accumulateAndSendFrames		56.2%
---
> github.com/weaveworks/weave/router/forwarder.go:253:			accumulateAndSendFrames		68.8%
381c381
< github.com/weaveworks/weave/router/forwarder.go:288:			appendFrame			80.0%
---
> github.com/weaveworks/weave/router/forwarder.go:288:			appendFrame			100.0%
385c385
< github.com/weaveworks/weave/router/forwarder.go:346:			run				82.6%
---
> github.com/weaveworks/weave/router/forwarder.go:346:			run				100.0%
563c563
< total:									(statements)			83.1%
---
> total:									(statements)			84.2%
````