### PR TITLE
Small improvements in features doc

### DIFF
--- a/site/features.md
+++ b/site/features.md
@@ -83,7 +83,7 @@ Instead of getting weave to allocate IP addresses automatically, it is
 also possible to specify an address and network explicitly, expressed
 in
 [CIDR notation](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation)
-- let's see how the first example would have looked:
+\- let's see how the first example in the README would have looked:
 
 On $HOST1:
 


### PR DESCRIPTION
Escape a minus character to stop it being taken as a bullet, and clarify which example we are talking about.