### PR TITLE
Use explicit index into operations slice in cancelOpsFor()

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -131,9 +131,9 @@ func (alloc *Allocator) cancelOpsFor(ops *[]operation, ident string) bool {
 			found = true
 			op.Cancel()
 			*ops = append((*ops)[:i], (*ops)[i+1:]...)
-			continue
+		} else {
+			i++
 		}
-		i++
 	}
 	return found
 }

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -126,12 +126,14 @@ func (alloc *Allocator) cancelOps(ops *[]operation) {
 // if we found any.
 func (alloc *Allocator) cancelOpsFor(ops *[]operation, ident string) bool {
 	var found bool
-	for i, op := range *ops {
-		if op.ForContainer(ident) {
+	for i := 0; i < len(*ops); {
+		if op := (*ops)[i]; op.ForContainer(ident) {
 			found = true
 			op.Cancel()
 			*ops = append((*ops)[:i], (*ops)[i+1:]...)
+			continue
 		}
+		i++
 	}
 	return found
 }


### PR DESCRIPTION
to avoid mis-indexing when more than one op is removed

Fixes #1424