### PR TITLE
Fix dotted imports for logging

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -6,10 +6,3 @@ func Assert(test bool) {
 		panic("Assertion failure")
 	}
 }
-
-func OnOff(b bool) string {
-	if b {
-		return "on"
-	}
-	return "off"
-}

--- a/router/connection.go
+++ b/router/connection.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-
-	. "github.com/weaveworks/weave/common"
 )
 
 type Connection interface {

--- a/router/connection.go
+++ b/router/connection.go
@@ -82,11 +82,11 @@ func (conn *RemoteConnection) BreakTie(Connection) ConnectionTieBreak { return T
 func (conn *RemoteConnection) Shutdown(error)                         {}
 
 func (conn *RemoteConnection) Log(args ...interface{}) {
-	Log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
+	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
 }
 
 func (conn *RemoteConnection) ErrorLog(args ...interface{}) {
-	Log.Errorln(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
+	log.Errorln(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
 }
 
 func (conn *RemoteConnection) String() string {
@@ -105,7 +105,7 @@ func (conn *RemoteConnection) String() string {
 // end up in the local peer's connections map.
 func StartLocalConnection(connRemote *RemoteConnection, tcpConn *net.TCPConn, udpAddr *net.UDPAddr, router *Router, acceptNewPeer bool) {
 	if connRemote.local != router.Ourself.Peer {
-		Log.Fatal("Attempt to create local connection from a peer which is not ourself")
+		log.Fatal("Attempt to create local connection from a peer which is not ourself")
 	}
 	// NB, we're taking a copy of connRemote here.
 	actionChan := make(chan ConnectionAction, ChannelSize)
@@ -231,7 +231,7 @@ func (conn *LocalConnection) ReceivedHeartbeat(remoteUDPAddr *net.UDPAddr, connU
 		if oldRemoteUDPAddr == nil {
 			return conn.sendFastHeartbeats()
 		} else if oldRemoteUDPAddr.String() != remoteUDPAddr.String() {
-			Log.Println("Peer", conn.remote, "moved from", oldRemoteUDPAddr, "to", remoteUDPAddr)
+			log.Println("Peer", conn.remote, "moved from", oldRemoteUDPAddr, "to", remoteUDPAddr)
 		}
 		return nil
 	})
@@ -486,7 +486,7 @@ func (conn *LocalConnection) actorLoop(actionChan <-chan ConnectionAction) (err 
 
 func (conn *LocalConnection) shutdown(err error) {
 	if conn.remote == nil {
-		Log.Errorf("->[%s] connection shutting down due to error during handshake: %v", conn.remoteTCPAddr, err)
+		log.Errorf("->[%s] connection shutting down due to error during handshake: %v", conn.remoteTCPAddr, err)
 	} else {
 		conn.ErrorLog("connection shutting down due to error:", err)
 	}

--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -297,9 +297,9 @@ func (cm *ConnectionMaker) connectToTargets(validTarget map[string]struct{}, dir
 }
 
 func (cm *ConnectionMaker) attemptConnection(address string, acceptNewPeer bool) {
-	Log.Printf("->[%s] attempting connection", address)
+	log.Printf("->[%s] attempting connection", address)
 	if err := cm.ourself.CreateConnection(address, acceptNewPeer); err != nil {
-		Log.Errorf("->[%s] error during connection attempt: %v", address, err)
+		log.Errorf("->[%s] error during connection attempt: %v", address, err)
 		cm.ConnectionTerminated(address, err)
 	}
 }

--- a/router/connection_maker.go
+++ b/router/connection_maker.go
@@ -6,8 +6,6 @@ import (
 	"math/rand"
 	"net"
 	"time"
-
-	. "github.com/weaveworks/weave/common"
 )
 
 const (

--- a/router/ethernet_decoder.go
+++ b/router/ethernet_decoder.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	. "github.com/weaveworks/weave/common"
 )
 
 type EthernetDecoder struct {

--- a/router/ethernet_decoder.go
+++ b/router/ethernet_decoder.go
@@ -60,7 +60,7 @@ func (dec *EthernetDecoder) sendICMPFragNeeded(mtu int, sendFrame func([]byte) e
 		return err
 	}
 
-	Log.Printf("Sending ICMP 3,4 (%v -> %v): PMTU= %v", dec.IP.DstIP, dec.IP.SrcIP, mtu)
+	log.Printf("Sending ICMP 3,4 (%v -> %v): PMTU= %v", dec.IP.DstIP, dec.IP.SrcIP, mtu)
 	return sendFrame(buf.Bytes())
 }
 

--- a/router/gossip_channel.go
+++ b/router/gossip_channel.go
@@ -224,5 +224,5 @@ func (c *GossipChannel) sendBroadcast(srcName PeerName, update GossipData) {
 }
 
 func (c *GossipChannel) log(args ...interface{}) {
-	Log.Println(append(append([]interface{}{}, "[gossip "+c.name+"]:"), args...)...)
+	log.Println(append(append([]interface{}{}, "[gossip "+c.name+"]:"), args...)...)
 }

--- a/router/gossip_channel.go
+++ b/router/gossip_channel.go
@@ -5,8 +5,6 @@ import (
 	"encoding/gob"
 	"fmt"
 	"sync"
-
-	. "github.com/weaveworks/weave/common"
 )
 
 type GossipChannel struct {

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -5,8 +5,6 @@ import (
 	"net"
 	"sync"
 	"time"
-
-	. "github.com/weaveworks/weave/common"
 )
 
 type LocalPeer struct {

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -40,13 +40,13 @@ func (peer *LocalPeer) Relay(srcPeer, dstPeer *Peer, frame []byte, dec *Ethernet
 	if !found {
 		// Not necessarily an error as there could be a race with the
 		// dst disappearing whilst the frame is in flight
-		Log.Println("Received packet for unknown destination:", dstPeer)
+		log.Println("Received packet for unknown destination:", dstPeer)
 		return nil
 	}
 	conn, found := peer.ConnectionTo(relayPeerName)
 	if !found {
 		// Again, could just be a race, not necessarily an error
-		Log.Println("Unable to find connection to relay peer", relayPeerName)
+		log.Println("Unable to find connection to relay peer", relayPeerName)
 		return nil
 	}
 	return conn.(*LocalConnection).Forward(&ForwardedFrame{
@@ -69,9 +69,9 @@ func (peer *LocalPeer) RelayBroadcast(srcPeer *Peer, frame []byte, dec *Ethernet
 			dec)
 		if err != nil {
 			if ftbe, ok := err.(FrameTooBigError); ok {
-				Log.Warningf("dropping too big DF broadcast frame (%v -> %v): PMTU= %v", dec.IP.DstIP, dec.IP.SrcIP, ftbe.EPMTU)
+				log.Warningf("dropping too big DF broadcast frame (%v -> %v): PMTU= %v", dec.IP.DstIP, dec.IP.SrcIP, ftbe.EPMTU)
 			} else {
-				Log.Errorln(err)
+				log.Errorln(err)
 			}
 		}
 	}
@@ -180,10 +180,10 @@ func (peer *LocalPeer) actorLoop(actionChan <-chan LocalPeerAction) {
 
 func (peer *LocalPeer) handleAddConnection(conn Connection) error {
 	if peer.Peer != conn.Local() {
-		Log.Fatal("Attempt made to add connection to peer where peer is not the source of connection")
+		log.Fatal("Attempt made to add connection to peer where peer is not the source of connection")
 	}
 	if conn.Remote() == nil {
-		Log.Fatal("Attempt made to add connection to peer with unknown remote peer")
+		log.Fatal("Attempt made to add connection to peer with unknown remote peer")
 	}
 	toName := conn.Remote().Name
 	dupErr := fmt.Errorf("Multiple connections to %s added to %s", conn.Remote(), peer.String())
@@ -222,7 +222,7 @@ func (peer *LocalPeer) handleAddConnection(conn Connection) error {
 
 func (peer *LocalPeer) handleConnectionEstablished(conn Connection) {
 	if peer.Peer != conn.Local() {
-		Log.Fatal("Peer informed of active connection where peer is not the source of connection")
+		log.Fatal("Peer informed of active connection where peer is not the source of connection")
 	}
 	if dupConn, found := peer.connections[conn.Remote().Name]; !found || conn != dupConn {
 		conn.Shutdown(fmt.Errorf("Cannot set unknown connection active"))
@@ -235,10 +235,10 @@ func (peer *LocalPeer) handleConnectionEstablished(conn Connection) {
 
 func (peer *LocalPeer) handleDeleteConnection(conn Connection) {
 	if peer.Peer != conn.Local() {
-		Log.Fatal("Attempt made to delete connection from peer where peer is not the source of connection")
+		log.Fatal("Attempt made to delete connection from peer where peer is not the source of connection")
 	}
 	if conn.Remote() == nil {
-		Log.Fatal("Attempt made to delete connection to peer with unknown remote peer")
+		log.Fatal("Attempt made to delete connection to peer with unknown remote peer")
 	}
 	toName := conn.Remote().Name
 	if connFound, found := peer.connections[toName]; !found || connFound != conn {

--- a/router/router.go
+++ b/router/router.go
@@ -120,14 +120,21 @@ func (router *Router) UsingPassword() bool {
 func (router *Router) Status() string {
 	var buf bytes.Buffer
 	fmt.Fprintln(&buf, "Our name is", router.Ourself)
-	fmt.Fprintln(&buf, "Encryption", OnOff(router.UsingPassword()))
-	fmt.Fprintln(&buf, "Peer discovery", OnOff(router.PeerDiscovery))
+	fmt.Fprintln(&buf, "Encryption", onOff(router.UsingPassword()))
+	fmt.Fprintln(&buf, "Peer discovery", onOff(router.PeerDiscovery))
 	fmt.Fprintln(&buf, "Sniffing traffic on", router.Iface)
 	fmt.Fprintf(&buf, "MACs:\n%s", router.Macs)
 	fmt.Fprintf(&buf, "Peers:\n%s", router.Peers)
 	fmt.Fprintf(&buf, "Routes:\n%s", router.Routes)
 	fmt.Fprint(&buf, router.ConnectionMaker.Status())
 	return buf.String()
+}
+
+func onOff(b bool) string {
+	if b {
+		return "on"
+	}
+	return "off"
 }
 
 func (router *Router) sniff(pio PacketSourceSink) {

--- a/router/router.go
+++ b/router/router.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	. "github.com/weaveworks/weave/common"
 )
 
 const (

--- a/router/udp_sender.go
+++ b/router/udp_sender.go
@@ -86,7 +86,7 @@ func (sender *RawUDPSender) Send(msg []byte) error {
 	}
 	defer f.Close()
 	fd := int(f.Fd())
-	Log.Println("EMSGSIZE on send, expecting PMTU update (IP packet was",
+	log.Println("EMSGSIZE on send, expecting PMTU update (IP packet was",
 		len(packet), "bytes, payload was", len(msg), "bytes)")
 	pmtu, err := syscall.GetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_MTU)
 	if err != nil {

--- a/router/udp_sender.go
+++ b/router/udp_sender.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	. "github.com/weaveworks/weave/common"
 )
 
 type UDPSender interface {

--- a/router/utils.go
+++ b/router/utils.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"net"
 
-	. "github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/common"
 )
+
+var Log = common.Log
 
 var void = struct{}{}
 

--- a/router/utils.go
+++ b/router/utils.go
@@ -10,19 +10,19 @@ import (
 	"github.com/weaveworks/weave/common"
 )
 
-var Log = common.Log
+var log = common.Log
 
 var void = struct{}{}
 
 func checkFatal(e error) {
 	if e != nil {
-		Log.Fatal(e)
+		log.Fatal(e)
 	}
 }
 
 func checkWarn(e error) {
 	if e != nil {
-		Log.Warnln(e)
+		log.Warnln(e)
 	}
 }
 


### PR DESCRIPTION
Many router files do a dotted import of `common` for the sake of `Log`.  This means everything else from `common` ends up in scope, for the sake of a single variable.