### PR TITLE
Expose dns server on tcp as well as udp

### DIFF
--- a/weave
+++ b/weave
@@ -1079,7 +1079,7 @@ case "$COMMAND" in
         # additional parameters, such as resource limits, to docker
         # when launching the weave container.
         DNS_CONTAINER=$(docker run --privileged -d --name=$DNS_CONTAINER_NAME \
-            -p $DOCKER_BRIDGE_IP:53:53/udp \
+            -p $DOCKER_BRIDGE_IP:53:53/udp -p $DOCKER_BRIDGE_IP:53:53/tcp \
             -e WEAVE_CIDR=none \
             -v /var/run/docker.sock:/var/run/docker.sock \
             $WEAVEDNS_DOCKER_ARGS $DNS_IMAGE -iface $CONTAINER_IFNAME -httpiface "$DNS_HTTP_IFNAME" "$@")


### PR DESCRIPTION
Issue was discovered when testing scope with master vs 1.0 branches.

@inercia, Any reason not to do this? AFAICT it initializes the same thing on tcp and udp, but just doesn't expose the tcp.