### PR TITLE
Pin version of docker-py image

### DIFF
--- a/test/600_proxy_docker_py_test.sh
+++ b/test/600_proxy_docker_py_test.sh
@@ -4,7 +4,10 @@
 
 start_suite "Run docker-py test suite against the proxy"
 
-docker_on $HOST1 pull joffrey/docker-py >/dev/null
+# pin the version to avoid being blind-sided by incompatible changes
+DOCKER_PY=weaveworks/docker-py:pinned
+
+docker_on $HOST1 pull $DOCKER_PY >/dev/null
 
 weave_on $HOST1 launch-proxy --no-default-ipam
 
@@ -13,7 +16,7 @@ if docker_on $HOST1 run \
     -e DOCKER_HOST=tcp://172.17.42.1:12375 \
     -v /tmp:/tmp \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    joffrey/docker-py python tests/integration_test.py ; then
+    $DOCKER_PY python tests/integration_test.py ; then
     assert_raises "true"
 else
     assert_raises "false"


### PR DESCRIPTION
Parallel change to #1360, for the 1.0 branch.

The file has changed a lot (including its name) on master, so a merge of this change to master would be equivalent to re-implementing #1360.