### PR TITLE
eliminate misleading flag parsing error

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -87,7 +87,15 @@ func main() {
 	mflag.IntVar(&dnsTTL, []string{"-dns-ttl"}, nameserver.DefaultTTL, "TTL for DNS request from our domain")
 	mflag.DurationVar(&dnsClientTimeout, []string{"-dns-fallback-timeout"}, nameserver.DefaultClientTimeout, "timeout for fallback DNS requests")
 
+	// crude way of detecting that we probably have been started in a
+	// container, with `weave launch` --> suppress misleading paths in
+	// mflags error messages.
+	if os.Args[0] == "/home/weave/weaver" { // matches the Dockerfile ENTRYPOINT
+		os.Args[0] = "weave"
+		mflag.CommandLine.Init("weave", mflag.ExitOnError)
+	}
 	mflag.Parse()
+
 	peers = mflag.Args()
 
 	SetLogLevel(logLevel)


### PR DESCRIPTION
The standard mflags error reporting produces an error like
```
flag provided but not defined: -p
See '/home/weave/weaver --help'.
```
on stderr. This is misleading since the program name is container local, so not something the user actually invoked. Furthermore, what the user *can* invoke doesn't have a `--help` option.

With this change the error becomes
```
FATA: 2015/08/18 10:56:23.635119 Incorrect usage: flag provided but not defined: -p
```

There are a few issues with this:

- we no longer get a usage message
- we no longer get deprecation warnings logged

Fixes #1321. Alas I am not at all happy with this. Wasted several hours on this already. Somebody else please have a go.