### PR TITLE
ignore interface deletion errors during `weave reset`

### DIFF
--- a/weave
+++ b/weave
@@ -1300,7 +1300,7 @@ case "$COMMAND" in
         conntrack -D -p udp --dport $PORT >/dev/null 2>&1 || true
         destroy_bridge
         for LOCAL_IFNAME in $(ip link show | grep v${CONTAINER_IFNAME}pl | cut -d ' ' -f 2 | tr -d ':') ; do
-            ip link del $LOCAL_IFNAME
+            ip link del $LOCAL_IFNAME >/dev/null 2>&1 || true
         done
         ;;
     rmpeer)


### PR DESCRIPTION
These can occur when a container dies during `weave reset`.

Fixes #1356.