### PR TITLE
When giving instructions, prefer set -x to export

### DIFF
--- a/test/gce.sh
+++ b/test/gce.sh
@@ -139,9 +139,9 @@ function hosts {
 		hosts="$hostname $hosts"
 		args="--add-host=$hostname:$(internal_ip $json $name) $args"
 	done
-	echo export SSH=ssh
-	echo export HOSTS=\"$hosts\"
-	echo export WEAVE_DOCKER_ARGS=\"$args\"
+	echo set -x SSH ssh
+	echo set -x HOSTS \"$hosts\"
+	echo set -x WEAVE_DOCKER_ARGS \"$args\"
 	rm $json
 }
 

--- a/weave
+++ b/weave
@@ -1298,7 +1298,7 @@ case "$COMMAND" in
         ;;
     env|proxy-env)
         [ "$COMMAND" = "env" ] || deprecation_warning "$COMMAND" "'weave env'"
-        proxy_addr "export DOCKER_HOST="
+        proxy_addr "set -x DOCKER_HOST "
         ;;
     config|proxy-config)
         [ "$COMMAND" = "config" ] || deprecation_warning "$COMMAND" "'weave config'"


### PR DESCRIPTION
`export` is a {ba,z,}sh-ism, whereas `set -x` is more generally accepted. Specifically, `export` doesn't work on [fish](http://fishshell.com/).

This changes instructions piped to users, either for manual copy/pasting or for inlining e.g. $(weave env), to use `set -x` instead of `export`.

(Any other places I missed?)