### PR TITLE
Pin the version of docker-py image in testing

### DIFF
--- a/test/600_proxy_docker_py.sh
+++ b/test/600_proxy_docker_py.sh
@@ -3,6 +3,9 @@
 
 . ./config.sh
 
+# pin the version to avoid being blind-sided by incompatible changes
+DOCKER_PY=weaveworks/docker-py:pinned
+
 docker_py_test() {
     SHARD=$1
     TOTAL_SHARDS=$2
@@ -10,13 +13,13 @@ docker_py_test() {
     start_suite "Run docker-py test suite against the proxy"
 
     # Get a list of the tests for use to shard
-    docker_on $HOST1 pull joffrey/docker-py >/dev/null
+    docker_on $HOST1 pull $DOCKER_PY >/dev/null
     C=$(docker_on $HOST1 create \
         -e NOT_ON_HOST=true \
         -e DOCKER_HOST=tcp://172.17.42.1:12375 \
         -v /tmp:/tmp \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        joffrey/docker-py)
+        $DOCKER_PY)
     CANDIDATES=$(docker_on $HOST1 cp $C:/home/docker-py/tests/integration_test.py - | sed -En 's/^class (Test[[:alpha:]]+).*/\1/p')
 
     i=0
@@ -35,7 +38,7 @@ docker_py_test() {
         -e DOCKER_HOST=tcp://172.17.42.1:12375 \
         -v /tmp:/tmp \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        joffrey/docker-py python tests/integration_test.py $TESTS ; then
+        $DOCKER_PY python tests/integration_test.py $TESTS ; then
         assert_raises "true"
     else
         assert_raises "false"


### PR DESCRIPTION
At the time of writing, all smoke-test runs are failing because of a bug in docker-py.
This change pins the version to (a) work round this and (b) avoid surprises in future.
We should update the pinned version periodically to ensure we keep up with the Docker API.

The image we use, `joffrey/docker-py`, has very few tags, and no recent ones work with weave's smoke-tests, so I created a new image `weaveworks/docker-py:pinned`, built from https://github.com/docker/docker-py/commit/8ba85ac26f08521a96aab7be1e358a4aec709d32