### PR TITLE
extract test functions for "start container via proxy"

### DIFF
--- a/test/630_proxy_dns_test.sh
+++ b/test/630_proxy_dns_test.sh
@@ -8,8 +8,8 @@ C1_NAME=c1.weave.local
 C2_NAME=seetwo.weave.local
 
 boot_containers() {
-  proxy docker_on $HOST1 run -e WEAVE_CIDR=$C2/24 -dt --name=c2 -h $C2_NAME $DNS_IMAGE /bin/sh
-  proxy docker_on $HOST1 run -e WEAVE_CIDR=$C1/24 -dt --name=c1             $DNS_IMAGE /bin/sh
+  proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C2/24 -dt --name=c2 -h $C2_NAME
+  proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C1/24 -dt --name=c1
 }
 
 kill_containers() {

--- a/test/635_proxy_dns_unqualified_test.sh
+++ b/test/635_proxy_dns_unqualified_test.sh
@@ -9,19 +9,15 @@ C4=10.2.0.99
 DOMAIN=weave.local
 NAME=seeone.$DOMAIN
 
-start_container() {
-  proxy docker_on $HOST1 run "$@" -dt $DNS_IMAGE /bin/sh
-}
-
 start_suite "Resolve unqualified names"
 
 weave_on $HOST1 launch-dns 10.2.254.1/24
 weave_on $HOST1 launch-proxy
 
-start_container -e WEAVE_CIDR=$C1/24 --name=c1 -h $NAME
-start_container -e WEAVE_CIDR=$C2/24 --name=c2 -h seetwo.$DOMAIN
-start_container -e WEAVE_CIDR=$C3/24 --name=c3 --dns-search=$DOMAIN
-container=$(start_container -e WEAVE_CIDR=$C4/24)
+proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C1/24 --name=c1 -h $NAME
+proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C2/24 --name=c2 -h seetwo.$DOMAIN
+proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C3/24 --name=c3 --dns-search=$DOMAIN
+container=$(proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C4/24)
 
 check() {
   assert "proxy exec_on $HOST1 $1 getent hosts seeone | tr -s ' '" "$C1 $NAME"

--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -10,8 +10,8 @@ start_suite "Proxy restart reattaches networking to containers"
 
 launch_dns_on $HOST1 10.2.254.1/24
 weave_on $HOST1 launch-proxy --with-dns
-proxy docker_on $HOST1 run -e WEAVE_CIDR=$C2/24 -dt --name=c2 -h $NAME $SMALL_IMAGE /bin/sh
-proxy docker_on $HOST1 run -e WEAVE_CIDR=$C1/24 -dt --name=c1          $DNS_IMAGE   /bin/sh
+proxy_start_container          $HOST1 -e WEAVE_CIDR=$C2/24 -dt --name=c2 -h $NAME
+proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C1/24 -dt --name=c1
 
 proxy docker_on $HOST1 restart c2
 assert_raises "proxy exec_on $HOST1 c2 $CHECK_ETHWE_UP"

--- a/test/660_proxy_ipam_test.sh
+++ b/test/660_proxy_ipam_test.sh
@@ -4,12 +4,6 @@
 
 UNIVERSE=10.2.2.0/24
 
-start() {
-  host=$1
-  shift
-  proxy docker_on "$host" run "$@" -dt $SMALL_IMAGE /bin/sh
-}
-
 assert_no_ethwe() {
   assert_raises "container_ip $1 $2" 1
   assert_raises "proxy exec_on $1 $2 ip link show | grep -v ethwe"
@@ -22,13 +16,13 @@ weave_on $HOST2 launch -iprange $UNIVERSE $HOST1
 weave_on $HOST1 launch-proxy
 weave_on $HOST2 launch-proxy --no-default-ipam
 
-start $HOST1 --name=auto
-start $HOST1 --name=none       -e WEAVE_CIDR=none
-start $HOST2 --name=zero       -e WEAVE_CIDR=
-start $HOST2 --name=no-default
-start $HOST1 --name=bridge     --net=bridge
-start $HOST1 --name=host       --net=host
-start $HOST1 --name=other      --net=container:auto
+proxy_start_container $HOST1 --name=auto
+proxy_start_container $HOST1 --name=none       -e WEAVE_CIDR=none
+proxy_start_container $HOST2 --name=zero       -e WEAVE_CIDR=
+proxy_start_container $HOST2 --name=no-default
+proxy_start_container $HOST1 --name=bridge     --net=bridge
+proxy_start_container $HOST1 --name=host       --net=host
+proxy_start_container $HOST1 --name=other      --net=container:auto
 
 AUTO=$(container_ip $HOST1 auto)
 ZERO=$(container_ip $HOST2 zero)

--- a/test/config.sh
+++ b/test/config.sh
@@ -120,6 +120,18 @@ start_container_with_dns() {
     weave_on $host run --with-dns "$@" -t $DNS_IMAGE /bin/sh
 }
 
+proxy_start_container() {
+    host=$1
+    shift 1
+    proxy docker_on $host run "$@" -dt $SMALL_IMAGE /bin/sh
+}
+
+proxy_start_container_with_dns() {
+    host=$1
+    shift 1
+    proxy docker_on $host run "$@" -dt $DNS_IMAGE /bin/sh
+}
+
 rm_containers() {
     host=$1
     shift


### PR DESCRIPTION
This also eliminates the redefinition of 'start_container' by some of the tests, which causes failures when multiple tests are run with `run_all.sh`.

Fixes #1294.