### PR TITLE
Fix docker api proxy smoke-tests after docker-py change (on 1.0 branch)

### DIFF
--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -45,6 +45,7 @@ func (i *createContainerInterceptor) InterceptRequest(r *http.Request) error {
 		return err
 	}
 	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(body))
 
 	container := createContainerRequestBody{}
 	if err := json.Unmarshal(body, &container); err != nil {
@@ -68,14 +69,14 @@ func (i *createContainerInterceptor) InterceptRequest(r *http.Request) error {
 		if err := i.setWeaveDNS(&container, r); err != nil {
 			return err
 		}
-	}
 
-	newBody, err := json.Marshal(container)
-	if err != nil {
-		return err
+		newBody, err := json.Marshal(container)
+		if err != nil {
+			return err
+		}
+		r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
+		r.ContentLength = int64(len(newBody))
 	}
-	r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
-	r.ContentLength = int64(len(newBody))
 
 	return nil
 }

--- a/proxy/create_exec_interceptor.go
+++ b/proxy/create_exec_interceptor.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -18,6 +19,7 @@ func (i *createExecInterceptor) InterceptRequest(r *http.Request) error {
 		return err
 	}
 	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(body))
 
 	options := docker.CreateExecOptions{}
 	if err := json.Unmarshal(body, &options); err != nil {
@@ -37,10 +39,10 @@ func (i *createExecInterceptor) InterceptRequest(r *http.Request) error {
 		Info.Printf("Exec in container %s with WEAVE_CIDR \"%s\"", container.ID, strings.Join(cidrs, " "))
 		cmd := append(weaveWaitEntrypoint, "-s")
 		options.Cmd = append(cmd, options.Cmd...)
-	}
 
-	if err := marshalRequestBody(r, options); err != nil {
-		return err
+		if err := marshalRequestBody(r, options); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/test/600_proxy_docker_py_test.sh
+++ b/test/600_proxy_docker_py_test.sh
@@ -5,6 +5,7 @@
 start_suite "Run docker-py test suite against the proxy"
 
 docker_on $HOST1 pull joffrey/docker-py >/dev/null
+docker_on $HOST1 pull busybox >/dev/null
 
 weave_on $HOST1 launch-proxy --no-default-ipam
 

--- a/test/600_proxy_docker_py_test.sh
+++ b/test/600_proxy_docker_py_test.sh
@@ -5,6 +5,7 @@
 start_suite "Run docker-py test suite against the proxy"
 
 docker_on $HOST1 pull joffrey/docker-py >/dev/null
+# workaround for https://github.com/docker/docker-py/issues/745
 docker_on $HOST1 pull busybox >/dev/null
 
 weave_on $HOST1 launch-proxy --no-default-ipam

--- a/test/600_proxy_docker_py_test.sh
+++ b/test/600_proxy_docker_py_test.sh
@@ -13,7 +13,7 @@ if docker_on $HOST1 run \
     -e DOCKER_HOST=tcp://172.17.42.1:12375 \
     -v /tmp:/tmp \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    joffrey/docker-py python tests/integration_test.py ; then
+    joffrey/docker-py py.test tests/integration_test.py ; then
     assert_raises "true"
 else
     assert_raises "false"


### PR DESCRIPTION
Docker-py was changed upstream to run using a test harness Pytest.

Also I have seen some failures due to the 'busybox' image not being found on the test host.