### PR TITLE
Looser docker-py test matcher for parallelization

### DIFF
--- a/test/600_proxy_docker_py.sh
+++ b/test/600_proxy_docker_py.sh
@@ -13,13 +13,10 @@ docker_py_test() {
     docker_on $HOST1 pull busybox >/dev/null
     # Get a list of the tests for use to shard
     docker_on $HOST1 pull joffrey/docker-py >/dev/null
-    C=$(docker_on $HOST1 create \
-        -e NOT_ON_HOST=true \
-        -e DOCKER_HOST=tcp://172.17.42.1:12375 \
-        -v /tmp:/tmp \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        joffrey/docker-py)
-    CANDIDATES=$(docker_on $HOST1 cp $C:/home/docker-py/tests/integration_test.py - | sed -En 's/^class (Test[[:alpha:]]+).*/\1/p')
+    CANDIDATES=$(docker_on $HOST1 run \
+      joffrey/docker-py \
+      py.test --collect-only tests/integration_test.py \
+      | sed -En "s/\s*<UnitTestCase '([[:alpha:]]+)'>/\1/p")
 
     i=0
     TESTS=


### PR DESCRIPTION
Previous one was only catching TestFoo, not FooTest. Python uses both.

~~Will expose a broken the test.~~

Found in https://github.com/weaveworks/weave/pull/1367

Depends on #1367