### PR TITLE
gliderlabs/alpine is now just alpine

### DIFF
--- a/prog/weaveexec/Dockerfile
+++ b/prog/weaveexec/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine
+FROM alpine
 
 MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system

--- a/test/config.sh
+++ b/test/config.sh
@@ -34,7 +34,7 @@ HOST3=$(echo $HOSTS | cut -f 3 -d ' ')
 SSH_DIR=${SSH_DIR:-$DIR}
 SSH=${SSH:-ssh -l vagrant -i "$SSH_DIR/insecure_private_key" -o "UserKnownHostsFile=$SSH_DIR/.ssh_known_hosts" -o CheckHostIP=no -o StrictHostKeyChecking=no}
 
-SMALL_IMAGE="gliderlabs/alpine"
+SMALL_IMAGE="alpine"
 DNS_IMAGE="aanand/docker-dnsutils"
 TEST_IMAGES="$SMALL_IMAGE $DNS_IMAGE"
 


### PR DESCRIPTION
Official image is now at: https://hub.docker.com/r/library/alpine/, but it's just an alias for gliderlabs/alpine.