### PR TITLE
Refactor dns handlers

### DIFF
--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -246,10 +246,10 @@ func (h *handler) makeResponse(req *dns.Msg, answers []dns.RR) *dns.Msg {
 	response.SetReply(req)
 	response.RecursionAvailable = true
 	response.Authoritative = true
+	response.Answer = answers
 
 	maxSize := h.getMaxResponseSize(req)
-	if len(answers) <= 1 || maxSize <= 0 {
-		response.Answer = answers
+	if len(answers) <= 1 || maxSize <= 0 || response.Len() <= maxSize {
 		return response
 	}
 

--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -166,8 +166,8 @@ func (h *handler) handleLocal(w dns.ResponseWriter, req *dns.Msg) {
 		ip := addr.IP4()
 		response.Answer[i] = &dns.A{Hdr: header, A: ip}
 	}
-
 	shuffleAnswers(&response.Answer)
+
 	h.truncateResponse(req, &response)
 
 	h.ns.debugf("response: %+v", response)
@@ -255,17 +255,6 @@ func (h *handler) handleRecursive(w dns.ResponseWriter, req *dns.Msg) {
 	h.errorResponse(req, dns.RcodeServerFailure, w)
 }
 
-func shuffleAnswers(answers *[]dns.RR) {
-	if len(*answers) <= 1 {
-		return
-	}
-
-	for i := range *answers {
-		j := rand.Intn(i + 1)
-		(*answers)[i], (*answers)[j] = (*answers)[j], (*answers)[i]
-	}
-}
-
 func (h *handler) truncateResponse(req, response *dns.Msg) {
 	maxSize := h.getMaxResponseSize(req)
 	if len(response.Answer) <= 1 || maxSize <= 0 {
@@ -295,4 +284,15 @@ func (h *handler) getMaxResponseSize(req *dns.Msg) int {
 		return int(opt.UDPSize())
 	}
 	return h.maxResponseSize
+}
+
+func shuffleAnswers(answers *[]dns.RR) {
+	if len(*answers) <= 1 {
+		return
+	}
+
+	for i := range *answers {
+		j := rand.Intn(i + 1)
+		(*answers)[i], (*answers)[j] = (*answers)[j], (*answers)[i]
+	}
 }

--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -246,26 +246,24 @@ func (h *handler) makeResponse(req *dns.Msg, answers []dns.RR) *dns.Msg {
 	response.SetReply(req)
 	response.RecursionAvailable = true
 	response.Authoritative = true
-	response.Answer = answers
 
 	maxSize := h.getMaxResponseSize(req)
-	if len(response.Answer) <= 1 || maxSize <= 0 {
-		return response
-	}
-
-	// search for smallest i that is too big
-	i := sort.Search(len(response.Answer), func(i int) bool {
-		// return true if too big
-		response.Answer = answers[:i+1]
-		return response.Len() > maxSize
-	})
-	if i == len(answers) {
+	if len(answers) <= 1 || maxSize <= 0 {
 		response.Answer = answers
 		return response
 	}
 
+	// search for smallest i that is too big
+	i := sort.Search(len(answers), func(i int) bool {
+		// return true if too big
+		response.Answer = answers[:i+1]
+		return response.Len() > maxSize
+	})
+
 	response.Answer = answers[:i]
-	response.Truncated = true
+	if i < len(answers) {
+		response.Truncated = true
+	}
 	return response
 }
 

--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -247,18 +247,11 @@ func (h *handler) makeResponse(req *dns.Msg, answers []dns.RR) *dns.Msg {
 	response.RecursionAvailable = true
 	response.Authoritative = true
 	response.Answer = answers
-	h.truncateResponse(req, response)
-	return response
-}
 
-func (h *handler) truncateResponse(req, response *dns.Msg) {
 	maxSize := h.getMaxResponseSize(req)
 	if len(response.Answer) <= 1 || maxSize <= 0 {
-		return
+		return response
 	}
-
-	// take a copy of answers, as we're going to mutate response
-	answers := response.Answer
 
 	// search for smallest i that is too big
 	i := sort.Search(len(response.Answer), func(i int) bool {
@@ -268,11 +261,12 @@ func (h *handler) truncateResponse(req, response *dns.Msg) {
 	})
 	if i == len(answers) {
 		response.Answer = answers
-		return
+		return response
 	}
 
 	response.Answer = answers[:i]
 	response.Truncated = true
+	return response
 }
 
 func (h *handler) getMaxResponseSize(req *dns.Msg) int {

--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -83,18 +83,17 @@ func TestTruncateResponse(t *testing.T) {
 	}
 
 	for i := 0; i < 10000; i++ {
-		// generate a random msg
-		response := &dns.Msg{}
+		// generate a random answer set
 		numAnswers := 40 + rand.Intn(200)
-		response.Answer = make([]dns.RR, numAnswers)
+		answers := make([]dns.RR, numAnswers)
 		for j := 0; j < numAnswers; j++ {
-			response.Answer[j] = &dns.A{Hdr: header, A: address.Address(j).IP4()}
+			answers[j] = &dns.A{Hdr: header, A: address.Address(j).IP4()}
 		}
 
 		// pick a random max size, truncate response to that, check it
-		maxSize := 512 + rand.Intn(response.Len()-512)
+		maxSize := 512 + rand.Intn(2*512)
 		h := handler{maxResponseSize: maxSize}
-		h.truncateResponse(&dns.Msg{}, response)
+		response := h.makeResponse(&dns.Msg{}, answers)
 		require.True(t, response.Len() <= maxSize)
 	}
 }

--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -93,7 +93,8 @@ func TestTruncateResponse(t *testing.T) {
 
 		// pick a random max size, truncate response to that, check it
 		maxSize := 512 + rand.Intn(response.Len()-512)
-		truncateResponse(response, maxSize)
+		h := handler{maxResponseSize: maxSize}
+		h.truncateResponse(&dns.Msg{}, response)
 		require.True(t, response.Len() <= maxSize)
 	}
 }


### PR DESCRIPTION
This takes the refactoring bit of #1334, evolves it (the handler construction is neater here), adds some extra refactors, and an optimisation.

Best reviewed by looking at the individual commits. And the first of those is best view in a good diff viewer, e.g. kompare in whitespace-ignore mode, where it will appear *much* smaller than here on github.