### PR TITLE
add pcap stats to `weave report`

### DIFF
--- a/router/pcap.go
+++ b/router/pcap.go
@@ -84,3 +84,15 @@ func (pio *PcapIO) ReadPacket() (data []byte, err error) {
 func (pio *PcapIO) WritePacket(data []byte) error {
 	return pio.handle.WritePacketData(data)
 }
+
+func (pio *PcapIO) Stats() map[string]int {
+	stats, err := pio.handle.Stats()
+	if err != nil {
+		return nil
+	}
+	res := make(map[string]int)
+	res["PacketsReceived"] = stats.PacketsReceived
+	res["PacketsDropped"] = stats.PacketsDropped
+	res["PacketsIfDropped"] = stats.PacketsIfDropped
+	return res
+}

--- a/router/router.go
+++ b/router/router.go
@@ -47,12 +47,14 @@ type Router struct {
 	gossipLock      sync.RWMutex
 	gossipChannels  GossipChannels
 	TopologyGossip  Gossip
+	PacketSource    PacketSource
 	UDPListener     *net.UDPConn
 	acceptLimiter   *TokenBucket
 }
 
 type PacketSource interface {
 	ReadPacket() ([]byte, error)
+	Stats() map[string]int
 }
 
 type PacketSink interface {
@@ -102,6 +104,7 @@ func (router *Router) Start() {
 	router.UDPListener = router.listenUDP(router.Port, po)
 	router.listenTCP(router.Port)
 	if pio != nil {
+		router.PacketSource = pio
 		router.sniff(pio)
 	}
 }

--- a/router/status.go
+++ b/router/status.go
@@ -14,6 +14,7 @@ type Status struct {
 	NickName           string
 	Port               int
 	Interface          string
+	CaptureStats       map[string]int
 	MACs               []MACStatus
 	Peers              []PeerStatus
 	UnicastRoutes      []UnicastRouteStatus
@@ -66,6 +67,10 @@ func NewStatus(router *Router) *Status {
 	if router.Iface != nil {
 		ifaceName = router.Iface.Name
 	}
+	var captureStats map[string]int
+	if router.PacketSource != nil {
+		captureStats = router.PacketSource.Stats()
+	}
 	return &Status{
 		Protocol,
 		ProtocolMinVersion,
@@ -76,6 +81,7 @@ func NewStatus(router *Router) *Status {
 		router.Ourself.NickName,
 		router.Port,
 		ifaceName,
+		captureStats,
 		NewMACStatusSlice(router.Macs),
 		NewPeerStatusSlice(router.Peers),
 		NewUnicastRouteStatusSlice(router.Routes),


### PR DESCRIPTION
Closes #1185.

````
$ weave report
...
        "CaptureStats": {
            "PacketsDropped": 1881,
            "PacketsIfDropped": 0,
            "PacketsReceived": 78612
        },
...
````

I decided not to add this to `weave status`; we can do that later if/when it proves to be an important for troubleshooting.