### PR TITLE
Only update DockerHub `latest` images on mainline release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -10,6 +10,16 @@ RELEASE_DESCRIPTION=${RELEASE_DESCRIPTION:-"Weaving Containers into Applications
 
 PWD=`pwd`
 
+infer_release_type() {
+    if echo $1 | grep -qE '^v[0-9]+\.[0-9]+\.0+$' ; then
+        echo MAINLINE
+    elif echo $1 | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' ; then
+        echo BRANCH
+    else
+        echo PRERELEASE
+    fi
+}
+
 setup() {
     # Ensure we have exactly one annotated tag pointing at HEAD
     HEAD_TAGS=$(git tag --points-at HEAD)
@@ -34,6 +44,9 @@ setup() {
             exit 1
             ;;
     esac
+
+    RELEASE_TYPE=$(infer_release_type $LATEST_TAG)
+    echo "== Inferred release type $RELEASE_TYPE from tag $LATEST_TAG"
 
     LATEST_TAG_SHA=$(git rev-parse $LATEST_TAG)
     LATEST_TAG_COMMIT_SHA=$(git rev-list -1 $LATEST_TAG)
@@ -95,17 +108,6 @@ build() {
 draft() {
     setup
 
-    TYPE="release"
-    RELEASE_ARGS="--draft"
-    if [ $# -ne 0 ] ; then
-        if [ $# -eq 1 -a "$1" = "--pre-release" ] ; then
-            TYPE="pre-release"
-            RELEASE_ARGS="$RELEASE_ARGS --pre-release"
-        else
-            usage
-        fi
-    fi
-
     cd $PWD/$RELEASE_DIR
 
     echo "== Sanity checks"
@@ -131,7 +133,12 @@ draft() {
 
     echo '** Sanity checks OK for publishing tag' $LATEST_TAG as $DOCKERHUB_USER/weave:$VERSION
 
-    echo "== Creating draft GitHub $TYPE $RELEASE_NAME $VERSION"
+    RELEASE_ARGS="--draft"
+    if [ "$RELEASE_TYPE" = 'PRERELEASE' ] ; then
+        RELEASE_ARGS="$RELEASE_ARGS --pre-release"
+    fi
+
+    echo "== Creating GitHub release $RELEASE_ARGS $RELEASE_NAME $VERSION"
     github-release release $RELEASE_ARGS \
         --user $GITHUB_USER \
         --repo weave \
@@ -154,25 +161,14 @@ publish() {
     setup
     cd $PWD/$RELEASE_DIR
 
-    echo "== Detecting draft type"
-    # Determine whether $LATEST_TAG version in GitHub is marked as pre-release
-    if ! INFO=$(github-release info --user $GITHUB_USER --repo weave --tag $LATEST_TAG) ; then
-        # github-release prints errors to stdout https://github.com/aktau/github-release/issues/32
-        echo $info >&2
-        exit 1
+    UPDATE_LATEST=false
+    if [ "$RELEASE_TYPE" = 'MAINLINE' ] ; then
+        UPDATE_LATEST=true
     fi
 
-    PRERELEASE=
-    TICK=$(echo -e '\u2714')
-    # Pre-releases are signified with a unicode $TICK character ಠ_ಠ
-    if echo "$INFO" | grep -q "prerelease: $TICK" ; then
-        PRERELEASE=1
-    fi
-
-    if [ -n "$PRERELEASE" ] ; then
-        echo "** Pre-release draft detected"
+    if [ "$RELEASE_TYPE" = 'PRERELEASE' ] ; then
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
-        make UPDATE_LATEST=false SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
+        make UPDATE_LATEST=$UPDATE_LATEST SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
         echo "** Docker images tagged and pushed"
 
         echo "== Publishing pre-release on GitHub"
@@ -185,7 +181,6 @@ publish() {
         echo "** Pre-release $RELEASE_NAME $VERSION published at"
         echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG"
     else
-        echo "** Release draft detected"
         echo "== Sanity checks"
         if ! [ "$LATEST_TAG_COMMIT_SHA" == "$LATEST_RELEASE_COMMIT_SHA" ] ; then
             echo -e "\u2757 The tag latest_release does not point to the same commit as $LATEST_TAG" >&2
@@ -205,7 +200,7 @@ publish() {
         echo '** Sanity checks OK for publishing tag' $LATEST_TAG as $DOCKERHUB_USER/weave:$VERSION
 
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
-        make SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
+        make UPDATE_LATEST=$UPDATE_LATEST SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
         echo "** Docker images tagged and pushed"
 
         echo "== Publishing release on GitHub"
@@ -247,7 +242,7 @@ usage() {
     echo "Usage:"
     echo -e "\t./bin/release build"
     echo "-- Build artefacts for the latest version tag"
-    echo -e "\t./bin/release draft [--pre-release]"
+    echo -e "\t./bin/release draft
     echo "-- Create draft release with artefacts in GitHub"
     echo -e "\t./bin/release publish"
     echo "-- Publish the GitHub release and update DockerHub"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,13 +8,27 @@
 set and export `$GITHUB_TOKEN` with this value
 * Update all dependencies with `make update`
 
+## Release Types
+
+The release script behaves differently depending on the kind of
+release you are doing. There are three types:
+
+* **Mainline** - a release (typically from master) with version tag
+  `vX.Y.Z` where Z is zero (e.g. `v2.1.0`)
+* **Branch** - a bugfix release (typically from a branch) with version tag
+  `vX.Y.Z` where Z is non-zero (e.g `v2.1.1`)
+* **Prerelease** - a release from an arbitrary branch with an arbitrary
+  version tag (e.g. `feature-preview-20150904`)
+
+N.B. the release script _infers the release type from the format of the
+version tag_. Ensure your tag is in the correct format and the desired
+behaviours for that type of release will be obtained from the script.
+
 ## Build Phase
 ### Update CHANGELOG.md
 
 * Checkout the branch from which you wish to release
-* Choose an appropriate version tag, henceforth referred to as `$TAG`.
-  Mainline releases use a version number (e.g. `TAG=v2.0.0`), whereas
-  pre-releases get a descriptive name (e.g. `TAG=feature-preview-20150902`)
+* Choose a version tag (see above) henceforth referred to as `$TAG`.
 * Add a changelog entry for the new tag at the top of `CHANGELOG.md`.
   The first line must be a markdown header of the form `## Release
   $TAG`
@@ -61,17 +75,15 @@ instead!
 
 You're now ready to draft your release notes:
 
-    bin/release draft [--pre-release]
+    bin/release draft
 
 This has the following effects:
 
 * A [release](https://help.github.com/articles/about-releases) is
   created in GitHub for `$TAG`. This release is in the draft state, so
-  it is only visible to contributors
+  it is only visible to contributors; for **Prerelease** builds the
+  pre-release attribute will also be set
 * The `weave` script is uploaded as an attachment to the release
-* If `--pre-release` is specified, the release will have the
-  pre-release attribute set (this affects the way GitHub displays the
-  release and modifies the behaviour of the publish phase)
 
 Navigate to https://github.com/weaveworks/weave/releases, 'Edit' the
 draft and input the release notes. When you are done make sure you
@@ -83,7 +95,7 @@ phase.
 ## Publish Phase
 ### Move/Force Push `latest_release` Tag
 
-This step must only be performed for mainline (non pre-release)
+This step must only be performed for **Mainline** and **Branch**
 releases:
 
     git tag -af -m "Release $TAG" latest_release $TAG
@@ -102,17 +114,19 @@ distributables to DockerHub:
 
     bin/release publish
 
-This has the following effects:
+The effects of this step depend on the inferred release type. The
+following occurs for all types:
 
 * Docker images are tagged `$TAG` and pushed to DockerHub
 * GitHub release moves from draft to published state
 
-Furthermore, if this is a mainline release (detected automatically
-from the GitHub release, you do not need to specify the flag again to
-the publish step)
+Additionally, for **Mainline** and **Branch** types:
+
+* Release named `latest_release` is updated on GitHub
+
+Finally, for **Mainline** releases only:
 
 * Images tagged `latest` are updated on DockerHub
-* Release named `latest_release` is updated on GitHub
 
 
 ## Troubleshooting


### PR DESCRIPTION
Script now infers release type (mainline, branch or prerelease) from the version tag and adjusts its behaviour accordingly. The `--pre-release` option to `bin/release draft` has also been removed in favour of the new inferencing mechanism.

Fixes #1383.