### PR TITLE
In ipam ring unit test, check if we have any peers with entries to avoid crash 

### DIFF
--- a/ipam/ring/ring_test.go
+++ b/ipam/ring/ring_test.go
@@ -709,6 +709,9 @@ func TestFuzzRingHard(t *testing.T) {
 				ringsWithEntries = append(ringsWithEntries, ring)
 			}
 		}
+		if len(ringsWithEntries) == 0 { // no rings have entries.
+			return
+		}
 		ring1 := ringsWithEntries[rand.Intn(len(ringsWithEntries))]
 		ring2index, _, ring2 := randomPeer(-1)
 		common.Log.Debugf("%s: 'Gossiping' to %s", ring1.Peer, ring2.Peer)


### PR DESCRIPTION
Fixes #1336