### PR TITLE
prevent proxy from interferring with `weave run`

### DIFF
--- a/test/680_proxy_weave_run_test.sh
+++ b/test/680_proxy_weave_run_test.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+. ./config.sh
+
+C1=10.2.1.13
+
+start_suite "Start containers with 'weave run' via proxy"
+
+weave_on $HOST1 launch
+weave_on $HOST1 launch-proxy
+
+proxy start_container $HOST1 $C1/24 --name=c1
+# check we get exactly one IP back, the one specified
+assert "weave_on $HOST1 ps c1 | cut -d ' ' -f 3-" $C1/24
+
+end_suite

--- a/weave
+++ b/weave
@@ -158,7 +158,7 @@ if [ "$1" = "run" ] ; then
     shift $(dns_arg_count "$@")
     collect_cidr_args "$@"
     shift $CIDR_ARG_COUNT
-    CONTAINER=$(docker $DOCKER_CLIENT_ARGS run $DNS_ARGS -d "$@")
+    CONTAINER=$(docker $DOCKER_CLIENT_ARGS run -e WEAVE_CIDR=none $DNS_ARGS -d "$@")
     exec_remote attach $CIDR_ARGS --or-die $CONTAINER
     echo $CONTAINER
     exit 0
@@ -1160,7 +1160,7 @@ case "$COMMAND" in
         shift $(dns_arg_count "$@")
         collect_cidr_args "$@"
         shift $CIDR_ARG_COUNT
-        CONTAINER=$(docker run $DNS_ARGS -d "$@")
+        CONTAINER=$(docker run -e WEAVE_CIDR=none $DNS_ARGS -d "$@")
         create_bridge
         ipam_cidrs_or_die $CONTAINER $CIDR_ARGS
         with_container_netns_or_die $CONTAINER attach $ALL_CIDRS


### PR DESCRIPTION
...which could result in containers unexpectedly getting multiple IP addresses.

Fixes #1279.