### PR TITLE
Add role label to weave containers so scope can filter

### DIFF
--- a/prog/weaveexec/Dockerfile
+++ b/prog/weaveexec/Dockerfile
@@ -1,6 +1,7 @@
 FROM gliderlabs/alpine
 
 MAINTAINER Weaveworks Inc <help@weave.works>
+LABEL works.weave.role=system
 
 WORKDIR /home/weave
 VOLUME /w

--- a/prog/weaver/Dockerfile
+++ b/prog/weaver/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 MAINTAINER Weaveworks Inc <help@weave.works>
+LABEL works.weave.role=system
 WORKDIR /home/weave
 ADD ./weaver /home/weave/
 ENTRYPOINT ["/home/weave/weaver"]


### PR DESCRIPTION
As part of https://github.com/weaveworks/scope/issues/337, I'd like to label the weave & scope containers and have them filtered out of the scope view by default.

Let the bike shedding begin...