### PR TITLE
Pass docker bridge ip to dns server, and filter it out of upstream dns ips.

### DIFF
--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -19,7 +19,7 @@ func startServer(t *testing.T) (*DNSServer, *Nameserver, int, int) {
 	peername, err := router.PeerNameFromString("00:00:00:02:00:00")
 	require.Nil(t, err)
 	nameserver := New(peername, nil, nil, "")
-	dnsserver, err := NewDNSServer(nameserver, "weave.local.", "0.0.0.0:0", 30, 5*time.Second)
+	dnsserver, err := NewDNSServer(nameserver, "weave.local.", "0.0.0.0:0", "", 30, 5*time.Second)
 	require.Nil(t, err)
 	udpPort := dnsserver.servers[0].PacketConn.LocalAddr().(*net.UDPAddr).Port
 	tcpPort := dnsserver.servers[1].Listener.Addr().(*net.TCPAddr).Port

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -55,11 +55,13 @@ func main() {
 		peerCount          int
 		apiPath            string
 		peers              []string
-		noDNS              bool
-		dnsDomain          string
-		dnsListenAddress   string
-		dnsTTL             int
-		dnsClientTimeout   time.Duration
+
+		noDNS                     bool
+		dnsDomain                 string
+		dnsListenAddress          string
+		dnsTTL                    int
+		dnsClientTimeout          time.Duration
+		dnsEffectiveListenAddress string
 	)
 
 	mflag.BoolVar(&justVersion, []string{"#version", "-version"}, false, "print version and exit")
@@ -86,6 +88,7 @@ func main() {
 	mflag.StringVar(&dnsListenAddress, []string{"-dns-listen-address"}, nameserver.DefaultListenAddress, "address to listen on for DNS requests")
 	mflag.IntVar(&dnsTTL, []string{"-dns-ttl"}, nameserver.DefaultTTL, "TTL for DNS request from our domain")
 	mflag.DurationVar(&dnsClientTimeout, []string{"-dns-fallback-timeout"}, nameserver.DefaultClientTimeout, "timeout for fallback DNS requests")
+	mflag.StringVar(&dnsEffectiveListenAddress, []string{"-dns-effective-listen-address"}, "", "address DNS will actually be listening, after Docker port mapping")
 
 	// crude way of detecting that we probably have been started in a
 	// container, with `weave launch` --> suppress misleading paths in
@@ -191,7 +194,8 @@ func main() {
 		}
 		ns.Start()
 		defer ns.Stop()
-		dnsserver, err = nameserver.NewDNSServer(ns, dnsDomain, dnsListenAddress, uint32(dnsTTL), dnsClientTimeout)
+		dnsserver, err = nameserver.NewDNSServer(ns, dnsDomain, dnsListenAddress,
+			dnsEffectiveListenAddress, uint32(dnsTTL), dnsClientTimeout)
 		if err != nil {
 			Log.Fatal("Unable to start dns server: ", err)
 		}

--- a/weave
+++ b/weave
@@ -1162,7 +1162,7 @@ launch_router() {
         -v /var/run/docker.sock:/var/run/docker.sock \
         -e WEAVE_PASSWORD \
         -e WEAVE_CIDR=none \
-        $WEAVE_DOCKER_ARGS $IMAGE $COVERAGE_ARGS --iface $CONTAINER_IFNAME --port $CONTAINER_PORT --name "$PEERNAME" --nickname "$(hostname)" --ipalloc-range "$IPRANGE" "$@")
+        $WEAVE_DOCKER_ARGS $IMAGE $COVERAGE_ARGS --iface $CONTAINER_IFNAME --port $CONTAINER_PORT --name "$PEERNAME" --nickname "$(hostname)" --ipalloc-range "$IPRANGE" --dns-effective-listen-address "$DOCKER_BRIDGE_IP" "$@")
     with_container_netns_or_die $ROUTER_CONTAINER launch
     wait_for_status $CONTAINER_NAME $HTTP_PORT
     if [ -n "$IPRANGE" ] ; then


### PR DESCRIPTION
Flag is called ```--dns-effective-listen-address```, and is automatically populated by the ```weave``` script.

Fixes #1343 

Note we don't actually validate the contents of this field (ie check its a real IP address).  We can do, but I didn't see the point.