### PR TITLE
[proxy] add --rewrite-inspect flag

### DIFF
--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -29,6 +29,7 @@ func main() {
 	mflagext.ListVar(&c.ListenAddrs, []string{"H"}, nil, "addresses on which to listen")
 	mflag.StringVar(&c.HostnameMatch, []string{"-hostname-match"}, "(.*)", "Regexp pattern to apply on container names (e.g. '^aws-[0-9]+-(.*)$')")
 	mflag.StringVar(&c.HostnameReplacement, []string{"-hostname-replacement"}, "$1", "Expression to generate hostnames based on matches from --hostname-match (e.g. 'my-app-$1')")
+	mflag.BoolVar(&c.RewriteInspect, []string{"-rewrite-inspect"}, false, "Rewrite 'inspect' calls to return the weave network settings (if attached)")
 	mflag.BoolVar(&c.NoDefaultIPAM, []string{"#-no-default-ipam", "-no-default-ipalloc"}, false, "do not automatically allocate addresses for containers without a WEAVE_CIDR")
 	mflag.BoolVar(&c.NoRewriteHosts, []string{"-no-rewrite-hosts"}, false, "do not automatically rewrite /etc/hosts. Use if you need the docker IP to remain in /etc/hosts")
 	mflag.StringVar(&c.TLSConfig.CACert, []string{"#tlscacert", "-tlscacert"}, "", "Trust certs signed only by this CA")

--- a/proxy/common.go
+++ b/proxy/common.go
@@ -105,8 +105,8 @@ func inspectContainerInPath(client *docker.Client, path string) (*docker.Contain
 	return container, err
 }
 
-func weaveContainerIPs(container *docker.Container) (mac string, ips []net.IP, nets []*net.IPNet, err error) {
-	stdout, stderr, err := callWeave("ps", container.ID)
+func weaveContainerIPs(containerID string) (mac string, ips []net.IP, nets []*net.IPNet, err error) {
+	stdout, stderr, err := callWeave("ps", containerID)
 	if err != nil || len(stderr) > 0 {
 		err = errors.New(string(stderr))
 		return

--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -1,8 +1,6 @@
 package proxy
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -42,15 +40,8 @@ func (err *ErrNoSuchImage) Error() string {
 }
 
 func (i *createContainerInterceptor) InterceptRequest(r *http.Request) error {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	r.Body.Close()
-	r.Body = ioutil.NopCloser(bytes.NewReader(body))
-
 	container := createContainerRequestBody{}
-	if err := json.Unmarshal(body, &container); err != nil {
+	if err := unmarshalRequestBody(r, &container); err != nil {
 		return err
 	}
 
@@ -74,12 +65,7 @@ func (i *createContainerInterceptor) InterceptRequest(r *http.Request) error {
 			return err
 		}
 
-		newBody, err := json.Marshal(container)
-		if err != nil {
-			return err
-		}
-		r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
-		r.ContentLength = int64(len(newBody))
+		return marshalRequestBody(r, container)
 	}
 
 	return nil

--- a/proxy/create_exec_interceptor.go
+++ b/proxy/create_exec_interceptor.go
@@ -1,9 +1,6 @@
 package proxy
 
 import (
-	"bytes"
-	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -14,15 +11,8 @@ import (
 type createExecInterceptor struct{ proxy *Proxy }
 
 func (i *createExecInterceptor) InterceptRequest(r *http.Request) error {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	r.Body.Close()
-	r.Body = ioutil.NopCloser(bytes.NewReader(body))
-
 	options := docker.CreateExecOptions{}
-	if err := json.Unmarshal(body, &options); err != nil {
+	if err := unmarshalRequestBody(r, &options); err != nil {
 		return err
 	}
 

--- a/proxy/inspect_container_interceptor.go
+++ b/proxy/inspect_container_interceptor.go
@@ -1,0 +1,60 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/weaveworks/weave/common"
+)
+
+type inspectContainerInterceptor struct{ proxy *Proxy }
+
+func (i *inspectContainerInterceptor) InterceptRequest(r *http.Request) error {
+	return nil
+}
+
+func (i *inspectContainerInterceptor) InterceptResponse(r *http.Response) error {
+	if !i.proxy.RewriteInspect {
+		return nil
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+
+	container := &docker.Container{}
+	if err := json.Unmarshal(body, container); err != nil {
+		return err
+	}
+
+	if err := updateContainerNetworkSettings(container); err != nil {
+		Log.Warningf("Inspecting container %s failed: %s", container.ID, err)
+	}
+
+	newBody, err := json.Marshal(container)
+	if err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
+	r.ContentLength = int64(len(newBody))
+	r.TransferEncoding = nil // Stop it being chunked, because that hangs
+
+	return nil
+}
+
+func updateContainerNetworkSettings(container *docker.Container) error {
+	mac, ips, nets, err := weaveContainerIPs(container)
+	if err != nil || len(ips) == 0 {
+		return err
+	}
+
+	container.NetworkSettings.MacAddress = mac
+	container.NetworkSettings.IPAddress = ips[0].String()
+	container.NetworkSettings.IPPrefixLen, _ = nets[0].Mask.Size()
+	return nil
+}

--- a/proxy/inspect_exec_interceptor.go
+++ b/proxy/inspect_exec_interceptor.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/weaveworks/weave/common"
+)
+
+type inspectExecInterceptor struct{ proxy *Proxy }
+
+func (i *inspectExecInterceptor) InterceptRequest(r *http.Request) error {
+	return nil
+}
+
+func (i *inspectExecInterceptor) InterceptResponse(r *http.Response) error {
+	if !i.proxy.RewriteInspect {
+		return nil
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	r.Body.Close()
+
+	exec := &docker.ExecInspect{}
+	if err := json.Unmarshal(body, exec); err != nil {
+		return err
+	}
+
+	if err := updateContainerNetworkSettings(&exec.Container); err != nil {
+		Log.Warningf("Inspecting exec %s failed: %s", exec.ID, err)
+	}
+
+	newBody, err := json.Marshal(exec)
+	if err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
+	r.ContentLength = int64(len(newBody))
+	r.TransferEncoding = nil // Stop it being chunked, because that hangs
+
+	return nil
+}

--- a/proxy/json.go
+++ b/proxy/json.go
@@ -1,0 +1,46 @@
+package proxy
+
+import (
+	"fmt"
+)
+
+type UnmarshalWrongTypeError struct {
+	Field, Expected string
+	Got             interface{}
+}
+
+func (e *UnmarshalWrongTypeError) Error() string {
+	return fmt.Sprintf("Wrong type for %s field, expected %s, but got %T", e.Field, e.Expected, e.Got)
+}
+
+// For parsing json objects. Look up (or create) a child object in the given map.
+func lookupObject(m map[string]interface{}, key string) (map[string]interface{}, error) {
+	iface, ok := m[key]
+	if !ok || iface == nil {
+		result := map[string]interface{}{}
+		m[key] = result
+		return result, nil
+	}
+
+	result, ok := iface.(map[string]interface{})
+	if !ok {
+		return nil, &UnmarshalWrongTypeError{key, "object", iface}
+	}
+
+	return result, nil
+}
+
+// For parsing json objects. Look up (or create) a string in the given map.
+func lookupString(m map[string]interface{}, key string) (string, error) {
+	iface, ok := m[key]
+	if !ok || iface == nil {
+		return "", nil
+	}
+
+	result, ok := iface.(string)
+	if !ok {
+		return "", &UnmarshalWrongTypeError{key, "string", iface}
+	}
+
+	return result, nil
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -24,15 +24,19 @@ const (
 )
 
 var (
-	containerCreateRegexp  = regexp.MustCompile("^(/v[0-9\\.]*)?/containers/create$")
-	containerStartRegexp   = regexp.MustCompile("^(/v[0-9\\.]*)?/containers/[^/]*/(re)?start$")
-	containerInspectRegexp = regexp.MustCompile("^(/v[0-9\\.]*)?/containers/[^/]*/json$")
-	execCreateRegexp       = regexp.MustCompile("^(/v[0-9\\.]*)?/containers/[^/]*/exec$")
-	execInspectRegexp      = regexp.MustCompile("^(/v[0-9\\.]*)?/exec/[^/]*/json$")
+	containerCreateRegexp  = dockerAPIEndpoint("containers/create")
+	containerStartRegexp   = dockerAPIEndpoint("containers/[^/]*/(re)?start")
+	containerInspectRegexp = dockerAPIEndpoint("containers/[^/]*/json")
+	execCreateRegexp       = dockerAPIEndpoint("containers/[^/]*/exec")
+	execInspectRegexp      = dockerAPIEndpoint("exec/[^/]*/json")
 
 	ErrWeaveCIDRNone = errors.New("the container was created with the '-e WEAVE_CIDR=none' option")
 	ErrNoDefaultIPAM = errors.New("the container was created without specifying an IP address with '-e WEAVE_CIDR=...' and the proxy was started with the '--no-default-ipalloc' option")
 )
+
+func dockerAPIEndpoint(endpoint string) *regexp.Regexp {
+	return regexp.MustCompile("^(/v[0-9\\.]*)?/" + endpoint + "$")
+}
 
 type Config struct {
 	HostnameMatch       string

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -104,9 +104,13 @@ Multiple IP addresses and networks can be supplied in the `WEAVE_CIDR`
 variable by space-separating them, as in
 `WEAVE_CIDR="10.2.1.1/24 10.2.2.1/24"`.
 
-The docker IP will still be returned by `docker inspect`. If you want
-`docker inspect` to return the weave IP instead, then the proxy must
-be launced with the `--rewrite-inspect` flag.
+The docker NetworkSettings (including IP address, MacAddress, and
+IPPrefixLen), will still be returned by `docker inspect`. If you want
+`docker inspect` to return the weave NetworkSettings instead, then the
+proxy must be launced with the `--rewrite-inspect` flag. This will
+only substitute in the weave network settings when the container has a
+weave IP. If a container has more than one weave IP, the inspect call
+will only include one of them.
 
     host1$ weave launch-router && weave launch-proxy --rewrite-inspect
 

--- a/site/proxy.md
+++ b/site/proxy.md
@@ -104,6 +104,12 @@ Multiple IP addresses and networks can be supplied in the `WEAVE_CIDR`
 variable by space-separating them, as in
 `WEAVE_CIDR="10.2.1.1/24 10.2.2.1/24"`.
 
+The docker IP will still be returned by `docker inspect`. If you want
+`docker inspect` to return the weave IP instead, then the proxy must
+be launced with the `--rewrite-inspect` flag.
+
+    host1$ weave launch-router && weave launch-proxy --rewrite-inspect
+
 ## <a name="ipam"></a>Automatic IP address assignment
 
 If [automatic IP address assignment](ipam.html) is enabled in weave,

--- a/test/605_proxy_inspect_test.sh
+++ b/test/605_proxy_inspect_test.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Check that docker inspect returns the weave IP"
+
+weave_on $HOST1 launch-router
+weave_on $HOST1 launch-proxy --rewrite-inspect
+
+proxy docker_on $HOST1 run -dt --name c1 $SMALL_IMAGE /bin/sh
+inspect_format="{{.Name}} {{.NetworkSettings.MacAddress}} {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}"
+expected="/$(weave_on $HOST1 ps c1)"
+
+assert "proxy docker_on $HOST1 inspect --format='$inspect_format' c1" "$expected"
+
+end_suite

--- a/weave
+++ b/weave
@@ -56,6 +56,7 @@ weave launch-proxy  [-H <endpoint>] [--with-dns | --without-dns]
                       [--no-default-ipalloc] [--no-rewrite-hosts]
                       [--hostname-match <regexp>]
                       [--hostname-replacement <replacement>]
+                      [--rewrite-inspect]
 weave env           [--restore]
 weave config
 weave connect       [--replace] [<peer> ...]


### PR DESCRIPTION
To return the weave ip/mac for docker inspect calls.

Fixes #117, and #1199 (possibly? Anything else outstanding for that?)