### PR TITLE
don't reconnect to ourself

### DIFF
--- a/router/connection.go
+++ b/router/connection.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -27,6 +28,8 @@ const (
 	TieBreakLost
 	TieBreakTied
 )
+
+var ErrConnectToSelf = errors.New("Cannot connect to ourself")
 
 type RemoteConnection struct {
 	local         *Peer
@@ -437,7 +440,7 @@ func (conn *LocalConnection) registerRemote(remote *Peer, acceptNewPeer bool) er
 	}
 
 	if conn.remote == conn.local {
-		return fmt.Errorf("Cannot connect to ourself")
+		return ErrConnectToSelf
 	}
 
 	return nil

--- a/router/status.go
+++ b/router/status.go
@@ -197,7 +197,11 @@ func NewLocalConnectionStatusSlice(cm *ConnectionMaker) []LocalConnectionStatus 
 				info = target.lastError.Error()
 			default:
 				state = "failed"
-				info = target.lastError.Error() + ", retry: " + target.tryAfter.String()
+				retry := "never"
+				if !target.tryAfter.IsZero() {
+					retry = target.tryAfter.String()
+				}
+				info = target.lastError.Error() + ", retry: " + retry
 			}
 			slice = append(slice, LocalConnectionStatus{address, true, state, info})
 		}


### PR DESCRIPTION
When we discover that a connection target address leads to ourself we set the retry time to the zero time.Time value - the only special time.Time value. We use that marker to a) suppress subsequent
connection attempts, and b) display the next retry as 'never' in `weave status|report`.

Closes #1305.