### PR TITLE
send ARP update for *all* container IPs; not just the first one

### DIFF
--- a/weave
+++ b/weave
@@ -449,7 +449,9 @@ attach() {
         netnsenter ip route add 224.0.0.0/4 dev $CONTAINER_IFNAME
     fi
 
-    arp_update $CONTAINER_IFNAME $1 "netnsenter"
+    for ADDR in "$@" ; do
+        arp_update $CONTAINER_IFNAME $ADDR "netnsenter"
+    done
 }
 
 detach() {


### PR DESCRIPTION
This was missed in #498.