### PR TITLE
Fix test 295

### DIFF
--- a/test/295_dns_large_response_test.sh
+++ b/test/295_dns_large_response_test.sh
@@ -19,7 +19,7 @@ weave_on $HOST1 dns-add $IPS $CID -h $NAME
 assert_raises "exec_on $HOST1 c0 dig MX $NAME | grep -q 'status: NXDOMAIN'"
 
 check() {
-    assert "exec_on $HOST1 c0 dig +short $@ $NAME A | grep -v ';;' | wc -l" $N
+    assert "exec_on $HOST1 c0 dig +short $* $NAME A | grep -v ';;' | wc -l" $N
 }
 
 check


### PR DESCRIPTION
Use `$*` instead of `$@` to get the desired quoting

Fixes #1362