### PR TITLE
add a sleep to improve test reliability

### DIFF
--- a/test/160_claim_3_test.sh
+++ b/test/160_claim_3_test.sh
@@ -25,6 +25,7 @@ start_container $HOST2 --name=c3
 C3=$(container_ip $HOST2 c3)
 assert_raises "[ $C3 != $C1 ]"
 
+sleep 1 # give routers some time to fully establish connectivity
 assert_raises "exec_on $HOST1 c1 $PING $C3"
 
 stop_router_on $HOST1


### PR DESCRIPTION
Fixes #1243.

I've also raised #1267 to address the issue more directly. The reason this is cropping up in this test more than others is that here we only start one container between launching weave and 'ping'ing, whereas elsewhere we start two. The extra start adds just enough of a delay for the routers to establish connectivity. So does a 'sleep', which is how I've "fixed" it - I've had 10 successful runs on CircleCI like that, only interrupted by some unrelated failures.