### PR TITLE
clarify test 160

### DIFF
--- a/test/160_claim_3_test.sh
+++ b/test/160_claim_3_test.sh
@@ -32,6 +32,7 @@ stop_router_on $HOST1
 stop_router_on $HOST2
 
 # Now make host1 attempt to claim from host2, when host2 is stopped
+# the point being to check whether host1 will hang trying to talk to host2
 weave_on $HOST2 launch-router
 # Introduce host3 to remember the IPAM CRDT when we stop host2
 weave_on $HOST3 launch-router $HOST2


### PR DESCRIPTION
The point of the last few lines of test 160 is to see whether starting weave in a state where it thinks it should talk to a currently-stopped peer will hang it.  This change makes this clearer (but does not run the launch command in a `timeout` wrapper because `weave_on` is a shell function and it's too complicated to extract it out for `timeout` to call).