### PR TITLE
always arp_update new addresses in 'attach'

### DIFF
--- a/test/170_ip_reuse_test.sh
+++ b/test/170_ip_reuse_test.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+. ./config.sh
+
+C1=10.2.1.43
+C2=10.2.1.44
+C3=10.2.1.45
+
+start_suite "re-using IP addresses (arp cache updating)"
+
+weave_on $HOST1 launch
+
+check() {
+    assert_raises "exec_on $HOST1 c1 $PING $C2"
+}
+
+start_container $HOST1 $C1/24 --name=c1
+
+start_container $HOST1 $C2/24 --name=c2
+check
+
+docker_on $HOST1 stop c2
+start_container $HOST1 $C2/24 --name=c3
+check
+
+docker_on $HOST1 stop c3
+start_container $HOST1 $C3/24 --name=c4
+weave_on $HOST1 attach $C2/24 c4
+check
+
+end_suite

--- a/weave
+++ b/weave
@@ -520,31 +520,27 @@ launch() {
 }
 
 attach() {
-    if netnsenter ip link show $CONTAINER_IFNAME >/dev/null 2>&1 ; then
-        for ADDR in "$@" ; do
-            # container already has the expected network interface, so assume we set it up already;
-            # just add the IP address.
-            if netnsenter ip addr show dev $CONTAINER_IFNAME | grep -F $ADDR >/dev/null ; then
-                # address was there already
-                continue
-            fi
-            netnsenter ip addr add $ADDR dev $CONTAINER_IFNAME || return 1
-        done
-
-        return 0
+    if ! netnsenter ip link show $CONTAINER_IFNAME >/dev/null 2>&1 ; then
+        connect_container_to_bridge || return 1
     fi
 
-    connect_container_to_bridge || return 1
-
+    NEW_ADDRS=
     for ADDR in "$@" ; do
+        if netnsenter ip addr show dev $CONTAINER_IFNAME | grep -F $ADDR >/dev/null ; then
+            # address was there already
+            continue
+        fi
         netnsenter ip addr add $ADDR dev $CONTAINER_IFNAME || return 1
+        NEW_ADDRS="$NEW_ADDRS $ADDR"
     done
 
     netnsenter ip link set $CONTAINER_IFNAME up || return 1
 
-    for ADDR in "$@" ; do
-        arp_update $CONTAINER_IFNAME $ADDR "netnsenter"
-    done
+    if [ -n "$NEW_ADDRS" ] ; then
+        for ADDR in "$NEW_ADDRS" ; do
+            arp_update $CONTAINER_IFNAME $ADDR "netnsenter"
+        done
+    fi
 
     # Route multicast packets across the weave network.
     # This must come last in 'attach'. If you change this, change weavewait to match.


### PR DESCRIPTION
Previously we'd only do that when the container had no ethwe at the start. Therefore adding a recycled IP address to an already attached container would not send out an arp update for that IP, which would break connectivity to that IP for containers which had previously accessed that IP.

Fixes #1405.