### PR TITLE
Get proxy to re-attach weave router if it restarts

### DIFF
--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -13,11 +13,16 @@ check_attached() {
 
 start_suite "Proxy restart reattaches networking to containers"
 
-weave_on $HOST1 launch
+WEAVE_DOCKER_ARGS=--restart=always WEAVEPROXY_DOCKER_ARGS=--restart=always weave_on $HOST1 launch
 proxy_start_container          $HOST1 -e WEAVE_CIDR=$C2/24 -di --name=c2 --restart=always -h $NAME
 proxy_start_container_with_dns $HOST1 -e WEAVE_CIDR=$C1/24 -di --name=c1 --restart=always
 
 proxy docker_on $HOST1 restart -t=1 c2
+check_attached
+
+# Restart weave router
+docker_on $HOST1 restart weave
+sleep 1
 check_attached
 
 # Kill outside of Docker so Docker will restart it
@@ -28,7 +33,6 @@ check_attached
 # Restart docker itself, using different commands for systemd- and upstart-managed.
 run_on $HOST1 sh -c "command -v systemctl >/dev/null && sudo systemctl restart docker || sudo service docker restart"
 sleep 1
-weave_on $HOST1 launch
 check_attached
 
 end_suite

--- a/weave
+++ b/weave
@@ -512,6 +512,10 @@ launch() {
         echo "Perhaps you are running the docker daemon with container networking disabled (-b=none)." >&2
         return 1
     fi
+    # No-op if already attached
+    if netnsenter ip link show $CONTAINER_IFNAME >/dev/null 2>&1 ; then
+        return 0
+    fi
     connect_container_to_bridge &&
         netnsenter ethtool -K eth0 tx off >/dev/null &&
         netnsenter ip link set $CONTAINER_IFNAME up
@@ -1177,6 +1181,17 @@ launch_router() {
         -e WEAVE_PASSWORD \
         -e WEAVE_CIDR=none \
         $WEAVE_DOCKER_ARGS $IMAGE $COVERAGE_ARGS --iface $CONTAINER_IFNAME --port $CONTAINER_PORT --name "$PEERNAME" --nickname "$(hostname)" --ipalloc-range "$IPRANGE" --dns-effective-listen-address "$DOCKER_BRIDGE_IP" "$@")
+}
+
+# Recreate the parameter values that are set when the router is first launched
+fetch_router_args() {
+    IPRANGE=$(docker inspect -f '{{.Args}}' $1 | grep -o -e '-ipalloc-range [^ ]*')
+    # This doesn't get back the right syntax, but it's enough for our purposes
+    DNS_PORT_MAPPING=$(docker inspect -f '{{with index .HostConfig.PortBindings "53/udp"}}{{.}}{{end}}' $1)
+}
+
+attach_router() {
+    ROUTER_CONTAINER=$1
     with_container_netns_or_die $ROUTER_CONTAINER launch
     wait_for_status $CONTAINER_NAME $HTTP_PORT
     if [ -n "$IPRANGE" ] ; then
@@ -1345,13 +1360,23 @@ case "$COMMAND" in
         check_not_running $PROXY_CONTAINER_NAME $EXEC_IMAGE
         COMMON_ARGS=$(common_launch_args "$@")
         launch_router "$@"
+        attach_router $CONTAINER_NAME
         launch_proxy  $COMMON_ARGS
         ;;
     launch-router)
         deprecation_warnings "$@"
         check_not_running $CONTAINER_NAME $BASE_IMAGE
         launch_router "$@"
+        attach_router $CONTAINER_NAME
         echo $ROUTER_CONTAINER
+        ;;
+    attach-router)
+        deprecation_warnings "$@"
+        check_running $CONTAINER_NAME
+        enforce_docker_bridge_addr_assign_type
+        create_bridge
+        fetch_router_args $CONTAINER_NAME
+        attach_router $CONTAINER_NAME
         ;;
     launch-proxy)
         deprecation_warnings "$@"

--- a/weave
+++ b/weave
@@ -1371,7 +1371,6 @@ case "$COMMAND" in
         echo $ROUTER_CONTAINER
         ;;
     attach-router)
-        deprecation_warnings "$@"
         check_running $CONTAINER_NAME
         enforce_docker_bridge_addr_assign_type
         create_bridge


### PR DESCRIPTION
This is a follow-on to #1210, created as a separate PR for clarity.

Fixes part (a) in #401

You get a bit of noise in the logs on a total restart (e.g. a reboot), because the router isn't necessarily up and listening before we start re-attaching other containers.  But it all works out in the end, because the router attach re-does all the parts that went wrong.