### PR TITLE
Make Weave build & work with Go 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ NETGO_CHECK=@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
 	echo "    sudo go install -tags netgo std"; \
 	false; \
 }
-BUILD_FLAGS=-ldflags "-extldflags \"-static\" -X main.version $(WEAVE_VERSION)" -tags netgo
+BUILD_FLAGS=-ldflags "-extldflags \"-static\" -linkmode=external -X main.version=$(WEAVE_VERSION)" -tags netgo
 
 all: $(WEAVE_EXPORT) $(COVER_EXE) $(RUNNER_EXE)
 
@@ -81,8 +81,8 @@ $(COVER_EXE): testing/cover/cover.go
 $(RUNNER_EXE): testing/runner/runner.go
 
 $(WEAVEWAIT_EXE) $(SIGPROXY_EXE) $(WEAVEHOSTS_EXE) $(COVER_EXE) $(RUNNER_EXE):
-	go get ./$(@D)
-	go build -o $@ ./$(@D)
+	go get -tags netgo ./$(@D)
+	go build $(BUILD_FLAGS) -o $@ ./$(@D)
 
 $(WEAVER_UPTODATE): prog/weaver/Dockerfile $(WEAVER_EXE)
 	$(SUDO) docker build -t $(WEAVER_IMAGE) prog/weaver

--- a/router/utils.go
+++ b/router/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/weaveworks/weave/common"
 )
@@ -26,15 +27,19 @@ func checkWarn(e error) {
 	}
 }
 
+// Look inside an error produced by the net package to get to the
+// syscall.Errno at the root of the problem.
 func PosixError(err error) error {
-	if err == nil {
-		return nil
+	if operr, ok := err.(*net.OpError); ok {
+		err = operr.Err
 	}
-	operr, ok := err.(*net.OpError)
-	if !ok {
-		return nil
+
+	// go1.5 wraps an Errno inside a SyscallError inside an OpError
+	if scerr, ok := err.(*os.SyscallError); ok {
+		err = scerr.Err
 	}
-	return operr.Err
+
+	return err
 }
 
 func (mtbe MsgTooBigError) Error() string {


### PR DESCRIPTION
FIxes:

```
go get ./prog/weavewait
go install net: open /usr/local/go/pkg/linux_amd64/net.a: permission denied
make: *** [prog/weavewait/weavewait] Error 1
```

And:

```
# github.com/weaveworks/weave/prog/weaver
link: warning: option -X main.version git-4c6a8f29c0ea may not work in future releases; use -X main.version=git-4c6a8f29c0ea
```

TODO:
- Update circle to install go1.5