### PR TITLE
Support draft and pre-releases in `bin/release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,9 @@ tests: $(COVER_EXE)
 $(PUBLISH): publish_%: $(IMAGES_UPTODATE)
 	$(SUDO) docker tag -f $(DOCKERHUB_USER)/$* $(DOCKERHUB_USER)/$*:$(WEAVE_VERSION)
 	$(SUDO) docker push   $(DOCKERHUB_USER)/$*:$(WEAVE_VERSION)
+ifneq ($(UPDATE_LATEST),false)
 	$(SUDO) docker push   $(DOCKERHUB_USER)/$*:latest
+endif
 
 publish: $(PUBLISH)
 

--- a/bin/release
+++ b/bin/release
@@ -90,16 +90,23 @@ build() {
     echo '** Release artefacts in' $RELEASE_DIR
 }
 
-publish() {
+draft() {
     setup
+
+    TYPE="release"
+    RELEASE_ARGS="--draft"
+    if [ $# -ne 0 ] ; then
+        if [ $# -eq 1 -a "$1" = "--pre-release" ] ; then
+            TYPE="pre-release"
+            RELEASE_ARGS="$RELEASE_ARGS --pre-release"
+        else
+            usage
+        fi
+    fi
+
     cd $PWD/$RELEASE_DIR
 
     echo "== Sanity checks"
-
-    if ! [ $(git rev-list -1 $LATEST_TAG) == $(git rev-list -1 latest_release) ]; then
-        echo -e "\u2757 The tag latest_release does not point to the same commit as $LATEST_TAG"
-        exit 1
-    fi
 
     ## Check that the tag exists by looking at github
     if ! curl -sSf https://api.github.com/repos/$GITHUB_USER/weave/git/tags/$LATEST_TAG_SHA >/dev/null 2>&1; then
@@ -110,19 +117,9 @@ publish() {
         exit 1
     fi
 
-    ## Check that the 'latest_release' tag exists by looking at github
-    if ! curl -sSf https://api.github.com/repos/$GITHUB_USER/weave/git/tags/$LATEST_RELEASE_SHA >/dev/null 2>&1; then
-        echo -e "\u2757 Tag latest_release is not on GitHub, or is not the same as the local tag" >&2
-        echo -e "\thttps://github.com/$GITHUB_USER/weave/tags" >&2
-        echo "You may need to" >&2
-        echo -e "\tgit tag -af latest_release"
-        echo -e "\tgit push -f git@github.com:$GITHUB_USER/weave latest_release"
-        exit 1
-    fi
-
     echo -e "\u2713 Tag $LATEST_TAG exists in GitHub repo $GITHUB_USER/weave"
 
-    ## Check that the version doesn't already exist by looking at github
+    ## Check that the version does not already exist by looking at github
     ## releases
     if github-release info --user $GITHUB_USER --repo weave --tag $LATEST_TAG >/dev/null 2>&1; then
         echo -e "\u2757 Release $LATEST_TAG already exists on GitHub" >&2
@@ -132,13 +129,8 @@ publish() {
 
     echo '** Sanity checks OK for publishing tag' $LATEST_TAG as $DOCKERHUB_USER/weave:$VERSION
 
-    echo "== Tagging and publishing images on docker hub as user $DOCKERHUB_USER"
-    make SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
-
-    echo "== Creating GitHub release $RELEASE_NAME $VERSION"
-    # This cannot be done as a draft because of a bug in
-    # github-release: https://github.com/aktau/github-release/issues/7
-    github-release release \
+    echo "== Creating draft GitHub $TYPE $RELEASE_NAME $VERSION"
+    github-release release $RELEASE_ARGS \
         --user $GITHUB_USER \
         --repo weave \
         --tag $LATEST_TAG \
@@ -152,41 +144,111 @@ publish() {
         --name "weave" \
         --file "./weave"
 
-    echo "** Published release $RELEASE_NAME $VERSION"
+    echo "** Draft $TYPE $RELEASE_NAME $VERSION created at"
     echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG"
+}
 
-    if github-release info --user $GITHUB_USER --repo weave \
-        --tag latest_release >/dev/null 2>&1; then
-        github-release delete \
-            --user $GITHUB_USER \
-            --repo weave \
-            --tag latest_release
+publish() {
+    setup
+    cd $PWD/$RELEASE_DIR
+
+    echo "== Detecting draft type"
+    # Determine whether $LATEST_TAG version in GitHub is marked as pre-release
+    if ! INFO=$(github-release info --user $GITHUB_USER --repo weave --tag $LATEST_TAG) ; then
+        # github-release prints errors to stdout https://github.com/aktau/github-release/issues/32
+        echo $info >&2
+        exit 1
     fi
 
-    github-release release \
-        --user $GITHUB_USER \
-        --repo weave \
-        --tag latest_release \
-        --name "$RELEASE_NAME latest ($VERSION)" \
-        --description "$RELEASE_DESCRIPTION"
+    PRERELEASE=
+    TICK=$(echo -e '\u2714')
+    # Pre-releases are signified with a unicode $TICK character ಠ_ಠ
+    if echo "$INFO" | grep -q "prerelease: $TICK" ; then
+        PRERELEASE=1
+    fi
 
-    github-release upload \
-        --user $GITHUB_USER \
-        --repo weave \
-        --tag latest_release \
-        --name "weave" \
-        --file "./weave"
+    if [ -n "$PRERELEASE" ] ; then
+        echo "** Pre-release draft detected"
+        echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
+        make UPDATE_LATEST=false SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
+        echo "** Docker images tagged and pushed"
 
-    echo "** Published $RELEASE_NAME as latest_release at"
-    echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/latest_release"
+        echo "== Publishing pre-release on GitHub"
+
+        github-release publish \
+            --user $GITHUB_USER \
+            --repo weave \
+            --tag $LATEST_TAG
+
+        echo "** Pre-release $RELEASE_NAME $VERSION published at"
+        echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG"
+    else
+        echo "** Release draft detected"
+        echo "== Sanity checks"
+        if ! [ $(git rev-list -1 $LATEST_TAG) == $(git rev-list -1 latest_release) ]; then
+            echo -e "\u2757 The tag latest_release does not point to the same commit as $LATEST_TAG"
+            exit 1
+        fi
+
+        ## Check that the 'latest_release' tag exists by looking at github
+        if ! curl -sSf https://api.github.com/repos/$GITHUB_USER/weave/git/tags/$LATEST_RELEASE_SHA >/dev/null 2>&1; then
+            echo -e "\u2757 Tag latest_release is not on GitHub, or is not the same as the local tag" >&2
+            echo -e "\thttps://github.com/$GITHUB_USER/weave/tags" >&2
+            echo "You may need to" >&2
+            echo -e "\tgit tag -af latest_release"
+            echo -e "\tgit push -f git@github.com:$GITHUB_USER/weave latest_release"
+            exit 1
+        fi
+        echo '** Sanity checks OK for publishing tag' $LATEST_TAG as $DOCKERHUB_USER/weave:$VERSION
+
+        echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
+        make SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
+        echo "** Docker images tagged and pushed"
+
+        echo "== Publishing release on GitHub"
+
+        github-release publish \
+            --user $GITHUB_USER \
+            --repo weave \
+            --tag $LATEST_TAG
+
+        if github-release info --user $GITHUB_USER --repo weave \
+            --tag latest_release >/dev/null 2>&1; then
+            github-release delete \
+                --user $GITHUB_USER \
+                --repo weave \
+                --tag latest_release
+        fi
+
+        github-release release \
+            --user $GITHUB_USER \
+            --repo weave \
+            --tag latest_release \
+            --name "$RELEASE_NAME latest ($VERSION)" \
+            --description "$RELEASE_DESCRIPTION"
+
+        github-release upload \
+            --user $GITHUB_USER \
+            --repo weave \
+            --tag latest_release \
+            --name "weave" \
+            --file "./weave"
+
+        echo "** Release $RELEASE_NAME $VERSION published at"
+        echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG"
+        echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/latest_release"
+    fi
 }
 
 usage() {
     echo "Usage:"
     echo -e "\t./bin/release build"
     echo "-- Build artefacts for the latest version tag"
+    echo -e "\t./bin/release draft [--pre-release]"
+    echo "-- Create draft release with artefacts in GitHub"
     echo -e "\t./bin/release publish"
-    echo "-- Publish the artefacts for the latest tag to GitHub and DockerHub"
+    echo "-- Publish the GitHub release and update DockerHub"
+    exit 1
 }
 
 # Ensure required tooling is installed
@@ -197,15 +259,22 @@ if ! which github-release >/dev/null; then
     exit 1
 fi
 
-case "$1" in
+[ $# -eq 0 ] && usage
+COMMAND=$1
+shift
+
+case "$COMMAND" in
     build)
-        build
+        build "$@"
+        ;;
+    draft)
+        draft "$@"
         ;;
     publish)
-        publish
+        publish "$@"
         ;;
     *)
-        echo "Unknown command \"$1\""
+        echo "Unknown command \"$COMMAND\""
         usage
         ;;
 esac

--- a/bin/release
+++ b/bin/release
@@ -96,13 +96,6 @@ publish() {
 
     echo "== Sanity checks"
 
-    if ! which github-release >/dev/null; then
-        echo "Please install git-release:" >&2
-        echo -e "\tgo get github.com/aktau/github-release" >&2
-        echo "and create a git token per https://github.com/aktau/github-release" >&2
-        exit 1
-    fi
-
     if ! [ $(git rev-list -1 $LATEST_TAG) == $(git rev-list -1 latest_release) ]; then
         echo -e "\u2757 The tag latest_release does not point to the same commit as $LATEST_TAG"
         exit 1
@@ -195,6 +188,14 @@ usage() {
     echo -e "\t./bin/release publish"
     echo "-- Publish the artefacts for the latest tag to GitHub and DockerHub"
 }
+
+# Ensure required tooling is installed
+if ! which github-release >/dev/null; then
+    echo "Please install git-release:" >&2
+    echo -e "\tgo get github.com/aktau/github-release" >&2
+    echo "and create a git token per https://github.com/aktau/github-release" >&2
+    exit 1
+fi
 
 case "$1" in
     build)

--- a/bin/release
+++ b/bin/release
@@ -36,7 +36,9 @@ setup() {
     esac
 
     LATEST_TAG_SHA=$(git rev-parse $LATEST_TAG)
+    LATEST_TAG_COMMIT_SHA=$(git rev-list -1 $LATEST_TAG)
     LATEST_RELEASE_SHA=$(git rev-parse latest_release)
+    LATEST_RELEASE_COMMIT_SHA=$(git rev-list -1 latest_release)
     VERSION=${LATEST_TAG}
     # NB does not check that this tag is on master
     RELEASE_DIR=./releases/$LATEST_TAG
@@ -185,8 +187,10 @@ publish() {
     else
         echo "** Release draft detected"
         echo "== Sanity checks"
-        if ! [ $(git rev-list -1 $LATEST_TAG) == $(git rev-list -1 latest_release) ]; then
-            echo -e "\u2757 The tag latest_release does not point to the same commit as $LATEST_TAG"
+        if ! [ "$LATEST_TAG_COMMIT_SHA" == "$LATEST_RELEASE_COMMIT_SHA" ] ; then
+            echo -e "\u2757 The tag latest_release does not point to the same commit as $LATEST_TAG" >&2
+            echo "You may need to" >&2
+            echo -e "\tgit tag -af latest_release $LATEST_TAG" >&2
             exit 1
         fi
 
@@ -195,8 +199,7 @@ publish() {
             echo -e "\u2757 Tag latest_release is not on GitHub, or is not the same as the local tag" >&2
             echo -e "\thttps://github.com/$GITHUB_USER/weave/tags" >&2
             echo "You may need to" >&2
-            echo -e "\tgit tag -af latest_release"
-            echo -e "\tgit push -f git@github.com:$GITHUB_USER/weave latest_release"
+            echo -e "\tgit push -f git@github.com:$GITHUB_USER/weave latest_release" >&2
             exit 1
         fi
         echo '** Sanity checks OK for publishing tag' $LATEST_TAG as $DOCKERHUB_USER/weave:$VERSION

--- a/bin/release
+++ b/bin/release
@@ -11,14 +11,33 @@ RELEASE_DESCRIPTION=${RELEASE_DESCRIPTION:-"Weaving Containers into Applications
 PWD=`pwd`
 
 setup() {
-    ## Get the new version number from the most recent tag
-    if ! LATEST_TAG=$(git describe --abbrev=0 --match='v*' 2>/dev/null) ; then
-        echo "Could not find an annotated 'v*' version tag." >&2
-        exit 1
-    fi
+    # Ensure we have exactly one annotated tag pointing at HEAD
+    HEAD_TAGS=$(git tag --points-at HEAD)
+    case $(echo $HEAD_TAGS | wc -w) in
+        1)
+            if [ $HEAD_TAGS != "latest_release" ] ; then
+                LATEST_TAG=$HEAD_TAGS
+            else
+                echo "Cannot determine version - latest_release points at HEAD" >&2
+                exit 1
+            fi
+            ;;
+        0)
+            echo "Cannot determine version - no tags point at HEAD" >&2
+            exit 1
+            ;;
+        *)
+            echo "Cannot determine version - multiple tags point at HEAD:" >&2
+            for TAG in $HEAD_TAGS ; do
+                echo -e "\t$TAG" >&2
+            done
+            exit 1
+            ;;
+    esac
+
     LATEST_TAG_SHA=$(git rev-parse $LATEST_TAG)
     LATEST_RELEASE_SHA=$(git rev-parse latest_release)
-    VERSION=${LATEST_TAG#v}
+    VERSION=${LATEST_TAG}
     # NB does not check that this tag is on master
     RELEASE_DIR=./releases/$LATEST_TAG
 }
@@ -39,8 +58,8 @@ build() {
     cd $RELEASE_DIR
 
     ## Check that the top changelog entry is this version
-    if ! latest_changelog=$(grep -o "## Release [0-9].*" -m1 ./CHANGELOG.md) || \
-       ! [ `echo "$latest_changelog" | grep -o '[0-9][^ ]*'` == "$VERSION" ]; then
+    if ! latest_changelog=$(grep -oP '(?<=^## Release ).*' -m1 ./CHANGELOG.md) || \
+       ! [ `echo "$latest_changelog" = "$VERSION"` ]; then
         echo -e "\u2757 Latest changelog entry \"$latest_changelog\" does not match the release version $VERSION" >&2
         exit 1
     fi
@@ -61,7 +80,7 @@ build() {
     fi
 
     ## Run tests with the distributables, including version check
-    v=$(./prog/weaver/weaver --version | grep -o '[0-9].*')
+    v=$(./prog/weaver/weaver --version | grep -oP '(?<=^weave router ).*')
     if ! [ "$v" == "$VERSION" ]; then
         echo "Version of distributable "$v" does not match release version $VERSION" >&2
         exit 1

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,131 @@
+# Release Process
+## Prerequisites
+
+* Up-to-date versions of `git`, `go` etc
+* Install GitHub release tool `go get github.com/weaveworks/github-release`
+* Create a [github token for
+  github-release](https://help.github.com/articles/creating-an-access-token-for-command-line-use/);
+set and export `$GITHUB_TOKEN` with this value
+* Update all dependencies with `make update`
+
+## Build Phase
+### Update CHANGELOG.md
+
+* Checkout the branch from which you wish to release
+* Choose an appropriate version tag, henceforth referred to as `$TAG`.
+  Mainline releases use a version number (e.g. `TAG=v2.0.0`), whereas
+  pre-releases get a descriptive name (e.g. `TAG=feature-preview-20150902`)
+* Add a changelog entry for the new tag at the top of `CHANGELOG.md`.
+  The first line must be a markdown header of the form `## Release
+  $TAG`
+
+Commit the changelog update:
+
+    git commit -m "Add release $TAG" CHANGELOG.md
+
+### Create Version Tag
+
+Next you must tag the changelog commit with `$TAG`
+
+    git tag -a -m "Release $TAG" $TAG
+
+### Execute Build
+
+You are now ready to perform the build. If you have skipped the
+previous steps (e.g. because you're doing a rebuild), you must ensure
+that `HEAD` points to the tagged commit. You may then execute
+
+    bin/release build
+
+This has the following effects:
+
+* `git tag --points-at HEAD` is used to determine `$TAG` (hence the
+  `HEAD` requirement)
+* Your *local* repository is cloned into `releases/$TAG`
+* `CHANGELOG.md` is checked to ensure it has an entry for `$TAG`
+* Distributables injected with `$TAG` are built
+* Tests are executed
+
+## Draft Phase
+### Push Version Tag Upstream
+
+First you must push your version tag upstream, so that an associated
+GitHub release may be created:
+
+    git push git@github.com:weaveworks/weave $TAG
+
+N.B. if you're testing the release process, push to your fork
+instead!
+
+### Create Draft Release
+
+You're now ready to draft your release notes:
+
+    bin/release draft [--pre-release]
+
+This has the following effects:
+
+* A [release](https://help.github.com/articles/about-releases) is
+  created in GitHub for `$TAG`. This release is in the draft state, so
+  it is only visible to contributors
+* The `weave` script is uploaded as an attachment to the release
+* If `--pre-release` is specified, the release will have the
+  pre-release attribute set (this affects the way GitHub displays the
+  release and modifies the behaviour of the publish phase)
+
+Navigate to https://github.com/weaveworks/weave/releases, 'Edit' the
+draft and input the release notes. When you are done make sure you
+'Save draft' (and not 'Publish release'!).
+
+Once the release notes have passed review, proceed to the publish
+phase.
+
+## Publish Phase
+### Move/Force Push `latest_release` Tag
+
+This step must only be performed for mainline (non pre-release)
+releases:
+
+    git tag -af -m "Release $TAG" latest_release $TAG
+    git push -f git@github.com:weaveworks/weave latest_release
+
+The `latest_release` tag *must* point at `$TAG`, *not* at `HEAD` -
+the build script will complain otherwise.
+
+N.B. if you're testing the release process, push to your fork
+instead!
+
+### Publish Release & Distributable Artefacts
+
+You can now publish the release and upload the remaining
+distributables to DockerHub:
+
+    bin/release publish
+
+This has the following effects:
+
+* Docker images are tagged `$TAG` and pushed to DockerHub
+* GitHub release moves from draft to published state
+
+Furthermore, if this is a mainline release (detected automatically
+from the GitHub release, you do not need to specify the flag again to
+the publish step)
+
+* Images tagged `latest` are updated on DockerHub
+* Release named `latest_release` is updated on GitHub
+
+
+## Troubleshooting
+
+There's a few things that can go wrong.
+
+ * If the build is wonky, e.g., the tests don't pass, you can delete
+   the directory in `./releases/`, fix whatever it is, move the
+   version tag (which should still be only local) and have another go.
+ * If the DockerHub pushes fail (which sadly seems to happen a lot),
+   you can just run `./bin/release publish` again.
+ * If you need to overwrite a release you can do so by manually
+   deleting the GitHub version release and re-running the process.
+   Please note that the DockerHub `latest` images, GitHub
+   `latest_release` and download links may be in an inconsistent state
+   until the overwrite is completed.


### PR DESCRIPTION
This PR refactors the `bin/release` script to have three steps:

````
bin/release build
bin/release draft [--pre-release]
bin/release publish
````

The second step creates the GitHub release in draft state, optionally marked as pre-release; the final step removes the draft state (making the release visible to the outside world) and updates latest in {Git,Docker}Hub only if the pre-release attribute is missing.

## Caveats
* The previous implementation used `git-describe` with a `--match=v*` to find the most recent version tag. To support non-mainline releases I've had to remove all the 'v' related logic with three consequences:
 * The version in the changelog must match the exact tag name. For mainline releases it must include the 'v' prefix, which is not currently the case
 * With no prefix to search for, the new implementation uses `git tag --points-at HEAD` and expects to find a single tag there which it assumes is the version tag. This is slightly less flexible that before, because it means the `HEAD` of your local branch must be the tagged commit that you want to build
 * The `latest_release` tag must point at the version tag, not directly at the commit object (e.g. you *must* now use `git tag -af latest_release v2.0.0` whereas before you could have had `v2.0.0` checked out and done `git tag -af latest_release`). The current release instructions describe the first method anyway, so probably not a big deal

## Outstanding Issues
* Something of a showstopper - the `github-release edit` command used to remove the draft status resets the description field. I can think of a several solutions to this, none of which are very appealing:
 * Read the description with `github release info` first and then supply it back as an argument to `github-release edit`. Note that the output of `info` isn't really amenable to reliable parsing, particularly in the face of the freeform multiline description field
 * Manipulate the GitHub API directly to remove the draft status. Not straightforward due to the need to manually search through the (potentially paginated) list of releases to find the release ID; if we are willing to do this, begs the question of why we're bothering with `github-release`
 * Prompt the user to publish the release manually using the Github UI. We could do this either at the end of `bin/release publish`, or we could require them to do it first and check at the start
* The current release process instructions specify (in bold) that the user updates the `latest_release` tag in the repository cloned into `releases/`, not in the repository in which they created the version tag and are running `bin/release`. This seems odd - does anyone object to the checks being modified so that they all operate on the 'outer' repository? (Related, there's a bug in the current logic anyway - see the 'Fix latest_release hash test' commit in this PR)

@dpw @rade @squaremo particularly interested in your opionions on the caveats and issues - this PR isn't ideal at the moment. Will hold off producing updated release process instructions for the wiki until things are ironed out.

Further explanatory material is available in the individual commit messages.

Fixes #880, fixes #909.