### PR TITLE
ignore DuplicateError when inserting mDNS answer in zone

### DIFF
--- a/nameserver/zone_lookup.go
+++ b/nameserver/zone_lookup.go
@@ -103,9 +103,11 @@ func (zone *ZoneDb) domainLookup(target string, lfun ZoneLookupFunc) (res []Zone
 	for _, answer := range lanswers {
 		r, err := remoteIdent.addIPToName(answer, now)
 		if err != nil {
-			zone.mx.Unlock()
-			Warning.Printf("[zonedb] '%s' insertion for %s failed: %s", answer, target, err)
-			return nil, err
+			if _, ok := err.(DuplicateError); !ok {
+				zone.mx.Unlock()
+				Warning.Printf("[zonedb] '%s' insertion for %s failed: %s", answer, target, err)
+				return nil, err
+			}
 		}
 		uniq.add(r)
 	}


### PR DESCRIPTION
When we issue two concurrent mDNS queries for the same name, the answer to the second one encounters a DuplicateError when inserting into the zone. We would return that error, which causes the query would fail. And we'd cache that fact. All bad.

So ignore DuplicateError.

Fixes #1270.