### PR TITLE
Update docs for mixed manual and automatic IP allocation

### DIFF
--- a/site/features.md
+++ b/site/features.md
@@ -112,11 +112,11 @@ Similarly, in the container on $HOST2...
     round-trip min/avg/max/stddev = 1.034/1.034/1.034/0.000 ms
 
 The IP addresses and netmasks can be anything you like, but make sure
-they don't conflict with any IP ranges in use on the hosts (including
-those delegated to weave's [automatic IP address allocator](ipam.html)) or
+they don't conflict with any IP ranges in use on the hosts or
 IP addresses of external services the hosts or containers need to
-connect to. The same IP range must be used everywhere, and the
-individual IP addresses must, of course, be unique.
+connect to. The individual IP addresses given to containers must, of
+course, be unique - if you pick an address that the automatic
+allocator has already assigned you will receive a warning.
 
 ### <a name="naming-and-discovery"></a>Naming and discovery
 

--- a/site/ipam.md
+++ b/site/ipam.md
@@ -159,9 +159,13 @@ symbolically with `net:default`.
 
 ## <a name="manual"></a>Mixing automatic and manual allocation
 
-If you want to start containers with a mixture of
-automatically-allocated addresses and manually-chosen addresses, *and
-have the containers communicate with each other*, you can choose a
+You can start containers with a mixture of automatically-allocated
+addresses and manually-chosen addresses in the same range, but you may
+find that the automatic allocator has already reserved a specific
+address that you wanted.
+
+To reserve a range for manual allocation in the same subnet as the
+automatic allocator, you can specify an
 `--ipalloc-range` that is smaller than `--ip-default-subnet`, For
 example, if you launch weave with:
 


### PR DESCRIPTION
Missed from #1200.

The phrase "The same IP range must be used everywhere" does not seem appropriate in that paragraph - if the user has multiple disjoint sets of containers they do not need to follow this advice -- so I dropped it.