### PR TITLE
Fast datapath

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -116,15 +116,11 @@ func main() {
 
 	if ifaceName != "" {
 		iface, err := weavenet.EnsureInterface(ifaceName)
-		if err != nil {
-			Log.Fatal(err)
-		}
+		checkFatal(err)
 
 		// bufsz flag is in MB
 		config.Bridge, err = weave.NewPcap(iface, bufSzMB*1024*1024)
-		if err != nil {
-			Log.Fatal(err)
-		}
+		checkFatal(err)
 	}
 
 	if routerName == "" {
@@ -135,15 +131,11 @@ func main() {
 	}
 
 	name, err := weave.PeerNameFromUserInput(routerName)
-	if err != nil {
-		Log.Fatal(err)
-	}
+	checkFatal(err)
 
 	if nickName == "" {
 		nickName, err = os.Hostname()
-		if err != nil {
-			Log.Fatal(err)
-		}
+		checkFatal(err)
 	}
 
 	if password == "" {
@@ -285,9 +277,8 @@ func (nopPacketLogging) LogForwardPacket(string, weave.ForwardPacketKey) {
 
 func parseAndCheckCIDR(cidrStr string) address.CIDR {
 	_, cidr, err := address.ParseCIDR(cidrStr)
-	if err != nil {
-		Log.Fatal(err)
-	}
+	checkFatal(err)
+
 	if cidr.Size() < ipam.MinSubnetSize {
 		Log.Fatalf("Allocation range smaller than minimum size %d: %s", ipam.MinSubnetSize, cidrStr)
 	}
@@ -344,5 +335,11 @@ func listenAndServeHTTP(httpAddr string, muxRouter *mux.Router) {
 	err = http.Serve(l, nil)
 	if err != nil {
 		Log.Fatal("Unable to create http server", err)
+	}
+}
+
+func checkFatal(e error) {
+	if e != nil {
+		Log.Fatal(e)
 	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -436,13 +436,15 @@ func (proxy *Proxy) getDNSDomain() (domain string) {
 	}
 
 	weaveContainer, err := proxy.client.InspectContainer("weave")
-	if err != nil ||
-		weaveContainer.NetworkSettings == nil ||
-		weaveContainer.NetworkSettings.IPAddress == "" {
-		return
+	var weaveIP string
+	if err == nil && weaveContainer.NetworkSettings != nil {
+		weaveIP = weaveContainer.NetworkSettings.IPAddress
+	}
+	if weaveIP == "" {
+		weaveIP = "127.0.0.1"
 	}
 
-	url := fmt.Sprintf("http://%s:%d/domain", weaveContainer.NetworkSettings.IPAddress, router.HTTPPort)
+	url := fmt.Sprintf("http://%s:%d/domain", weaveIP, router.HTTPPort)
 	resp, err := http.Get(url)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return

--- a/router/connection.go
+++ b/router/connection.go
@@ -255,6 +255,7 @@ func (conn *LocalConnection) makeFeatures() map[string]string {
 		"PeerNameFlavour": PeerNameFlavour,
 		"Name":            conn.local.Name.String(),
 		"NickName":        conn.local.NickName,
+		"ShortID":         fmt.Sprint(conn.local.ShortID),
 		"UID":             fmt.Sprint(conn.local.UID),
 		"ConnID":          fmt.Sprint(conn.uid),
 	}
@@ -276,7 +277,7 @@ func (features features) Get(key string) string {
 }
 
 func (conn *LocalConnection) parseFeatures(features features) (*Peer, error) {
-	if err := features.MustHave([]string{"PeerNameFlavour", "Name", "NickName", "UID", "ConnID"}); err != nil {
+	if err := features.MustHave([]string{"PeerNameFlavour", "Name", "NickName", "ShortID", "UID", "ConnID"}); err != nil {
 		return nil, err
 	}
 
@@ -292,6 +293,12 @@ func (conn *LocalConnection) parseFeatures(features features) (*Peer, error) {
 
 	nickName := features.Get("NickName")
 
+	shortID, err := strconv.ParseUint(features.Get("ShortID"), 10,
+		PeerShortIDBits)
+	if err != nil {
+		return nil, err
+	}
+
 	uid, err := ParsePeerUID(features.Get("UID"))
 	if err != nil {
 		return nil, err
@@ -303,7 +310,7 @@ func (conn *LocalConnection) parseFeatures(features features) (*Peer, error) {
 	}
 
 	conn.uid ^= remoteConnID
-	return NewPeer(name, nickName, uid, 0), nil
+	return NewPeer(name, nickName, uid, 0, PeerShortID(shortID)), nil
 }
 
 func (conn *LocalConnection) registerRemote(remote *Peer, acceptNewPeer bool) error {

--- a/router/consts.go
+++ b/router/consts.go
@@ -6,12 +6,16 @@ import (
 )
 
 const (
-	Port             = 6783
-	HTTPPort         = Port + 1
-	MaxUDPPacketSize = 65535
-	ChannelSize      = 16
-	TCPHeartbeat     = 30 * time.Second
-	GossipInterval   = 30 * time.Second
-	MaxDuration      = time.Duration(math.MaxInt64)
-	MaxTCPMsgSize    = 10 * 1024 * 1024
+	Port                = 6783
+	HTTPPort            = Port + 1
+	MaxUDPPacketSize    = 65535
+	ChannelSize         = 16
+	TCPHeartbeat        = 30 * time.Second
+	GossipInterval      = 30 * time.Second
+	MaxDuration         = time.Duration(math.MaxInt64)
+	MaxTCPMsgSize       = 10 * 1024 * 1024
+	FastHeartbeat       = 500 * time.Millisecond
+	SlowHeartbeat       = 10 * time.Second
+	MaxMissedHeartbeats = 6
+	HeartbeatTimeout    = MaxMissedHeartbeats * SlowHeartbeat
 )

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -1,0 +1,1115 @@
+package router
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/weaveworks/go-odp/odp"
+)
+
+// The virtual bridge accepts packets from ODP vports and the router
+// port (i.e. InjectPacket).  We need a map key to index those
+// possibilities:
+type bridgePortID struct {
+	vport  odp.VportID
+	router bool
+}
+
+// A bridgeSender sends out a packet from the virtual bridge
+type bridgeSender func(key PacketKey, lock *fastDatapathLock) FlowOp
+
+// A missHandler handles an ODP miss
+type missHandler func(fks odp.FlowKeys, lock *fastDatapathLock) FlowOp
+
+type FastDatapath struct {
+	dpname string
+
+	// The mtu from the datapath netdev (which should match the
+	// mtus on all the veths hooked up to the datapath).  We
+	// validate that we are able to support that mtu.
+	mtu int
+
+	// The lock guards the FastDatapath state, and also
+	// synchronizes use of the dpif
+	lock             sync.Mutex
+	dpif             *odp.Dpif
+	dp               odp.DatapathHandle
+	deleteFlowsCount uint64
+	missHandlers     map[odp.VportID]missHandler
+	localPeer        *Peer
+	peers            *Peers
+	overlayConsumer  OverlayConsumer
+
+	// Bridge state: How to send to the given bridge port
+	sendToPort map[bridgePortID]bridgeSender
+
+	// How to send to a given destination MAC
+	sendToMAC map[MAC]bridgeSender
+
+	// MACs seen on the bridge recently
+	seenMACs map[MAC]struct{}
+
+	// vxlan vports associated with the given UDP ports
+	vxlanVportIDs    map[int]odp.VportID
+	mainVxlanVportID odp.VportID
+
+	// A singleton pool for the occasions when we need to decode
+	// the packet.
+	dec *EthernetDecoder
+
+	// forwarders by remote peer
+	forwarders map[PeerName]*fastDatapathForwarder
+}
+
+type FastDatapathConfig struct {
+	DatapathName        string
+	Port                int
+	ExpireFlowsInterval time.Duration
+	ExpireMACsInterval  time.Duration
+}
+
+func NewFastDatapath(config FastDatapathConfig) (*FastDatapath, error) {
+	dpif, err := odp.NewDpif()
+	if err != nil {
+		return nil, err
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			dpif.Close()
+		}
+	}()
+
+	dp, err := dpif.LookupDatapath(config.DatapathName)
+	if err != nil {
+		return nil, err
+	}
+
+	iface, err := net.InterfaceByName(config.DatapathName)
+	if err != nil {
+		return nil, err
+	}
+
+	fastdp := &FastDatapath{
+		dpname:        config.DatapathName,
+		mtu:           iface.MTU,
+		dpif:          dpif,
+		dp:            dp,
+		missHandlers:  make(map[odp.VportID]missHandler),
+		sendToPort:    nil,
+		sendToMAC:     make(map[MAC]bridgeSender),
+		seenMACs:      make(map[MAC]struct{}),
+		vxlanVportIDs: make(map[int]odp.VportID),
+		forwarders:    make(map[PeerName]*fastDatapathForwarder),
+	}
+
+	if err := fastdp.deleteVxlanVports(); err != nil {
+		return nil, err
+	}
+
+	if err := fastdp.deleteFlows(); err != nil {
+		return nil, err
+	}
+
+	// We use the weave port number plus 1 for vxlan.  Hard-coding
+	// this relationship may seem dubious, but there is no moral
+	// difference between this and requiring that the sleeve UDP
+	// port number is the same as the TCP port number.  The hard
+	// part would be not adding weaver flags to allow the port
+	// numbers to be independent, but working out how to specify
+	// them on the connecting side.  So we can wait to find out if
+	// anyone wants that.
+	fastdp.mainVxlanVportID, err = fastdp.getVxlanVportID(config.Port + 1)
+	if err != nil {
+		return nil, err
+	}
+
+	// need to lock before we might receive events
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+
+	if _, err := dp.ConsumeMisses(fastdp); err != nil {
+		return nil, err
+	}
+
+	if _, err := dp.ConsumeVportEvents(fastdp); err != nil {
+		return nil, err
+	}
+
+	vports, err := dp.EnumerateVports()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vport := range vports {
+		fastdp.makeBridgeVport(vport)
+	}
+
+	success = true
+	go fastdp.run()
+	return fastdp, nil
+}
+
+func (fastdp *FastDatapath) Close() error {
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+	err := fastdp.dpif.Close()
+	fastdp.dpif = nil
+	return err
+}
+
+// While processing a packet, we can potentially acquire and drop the
+// FastDatapath lock many times (acquiring it to acceess FastDatapath
+// state, and invoke ODP operations; dropping it to invoke callbacks
+// that may re-enter the FastDatapath).  A fastDatapathLock
+// coordinates this process.
+type fastDatapathLock struct {
+	fastdp *FastDatapath
+	locked bool
+
+	// While the lock is dropped, deleteFlows could be called.  We
+	// need to detect when this happens and avoid creating flows,
+	// because they may be based on stale information.
+	deleteFlowsCount uint64
+}
+
+func (fastdp *FastDatapath) startLock() fastDatapathLock {
+	fastdp.lock.Lock()
+	return fastDatapathLock{
+		fastdp:           fastdp,
+		locked:           true,
+		deleteFlowsCount: fastdp.deleteFlowsCount,
+	}
+}
+
+func (lock *fastDatapathLock) unlock() {
+	if lock.locked {
+		lock.fastdp.lock.Unlock()
+		lock.locked = false
+	}
+}
+
+func (lock *fastDatapathLock) relock() {
+	if !lock.locked {
+		lock.fastdp.lock.Lock()
+		lock.locked = true
+	}
+}
+
+// Bridge bits
+
+type fastDatapathBridge struct {
+	*FastDatapath
+}
+
+func (fastdp *FastDatapath) Bridge() Bridge {
+	return fastDatapathBridge{fastdp}
+}
+
+func (fastdp fastDatapathBridge) String() string {
+	return fmt.Sprint(fastdp.dpname, " (via ODP)")
+}
+
+func (fastDatapathBridge) Stats() map[string]int {
+	return nil
+}
+
+var routerBridgePortID = bridgePortID{router: true}
+
+func (fastdp fastDatapathBridge) StartConsumingPackets(consumer BridgeConsumer) error {
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+
+	if fastdp.sendToPort[routerBridgePortID] != nil {
+		return fmt.Errorf("FastDatapath already has a BridgeConsumer")
+	}
+
+	// set up delivery to the weave router port on the bridge
+	fastdp.addSendToPort(routerBridgePortID,
+		func(key PacketKey, lock *fastDatapathLock) FlowOp {
+			// drop the FastDatapath lock in order to call
+			// the consumer
+			lock.unlock()
+			return consumer(key)
+		})
+	return nil
+}
+
+func (fastdp fastDatapathBridge) InjectPacket(key PacketKey) FlowOp {
+	lock := fastdp.startLock()
+	defer lock.unlock()
+	return fastdp.bridge(routerBridgePortID, key, &lock)
+}
+
+// Ethernet bridge implementation
+
+func (fastdp *FastDatapath) bridge(ingress bridgePortID,
+	key PacketKey, lock *fastDatapathLock) FlowOp {
+	lock.relock()
+	if fastdp.sendToMAC[key.SrcMAC] == nil {
+		// Learn the source MAC
+		fastdp.sendToMAC[key.SrcMAC] = fastdp.sendToPort[ingress]
+		fastdp.seenMACs[key.SrcMAC] = struct{}{}
+	}
+
+	// If we know about the destination MAC, deliver it to the
+	// associated port.
+	if sender := fastdp.sendToMAC[key.DstMAC]; sender != nil {
+		return NewMultiFlowOp(false, odpEthernetFlowKey(key),
+			sender(key, lock))
+	}
+
+	// Otherwise, it might be a real broadcast, or it might
+	// be for a MAC we don't know about yet.  Either way, we'll
+	// broadcast it.
+	mfop := NewMultiFlowOp(false)
+
+	if (key.DstMAC[0] & 1) == 0 {
+		// Not a real broadcast, so don't create a flow rule.
+		// If we did, we'd need to delete the flows every time
+		// we learned a new MAC address, or have a more
+		// complicated selective invalidation scheme.
+		mfop.Add(vetoFlowCreationFlowOp{})
+	} else {
+		// A real broadcast
+		mfop.Add(odpEthernetFlowKey(key))
+	}
+
+	// Send to all ports except the one it came in on. The
+	// sendToPort map is immutable, so it is safe to iterate over
+	// it even though the sender functions can drop the
+	// fastDatapathLock
+	for id, sender := range fastdp.sendToPort {
+		if id != ingress {
+			mfop.Add(sender(key, lock))
+		}
+	}
+
+	return mfop
+}
+
+// Overlay bits
+
+type fastDatapathOverlay struct {
+	*FastDatapath
+}
+
+func (fastdp *FastDatapath) Overlay() Overlay {
+	return fastDatapathOverlay{fastdp}
+}
+
+func (fastdp fastDatapathOverlay) InvalidateRoutes() {
+	log.Debug("InvalidateRoutes")
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+	checkWarn(fastdp.deleteFlows())
+}
+
+func (fastdp fastDatapathOverlay) InvalidateShortIDs() {
+	log.Debug("InvalidateShortIDs")
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+	checkWarn(fastdp.deleteFlows())
+}
+
+func (fastDatapathOverlay) AddFeaturesTo(features map[string]string) {
+	// Nothing needed.  Fast datapath support is indicated through
+	// OverlaySwitch.
+}
+
+func (fastdp fastDatapathOverlay) StartConsumingPackets(localPeer *Peer,
+	peers *Peers, consumer OverlayConsumer) error {
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+
+	if fastdp.overlayConsumer != nil {
+		return fmt.Errorf("FastDatapath already has an OverlayConsumer")
+	}
+
+	fastdp.localPeer = localPeer
+	fastdp.peers = peers
+	fastdp.overlayConsumer = consumer
+	return nil
+}
+
+func (fastdp *FastDatapath) getVxlanVportID(udpPort int) (odp.VportID, error) {
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+
+	if vxlanVportID, present := fastdp.vxlanVportIDs[udpPort]; present {
+		return vxlanVportID, nil
+	}
+
+	vxlanVportID, err := fastdp.dp.CreateVport(
+		odp.NewVxlanVportSpec(fmt.Sprintf("vxlan-%d", udpPort),
+			uint16(udpPort)))
+	if err != nil {
+		return 0, err
+	}
+
+	fastdp.vxlanVportIDs[udpPort] = vxlanVportID
+	fastdp.missHandlers[vxlanVportID] = func(fks odp.FlowKeys, lock *fastDatapathLock) FlowOp {
+		tunnel := fks[odp.OVS_KEY_ATTR_TUNNEL].(odp.TunnelFlowKey)
+		tunKey := tunnel.Key()
+
+		lock.relock()
+		consumer := fastdp.overlayConsumer
+		if consumer == nil {
+			return vetoFlowCreationFlowOp{}
+		}
+
+		srcPeer, dstPeer := fastdp.extractPeers(tunKey.TunnelId)
+		if srcPeer == nil || dstPeer == nil {
+			return vetoFlowCreationFlowOp{}
+		}
+
+		lock.unlock()
+		pk := flowKeysToPacketKey(fks)
+		var zeroMAC MAC
+		if pk.SrcMAC == zeroMAC && pk.DstMAC == zeroMAC {
+			return vxlanSpecialPacketFlowOp{fastdp, srcPeer,
+				&net.UDPAddr{
+					IP:   net.IP(tunKey.Ipv4Src[:]),
+					Port: udpPort,
+				},
+			}
+		}
+
+		key := ForwardPacketKey{
+			SrcPeer:   srcPeer,
+			DstPeer:   dstPeer,
+			PacketKey: pk,
+		}
+
+		var tunnelFlowKey odp.TunnelFlowKey
+		tunnelFlowKey.SetTunnelId(tunKey.TunnelId)
+		tunnelFlowKey.SetIpv4Src(tunKey.Ipv4Src)
+		tunnelFlowKey.SetIpv4Dst(tunKey.Ipv4Dst)
+
+		return NewMultiFlowOp(false, odpFlowKey(tunnelFlowKey),
+			consumer(key))
+	}
+
+	return vxlanVportID, nil
+}
+
+func (fastdp *FastDatapath) extractPeers(tunnelID [8]byte) (*Peer, *Peer) {
+	vni := binary.BigEndian.Uint64(tunnelID[:])
+	srcPeer := fastdp.peers.FetchByShortID(PeerShortID(vni & 0xfff))
+	dstPeer := fastdp.peers.FetchByShortID(PeerShortID((vni >> 12) & 0xfff))
+	return srcPeer, dstPeer
+}
+
+type vxlanSpecialPacketFlowOp struct {
+	fastdp  *FastDatapath
+	srcPeer *Peer
+	sender  *net.UDPAddr
+}
+
+func (op vxlanSpecialPacketFlowOp) Process(frame []byte, dec *EthernetDecoder,
+	broadcast bool) {
+	op.fastdp.lock.Lock()
+	fwd := op.fastdp.forwarders[op.srcPeer.Name]
+	op.fastdp.lock.Unlock()
+
+	if fwd != nil && dec.IsSpecial() {
+		fwd.handleVxlanSpecialPacket(frame, op.sender)
+	}
+}
+
+type fastDatapathForwarder struct {
+	fastdp         *FastDatapath
+	remotePeer     *Peer
+	localIP        [4]byte
+	sendControlMsg func(byte, []byte) error
+	connUID        uint64
+	vxlanVportID   odp.VportID
+
+	lock              sync.RWMutex
+	confirmed         bool
+	remoteAddr        *net.UDPAddr
+	heartbeatInterval time.Duration
+	heartbeatTimer    *time.Timer
+	heartbeatTimeout  *time.Timer
+	ackedHeartbeat    bool
+	stopChan          chan struct{}
+	stopped           bool
+
+	establishedChan chan struct{}
+	errorChan       chan error
+}
+
+func (fastdp fastDatapathOverlay) MakeForwarder(
+	params ForwarderParams) (OverlayForwarder, error) {
+	if params.Crypto != nil {
+		// No encryption suport in fastdp.  The weaver main.go
+		// is responsible for ensuring this doesn't happen.
+		log.Fatal("Attempt to use FastDatapath with encryption")
+	}
+
+	vxlanVportID := fastdp.mainVxlanVportID
+	remoteAddr := params.RemoteAddr
+	if remoteAddr != nil {
+		// The provided address contains the main weave port
+		// number to connect to.  We need to derive the vxlan
+		// port number from that.
+		vxlanRemoteAddr := *params.RemoteAddr
+		vxlanRemoteAddr.Port++
+		remoteAddr = &vxlanRemoteAddr
+
+		var err error
+		vxlanVportID, err = fastdp.getVxlanVportID(remoteAddr.Port)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	localIP, err := ipv4Bytes(params.LocalIP)
+	if err != nil {
+		return nil, err
+	}
+
+	fwd := &fastDatapathForwarder{
+		fastdp:         fastdp.FastDatapath,
+		remotePeer:     params.RemotePeer,
+		localIP:        localIP,
+		sendControlMsg: params.SendControlMessage,
+		connUID:        params.ConnUID,
+		vxlanVportID:   vxlanVportID,
+
+		remoteAddr:        remoteAddr,
+		heartbeatInterval: FastHeartbeat,
+		stopChan:          make(chan struct{}),
+
+		establishedChan: make(chan struct{}),
+		errorChan:       make(chan error, 1),
+	}
+
+	return fwd, err
+}
+
+func ipv4Bytes(ip net.IP) (res [4]byte, err error) {
+	ipv4 := ip.To4()
+	if ipv4 != nil {
+		copy(res[:], ipv4)
+	} else {
+		err = fmt.Errorf("IP address %s is not IPv4", ip)
+	}
+	return
+}
+
+func (fwd *fastDatapathForwarder) logPrefix() string {
+	return fmt.Sprintf("fastdp ->[%s|%s]: ", fwd.remoteAddr, fwd.remotePeer)
+}
+
+func (fwd *fastDatapathForwarder) Confirm() {
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+
+	if fwd.confirmed {
+		log.Fatal(fwd.logPrefix(), "already confirmed")
+	}
+
+	log.Debug(fwd.logPrefix(), "confirmed")
+	fwd.fastdp.addForwarder(fwd.remotePeer.Name, fwd)
+	fwd.confirmed = true
+
+	if fwd.remoteAddr != nil {
+		// have the goroutine send a heartbeat straight away
+		fwd.heartbeatTimer = time.NewTimer(0)
+	} else {
+		// we'll reset the timer when we learn the remote ip
+		fwd.heartbeatTimer = time.NewTimer(MaxDuration)
+	}
+
+	fwd.heartbeatTimeout = time.NewTimer(HeartbeatTimeout)
+	go fwd.doHeartbeats()
+}
+
+func (fwd *fastDatapathForwarder) EstablishedChannel() <-chan struct{} {
+	return fwd.establishedChan
+}
+
+func (fwd *fastDatapathForwarder) ErrorChannel() <-chan error {
+	return fwd.errorChan
+}
+
+func (fwd *fastDatapathForwarder) doHeartbeats() {
+	var err error
+
+	for err == nil {
+		select {
+		case <-fwd.heartbeatTimer.C:
+			if fwd.confirmed {
+				fwd.sendHeartbeat()
+			}
+			fwd.heartbeatTimer.Reset(fwd.heartbeatInterval)
+
+		case <-fwd.heartbeatTimeout.C:
+			err = fmt.Errorf("timed out waiting for vxlan heartbeat")
+
+		case <-fwd.stopChan:
+			return
+		}
+	}
+
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+	fwd.handleError(err)
+}
+
+// Handle an error which leads to notifying the listener and
+// termination of the forwarder
+func (fwd *fastDatapathForwarder) handleError(err error) {
+	if err == nil {
+		return
+	}
+
+	select {
+	case fwd.errorChan <- err:
+	default:
+	}
+
+	// stop the heartbeat goroutine
+	if !fwd.stopped {
+		fwd.stopped = true
+		close(fwd.stopChan)
+	}
+}
+
+func (fwd *fastDatapathForwarder) sendHeartbeat() {
+	fwd.lock.RLock()
+	log.Debug(fwd.logPrefix(), "sendHeartbeat")
+
+	// the heartbeat payload consists of the 64-bit connection uid
+	// followed by the 16-bit packet size.
+	buf := make([]byte, EthernetOverhead+fwd.fastdp.mtu)
+	binary.BigEndian.PutUint64(buf[EthernetOverhead:], fwd.connUID)
+	binary.BigEndian.PutUint16(buf[EthernetOverhead+8:], uint16(len(buf)))
+
+	dec := NewEthernetDecoder()
+	dec.DecodeLayers(buf)
+	pk := ForwardPacketKey{
+		PacketKey: dec.PacketKey(),
+		SrcPeer:   fwd.fastdp.localPeer,
+		DstPeer:   fwd.remotePeer,
+	}
+	fwd.lock.RUnlock()
+	fwd.Forward(pk).Process(buf, dec, false)
+}
+
+const (
+	FastDatapathHeartbeatAck = iota
+)
+
+func (fwd *fastDatapathForwarder) handleVxlanSpecialPacket(frame []byte,
+	sender *net.UDPAddr) {
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+
+	log.Debug(fwd.logPrefix(), "handleVxlanSpecialPacket")
+
+	// the only special packet type is a heartbeat
+	if len(frame) < EthernetOverhead+10 {
+		log.Warning(fwd.logPrefix(), "short vxlan special packet: ", len(frame), " bytes")
+		return
+	}
+
+	if binary.BigEndian.Uint64(frame[EthernetOverhead:]) != fwd.connUID ||
+		uint16(len(frame)) != binary.BigEndian.Uint16(frame[EthernetOverhead+8:]) {
+		return
+	}
+
+	if fwd.remoteAddr == nil {
+		fwd.remoteAddr = sender
+
+		if fwd.confirmed {
+			fwd.heartbeatTimer.Reset(0)
+		}
+	} else if !udpAddrsEqual(fwd.remoteAddr, sender) {
+		log.Info(fwd.logPrefix(),
+			"Peer IP address changed to ", sender)
+		fwd.remoteAddr = sender
+	}
+
+	if !fwd.ackedHeartbeat {
+		fwd.ackedHeartbeat = true
+		fwd.handleError(fwd.sendControlMsg(FastDatapathHeartbeatAck, nil))
+	}
+
+	// we can receive a heartbeat before Confirm() has set up
+	// heartbeatTimeout
+	if fwd.heartbeatTimeout != nil {
+		fwd.heartbeatTimeout.Reset(HeartbeatTimeout)
+	}
+}
+
+func (fwd *fastDatapathForwarder) ControlMessage(tag byte, msg []byte) {
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+
+	switch tag {
+	case FastDatapathHeartbeatAck:
+		fwd.handleHeartbeatAck()
+
+	default:
+		log.Info(fwd.logPrefix(),
+			"Ignoring unknown control message: ", tag)
+	}
+}
+
+func (fwd *fastDatapathForwarder) handleHeartbeatAck() {
+	log.Debug(fwd.logPrefix(), "handleHeartbeatAck")
+
+	if fwd.heartbeatInterval != SlowHeartbeat {
+		close(fwd.establishedChan)
+		fwd.heartbeatInterval = SlowHeartbeat
+		if fwd.heartbeatTimer != nil {
+			fwd.heartbeatTimer.Reset(fwd.heartbeatInterval)
+		}
+	}
+}
+
+func (fwd *fastDatapathForwarder) Forward(key ForwardPacketKey) FlowOp {
+	fwd.lock.RLock()
+	defer fwd.lock.RUnlock()
+
+	if fwd.remoteAddr == nil {
+		// Returning nil would discard the packet, but also
+		// result in a flow rule, which we would have to
+		// invalidate when we learn the remote IP.  So for
+		// now, just prevent flows.
+		return vetoFlowCreationFlowOp{}
+	}
+
+	remoteIP, err := ipv4Bytes(fwd.remoteAddr.IP)
+	if err != nil {
+		log.Error(err)
+		return nil
+	}
+
+	var sta odp.SetTunnelAction
+	sta.SetTunnelId(tunnelIDFor(key))
+	sta.SetIpv4Src(fwd.localIP)
+	sta.SetIpv4Dst(remoteIP)
+	sta.SetTos(0)
+	sta.SetTtl(64)
+	sta.SetDf(true)
+	sta.SetCsum(false)
+	return fwd.fastdp.odpActions(sta, odp.NewOutputAction(fwd.vxlanVportID))
+}
+
+func tunnelIDFor(key ForwardPacketKey) (tunnelID [8]byte) {
+	src := uint64(key.SrcPeer.ShortID)
+	dst := uint64(key.DstPeer.ShortID)
+	binary.BigEndian.PutUint64(tunnelID[:], src|dst<<12)
+	return
+}
+
+func (fwd *fastDatapathForwarder) Stop() {
+	// Might be nice to delete all the relevant flows here, but we
+	// can just let them expire.
+	fwd.fastdp.removeForwarder(fwd.remotePeer.Name, fwd)
+
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+	fwd.sendControlMsg = func(byte, []byte) error { return nil }
+
+	// stop the heartbeat goroutine
+	if !fwd.stopped {
+		fwd.stopped = true
+		close(fwd.stopChan)
+	}
+}
+
+func (fastdp *FastDatapath) addForwarder(peer PeerName,
+	fwd *fastDatapathForwarder) {
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+
+	// We shouldn't have two confirmed forwarders to the same
+	// remotePeer, due to the checks in LocalPeer AddConnection.
+	fastdp.forwarders[peer] = fwd
+}
+
+func (fastdp *FastDatapath) removeForwarder(peer PeerName,
+	fwd *fastDatapathForwarder) {
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+	if fastdp.forwarders[peer] == fwd {
+		delete(fastdp.forwarders, peer)
+	}
+}
+
+func (fastdp *FastDatapath) deleteFlows() error {
+	fastdp.deleteFlowsCount++
+
+	flows, err := fastdp.dp.EnumerateFlows()
+	if err != nil {
+		return err
+	}
+
+	for _, flow := range flows {
+		err = fastdp.dp.DeleteFlow(flow.FlowKeys)
+		if err != nil && !odp.IsNoSuchFlowError(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (fastdp *FastDatapath) deleteVxlanVports() error {
+	vports, err := fastdp.dp.EnumerateVports()
+	if err != nil {
+		return err
+	}
+
+	for _, vport := range vports {
+		if vport.Spec.TypeName() != "vxlan" {
+			continue
+		}
+
+		err = fastdp.dp.DeleteVport(vport.ID)
+		if err != nil && !odp.IsNoSuchVportError(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (fastdp *FastDatapath) run() {
+	expireMACsCh := time.Tick(10 * time.Minute)
+	expireFlowsCh := time.Tick(5 * time.Minute)
+
+	for {
+		select {
+		case <-expireMACsCh:
+			fastdp.expireMACs()
+
+		case <-expireFlowsCh:
+			fastdp.expireFlows()
+		}
+	}
+}
+
+func (fastdp *FastDatapath) expireMACs() {
+	lock := fastdp.startLock()
+	defer lock.unlock()
+
+	for mac := range fastdp.sendToMAC {
+		if _, present := fastdp.seenMACs[mac]; !present {
+			delete(fastdp.sendToMAC, mac)
+		}
+	}
+
+	fastdp.seenMACs = make(map[MAC]struct{})
+}
+
+func (fastdp *FastDatapath) expireFlows() {
+	lock := fastdp.startLock()
+	defer lock.unlock()
+
+	flows, err := fastdp.dp.EnumerateFlows()
+	if err != nil {
+		log.Warn(err)
+	}
+
+	for _, flow := range flows {
+		if flow.Used == 0 {
+			log.Debug("Expiring flow ", flow.FlowSpec)
+			err = fastdp.dp.DeleteFlow(flow.FlowKeys)
+		} else {
+			fastdp.touchFlow(flow.FlowKeys, &lock)
+			err = fastdp.dp.ClearFlow(flow.FlowSpec)
+		}
+
+		if err != nil && !odp.IsNoSuchFlowError(err) {
+			log.Warn(err)
+		}
+	}
+}
+
+// The router needs to know which flows are active in order to
+// maintain its MAC->peer table.  We do this by querying the router
+// without an actual packet being involved.  Maybe it's
+// worth devising a more unified approach in the future.
+func (fastdp *FastDatapath) touchFlow(fks odp.FlowKeys,
+	lock *fastDatapathLock) {
+	// All the flows we create should have an ingress key, but we
+	// check here just in case we encounter one from somewhere
+	// else.
+	ingressKey, present := fks[odp.OVS_KEY_ATTR_IN_PORT]
+	if present {
+		ingress := ingressKey.(odp.InPortFlowKey).VportID()
+		handler := fastdp.getMissHandler(ingress)
+		if handler != nil {
+			handler(fks, lock)
+			lock.relock()
+		}
+	}
+}
+
+func (fastdp *FastDatapath) Error(err error, stopped bool) {
+	if stopped {
+		log.Fatal("Error while listeniing on ODP datapath: ", err)
+	}
+
+	log.Error("Error while listening on ODP datapath: ", err)
+}
+
+func (fastdp *FastDatapath) Miss(packet []byte, fks odp.FlowKeys) error {
+	ingress := fks[odp.OVS_KEY_ATTR_IN_PORT].(odp.InPortFlowKey).VportID()
+	log.Debug("ODP miss ", fks, " on port ", ingress)
+
+	lock := fastdp.startLock()
+	defer lock.unlock()
+
+	handler := fastdp.getMissHandler(ingress)
+	if handler == nil {
+		return nil
+	}
+
+	// Always include the ingress vport in the flow key.  While
+	// this is not strictly necessary in some cases (e.g. for
+	// delivery to a local netdev based on the dest MAC),
+	// including the ingress in every flow makes things simpler
+	// in touchFlow.
+	mfop := NewMultiFlowOp(false, handler(fks, &lock),
+		odpFlowKey(odp.NewInPortFlowKey(ingress)))
+	fastdp.send(mfop, packet, &lock)
+	return nil
+}
+
+func (fastdp *FastDatapath) getMissHandler(ingress odp.VportID) missHandler {
+	handler := fastdp.missHandlers[ingress]
+	if handler == nil {
+		vport, err := fastdp.dp.LookupVport(ingress)
+		if err != nil {
+			log.Error(err)
+			return nil
+		}
+
+		fastdp.makeBridgeVport(vport)
+	}
+
+	return handler
+}
+
+func (fastdp *FastDatapath) VportCreated(dpid odp.DatapathID, vport odp.Vport) error {
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+
+	if _, present := fastdp.missHandlers[vport.ID]; !present {
+		fastdp.makeBridgeVport(vport)
+	}
+
+	return nil
+}
+
+func (fastdp *FastDatapath) VportDeleted(dpid odp.DatapathID, vport odp.Vport) error {
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+
+	// there might be flow rules that still refer to the id of
+	// this vport.  But we just allow them to expire.  Unless we
+	// want prompt migration of MAC addresses, that should be
+	// fine.
+	delete(fastdp.missHandlers, vport.ID)
+	fastdp.deleteSendToPort(bridgePortID{vport: vport.ID})
+	return nil
+}
+
+func (fastdp *FastDatapath) makeBridgeVport(vport odp.Vport) {
+	// Set up a bridge port for netdev and internal vports.  vxlan
+	// vports are handled separately, as they do not correspond to
+	// bridge ports (we set up the miss handler for them in
+	// getVxlanVportID).
+	typ := vport.Spec.TypeName()
+	if typ != "netdev" && typ != "internal" {
+		return
+	}
+
+	vportID := vport.ID
+
+	// Sending to the bridge port outputs on the vport:
+	fastdp.addSendToPort(bridgePortID{vport: vportID},
+		func(_ PacketKey, _ *fastDatapathLock) FlowOp {
+			return fastdp.odpActions(odp.NewOutputAction(vportID))
+		})
+
+	// Delete flows, in order to recalculate flows for broadcasts
+	// on the bridge.
+	checkWarn(fastdp.deleteFlows())
+
+	// Packets coming from the netdev are processed by the bridge
+	fastdp.missHandlers[vportID] = func(flowKeys odp.FlowKeys, lock *fastDatapathLock) FlowOp {
+		return fastdp.bridge(bridgePortID{vport: vportID},
+			flowKeysToPacketKey(flowKeys), lock)
+	}
+}
+
+func flowKeysToPacketKey(fks odp.FlowKeys) PacketKey {
+	eth := fks[odp.OVS_KEY_ATTR_ETHERNET].(odp.EthernetFlowKey).Key()
+	return PacketKey{SrcMAC: eth.EthSrc, DstMAC: eth.EthDst}
+}
+
+// The sendToPort map is read-only, so this method does the copy in
+// order to add an entry.
+func (fastdp *FastDatapath) addSendToPort(portID bridgePortID,
+	sender bridgeSender) {
+	sendToPort := map[bridgePortID]bridgeSender{portID: sender}
+	for id, sender := range fastdp.sendToPort {
+		sendToPort[id] = sender
+	}
+	fastdp.sendToPort = sendToPort
+}
+
+func (fastdp *FastDatapath) deleteSendToPort(portID bridgePortID) {
+	sendToPort := make(map[bridgePortID]bridgeSender)
+	for id, sender := range fastdp.sendToPort {
+		if id != portID {
+			sendToPort[id] = sender
+		}
+	}
+	fastdp.sendToPort = sendToPort
+}
+
+// Send a packet, creating a corresponding ODP flow rule if possible
+func (fastdp *FastDatapath) send(fops FlowOp, frame []byte,
+	lock *fastDatapathLock) {
+	// Gather the actions from actionFlowOps, execute any others
+	var dec *EthernetDecoder
+	flow := odp.NewFlowSpec()
+	createFlow := true
+
+	for _, xfop := range FlattenFlowOp(fops) {
+		switch fop := xfop.(type) {
+		case interface {
+			updateFlowSpec(*odp.FlowSpec)
+		}:
+			fop.updateFlowSpec(&flow)
+		case vetoFlowCreationFlowOp:
+			createFlow = false
+		default:
+			// A foreign FlowOp (e.g. a sleeve forwarding
+			// FlowOp), so send the packet through the
+			// FlowOp interface, decoding the packet
+			// lazily.
+			if dec == nil {
+				dec = fastdp.takeDecoder(lock)
+				dec.DecodeLayers(frame)
+
+				// If we are sending the packet
+				// through the FlowOp interface, we
+				// mustn't create a flow, as that
+				// could prevent the proper handling
+				// of similar packets in the future.
+				createFlow = false
+			}
+
+			if len(dec.decoded) != 0 {
+				lock.unlock()
+				fop.Process(frame, dec, false)
+			}
+		}
+	}
+
+	if dec != nil {
+		// put the decoder back
+		lock.relock()
+		fastdp.dec = dec
+	}
+
+	if len(flow.Actions) != 0 {
+		lock.relock()
+		checkWarn(fastdp.dp.Execute(frame, nil, flow.Actions))
+	}
+
+	if createFlow {
+		lock.relock()
+		// if the fastdp's deleteFlowsCount changed since we
+		// initially locked it, then we might have created a
+		// flow on the basis of stale information.  It's fine
+		// to handle one packet like that, but it would be bad
+		// to introduce a stale flow.
+		if lock.deleteFlowsCount == fastdp.deleteFlowsCount {
+			log.Debug("Creating ODP flow ", flow)
+			checkWarn(fastdp.dp.CreateFlow(flow))
+		}
+	}
+}
+
+// Get the EthernetDecoder from the singleton pool
+func (fastdp *FastDatapath) takeDecoder(lock *fastDatapathLock) *EthernetDecoder {
+	lock.relock()
+	dec := fastdp.dec
+	if dec == nil {
+		dec = NewEthernetDecoder()
+	} else {
+		fastdp.dec = nil
+	}
+	return dec
+}
+
+type odpActionsFlowOp struct {
+	fastdp  *FastDatapath
+	actions []odp.Action
+}
+
+func (fastdp *FastDatapath) odpActions(actions ...odp.Action) FlowOp {
+	return odpActionsFlowOp{
+		fastdp:  fastdp,
+		actions: actions,
+	}
+}
+
+func (fop odpActionsFlowOp) updateFlowSpec(flow *odp.FlowSpec) {
+	flow.AddActions(fop.actions)
+}
+
+func (fop odpActionsFlowOp) Process(frame []byte, dec *EthernetDecoder,
+	broadcast bool) {
+	fastdp := fop.fastdp
+	fastdp.lock.Lock()
+	defer fastdp.lock.Unlock()
+	checkWarn(fastdp.dp.Execute(frame, nil, fop.actions))
+}
+
+type nopFlowOp struct{}
+
+func (nopFlowOp) Process([]byte, *EthernetDecoder, bool) {
+	// A nopFlowOp just provides a hint about flow creation, it
+	// doesn't send anything
+}
+
+// A vetoFlowCreationFlowOp flags that no flow should be created
+type vetoFlowCreationFlowOp struct {
+	nopFlowOp
+}
+
+// A odpFlowKeyFlowOp adds a FlowKey to the resulting flow
+type odpFlowKeyFlowOp struct {
+	key odp.FlowKey
+	nopFlowOp
+}
+
+func odpFlowKey(key odp.FlowKey) FlowOp {
+	return odpFlowKeyFlowOp{key: key}
+}
+
+func (fop odpFlowKeyFlowOp) updateFlowSpec(flow *odp.FlowSpec) {
+	flow.AddKey(fop.key)
+}
+
+func odpEthernetFlowKey(key PacketKey) FlowOp {
+	fk := odp.NewEthernetFlowKey()
+	fk.SetEthSrc(key.SrcMAC)
+	fk.SetEthDst(key.DstMAC)
+	return odpFlowKeyFlowOp{key: fk}
+}

--- a/router/local_peer.go
+++ b/router/local_peer.go
@@ -160,7 +160,10 @@ func (peer *LocalPeer) handleAddConnection(conn Connection) error {
 		conn.Log("connection added (new peer)")
 		peer.router.SendAllGossipDown(conn)
 	}
+
+	peer.router.Routes.Recalculate()
 	peer.broadcastPeerUpdate(conn.Remote())
+
 	return nil
 }
 
@@ -174,6 +177,8 @@ func (peer *LocalPeer) handleConnectionEstablished(conn Connection) {
 	}
 	peer.connectionEstablished(conn)
 	conn.Log("connection fully established")
+
+	peer.router.Routes.Recalculate()
 	peer.broadcastPeerUpdate()
 }
 
@@ -193,14 +198,14 @@ func (peer *LocalPeer) handleDeleteConnection(conn Connection) {
 	// Must do garbage collection first to ensure we don't send out an
 	// update with unreachable peers (can cause looping)
 	peer.router.Peers.GarbageCollect()
+	peer.router.Routes.Recalculate()
 	peer.broadcastPeerUpdate()
 }
 
 // helpers
 
 func (peer *LocalPeer) broadcastPeerUpdate(peers ...*Peer) {
-	peer.router.Routes.Recalculate()
-	peer.router.TopologyGossip.GossipBroadcast(NewTopologyGossipData(peer.router.Peers, append(peers, peer.Peer)...))
+	peer.router.BroadcastTopologyUpdate(append(peers, peer.Peer))
 }
 
 func (peer *LocalPeer) checkConnectionLimit() error {

--- a/router/mocks_test.go
+++ b/router/mocks_test.go
@@ -70,7 +70,7 @@ func checkEqualConns(t *testing.T, ourName PeerName, got, wanted map[PeerName]Co
 // Get all the peers from a Peers in a slice
 func (peers *Peers) allPeers() []*Peer {
 	var res []*Peer
-	for _, peer := range peers.table {
+	for _, peer := range peers.byName {
 		res = append(res, peer)
 	}
 	return res

--- a/router/odp.go
+++ b/router/odp.go
@@ -1,0 +1,60 @@
+package router
+
+import (
+	"github.com/weaveworks/go-odp/odp"
+)
+
+// ODP admin functionality
+
+func CreateDatapath(dpname string) error {
+	dpif, err := odp.NewDpif()
+	if err != nil {
+		return err
+	}
+
+	defer dpif.Close()
+
+	_, err = dpif.CreateDatapath(dpname)
+	if err != nil && !odp.IsDatapathNameAlreadyExistsError(err) {
+		return err
+	}
+
+	return nil
+}
+
+func DeleteDatapath(dpname string) error {
+	dpif, err := odp.NewDpif()
+	if err != nil {
+		return err
+	}
+
+	defer dpif.Close()
+
+	dp, err := dpif.LookupDatapath(dpname)
+	if err != nil {
+		if odp.IsNoSuchDatapathError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return dp.Delete()
+}
+
+func AddDatapathInterface(dpname string, ifname string) error {
+	dpif, err := odp.NewDpif()
+	if err != nil {
+		return err
+	}
+
+	defer dpif.Close()
+
+	dp, err := dpif.LookupDatapath(dpname)
+	if err != nil {
+		return err
+	}
+
+	_, err = dp.CreateVport(odp.NewNetdevVportSpec(ifname))
+	return err
+}

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -15,6 +15,9 @@ type Overlay interface {
 	// The routes have changed, so any cached information should
 	// be discarded.
 	InvalidateRoutes()
+
+	// A mapping of a short id to a peer has changed
+	InvalidateShortIDs()
 }
 
 type ForwarderParams struct {
@@ -88,6 +91,9 @@ func (NullOverlay) MakeForwarder(ForwarderParams) (OverlayForwarder, error) {
 }
 
 func (NullOverlay) InvalidateRoutes() {
+}
+
+func (NullOverlay) InvalidateShortIDs() {
 }
 
 func (NullOverlay) SetListener(OverlayForwarderListener) {

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -18,6 +18,9 @@ type Overlay interface {
 
 	// A mapping of a short id to a peer has changed
 	InvalidateShortIDs()
+
+	// Enhance a features map with overlay-related features
+	AddFeaturesTo(map[string]string)
 }
 
 type ForwarderParams struct {
@@ -41,7 +44,10 @@ type ForwarderParams struct {
 
 	// Function to send a control message to the counterpart
 	// forwarder.
-	SendControlMessage func(tag ProtocolTag, msg []byte) error
+	SendControlMessage func(tag byte, msg []byte) error
+
+	// Features passed at connection initiation
+	Features map[string]string
 }
 
 // When a consumer is called, the decoder will already have been used
@@ -81,7 +87,7 @@ type OverlayForwarder interface {
 	// Handle a message from the peer.  'tag' exists for
 	// compatibility, and should always be
 	// ProtocolOverlayControlMessage for non-sleeve overlays.
-	ControlMessage(tag ProtocolTag, msg []byte)
+	ControlMessage(tag byte, msg []byte)
 }
 
 type NullOverlay struct{}
@@ -111,6 +117,9 @@ func (NullOverlay) ErrorChannel() <-chan error {
 	return nil
 }
 
+func (NullOverlay) AddFeaturesTo(map[string]string) {
+}
+
 func (NullOverlay) Forward(ForwardPacketKey) FlowOp {
 	return nil
 }
@@ -118,5 +127,5 @@ func (NullOverlay) Forward(ForwardPacketKey) FlowOp {
 func (NullOverlay) Stop() {
 }
 
-func (NullOverlay) ControlMessage(ProtocolTag, []byte) {
+func (NullOverlay) ControlMessage(byte, []byte) {
 }

--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -1,0 +1,395 @@
+package router
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// OverlaySwitch selects which overlay to use, from a set of
+// subsidiary overlays.  First, it passes a list of supported overlays
+// in the connection features, and uses that to determine which
+// overlays are in common.  Then it tries those common overlays, and
+// uses the best one that seems to be working.
+
+type OverlaySwitch struct {
+	overlays     map[string]Overlay
+	overlayNames []string
+}
+
+func NewOverlaySwitch() *OverlaySwitch {
+	return &OverlaySwitch{overlays: make(map[string]Overlay)}
+}
+
+func (osw *OverlaySwitch) Add(name string, overlay Overlay) {
+	// check for repeated names
+	if _, present := osw.overlays[name]; present {
+		log.Fatal("OverlaySwitch: repeated overlay name")
+	}
+
+	osw.overlays[name] = overlay
+	osw.overlayNames = append(osw.overlayNames, name)
+}
+
+func (osw *OverlaySwitch) AddFeaturesTo(features map[string]string) {
+	features["Overlays"] = strings.Join(osw.overlayNames, " ")
+}
+
+func (osw *OverlaySwitch) InvalidateRoutes() {
+	for _, overlay := range osw.overlays {
+		overlay.InvalidateRoutes()
+	}
+}
+
+func (osw *OverlaySwitch) InvalidateShortIDs() {
+	for _, overlay := range osw.overlays {
+		overlay.InvalidateShortIDs()
+	}
+}
+
+func (osw *OverlaySwitch) StartConsumingPackets(localPeer *Peer, peers *Peers,
+	consumer OverlayConsumer) error {
+	for _, overlay := range osw.overlays {
+		if err := overlay.StartConsumingPackets(localPeer, peers,
+			consumer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type namedOverlay struct {
+	Overlay
+	name string
+}
+
+// Find the common set of overlays supported by both sides, with the
+// ordering being the same on both sides too.
+func (osw *OverlaySwitch) commonOverlays(params ForwarderParams) ([]namedOverlay, error) {
+	var peerOverlays []string
+	if overlaysFeature, present := params.Features["Overlays"]; present {
+		peerOverlays = strings.Split(overlaysFeature, " ")
+	}
+
+	common := make(map[string]Overlay)
+	for _, name := range peerOverlays {
+		if overlay := osw.overlays[name]; overlay != nil {
+			common[name] = overlay
+		}
+	}
+
+	if len(common) == 0 {
+		return nil, fmt.Errorf("no overlays in common with peer")
+	}
+
+	// we order them according to the connecting node
+	ordering := osw.overlayNames
+	if params.RemoteAddr == nil {
+		// we are the connectee
+		ordering = peerOverlays
+	}
+
+	res := make([]namedOverlay, 0, len(common))
+	for _, name := range ordering {
+		overlay := common[name]
+		if overlay != nil {
+			res = append(res, namedOverlay{overlay, name})
+		}
+	}
+
+	// we use bytes to represent forwarder indices in control
+	// messages, so just in case:
+	if len(res) > 256 {
+		res = res[:256]
+	}
+
+	return res, nil
+}
+
+type overlaySwitchForwarder struct {
+	remotePeer *Peer
+
+	lock sync.Mutex
+
+	// the forwarder to send on
+	best OverlayForwarder
+
+	// the subsidiary forwarders
+	forwarders []subForwarder
+
+	// closed to tell the main goroutine to stop
+	stopChan chan<- struct{}
+
+	alreadyEstablished bool
+	establishedChan    chan struct{}
+	errorChan          chan error
+}
+
+// A subsidiary forwarder
+type subForwarder struct {
+	fwd         OverlayForwarder
+	overlayName string
+
+	// Has the forwarder signalled that it is established?
+	established bool
+
+	// closed to tell the forwarder monitor goroutine to stop
+	stopChan chan<- struct{}
+}
+
+// An event from a subsidiary forwarder
+type subForwarderEvent struct {
+	// the index of the forwarder
+	index int
+
+	// is this an "established" event?
+	established bool
+
+	// is this an error event?
+	err error
+}
+
+func (osw *OverlaySwitch) MakeForwarder(
+	params ForwarderParams) (OverlayForwarder, error) {
+	overlays, err := osw.commonOverlays(params)
+	if err != nil {
+		return nil, err
+	}
+
+	// channel to carry events from the subforwarder monitors to
+	// the main goroutine
+	eventsChan := make(chan subForwarderEvent)
+
+	// channel to stop the main goroutine
+	stopChan := make(chan struct{})
+
+	fwd := &overlaySwitchForwarder{
+		remotePeer: params.RemotePeer,
+
+		forwarders: make([]subForwarder, len(overlays)),
+		stopChan:   stopChan,
+
+		establishedChan: make(chan struct{}),
+		errorChan:       make(chan error, 1),
+	}
+
+	origSendControlMessage := params.SendControlMessage
+	for i, overlay := range overlays {
+		// Prefix control messages to indicate the relevant forwarder
+		index := i
+		params.SendControlMessage = func(tag byte, msg []byte) error {
+			xmsg := make([]byte, len(msg)+2)
+			xmsg[0] = byte(index)
+			xmsg[1] = tag
+			copy(xmsg[2:], msg)
+			return origSendControlMessage(ProtocolOverlayControlMsg,
+				xmsg)
+		}
+
+		subFwd, err := overlay.MakeForwarder(params)
+		if err != nil {
+			fwd.stopFrom(0)
+			return nil, err
+		}
+
+		subStopChan := make(chan struct{})
+		go monitorForwarder(i, eventsChan, subStopChan, subFwd)
+		fwd.forwarders[i] = subForwarder{
+			fwd:         subFwd,
+			overlayName: overlay.name,
+			stopChan:    subStopChan,
+		}
+	}
+
+	fwd.chooseBest()
+	go fwd.run(eventsChan, stopChan)
+	return fwd, nil
+}
+
+func monitorForwarder(index int, eventsChan chan<- subForwarderEvent,
+	stopChan <-chan struct{}, fwd OverlayForwarder) {
+	establishedChan := fwd.EstablishedChannel()
+loop:
+	for {
+		e := subForwarderEvent{index: index}
+
+		select {
+		case <-establishedChan:
+			e.established = true
+			establishedChan = nil
+
+		case err := <-fwd.ErrorChannel():
+			e.err = err
+
+		case <-stopChan:
+			break loop
+		}
+
+		select {
+		case eventsChan <- e:
+		case <-stopChan:
+			break loop
+		}
+
+		if e.err != nil {
+			break loop
+		}
+	}
+
+	fwd.Stop()
+}
+
+func (fwd *overlaySwitchForwarder) run(eventsChan <-chan subForwarderEvent,
+	stopChan <-chan struct{}) {
+loop:
+	for {
+		select {
+		case <-stopChan:
+			break loop
+
+		case e := <-eventsChan:
+			switch {
+			case e.established:
+				fwd.established(e.index)
+			case e.err != nil:
+				fwd.error(e.index, e.err)
+			}
+		}
+	}
+
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+	fwd.stopFrom(0)
+}
+
+func (fwd *overlaySwitchForwarder) established(index int) {
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+
+	fwd.forwarders[index].established = true
+
+	// less preferred forwarders are no longer needed
+	fwd.stopFrom(index + 1)
+
+	if !fwd.alreadyEstablished {
+		fwd.alreadyEstablished = true
+		close(fwd.establishedChan)
+	}
+
+	fwd.chooseBest()
+}
+
+func (fwd *overlaySwitchForwarder) logPrefix() string {
+	return fmt.Sprintf("overlay_switch ->[%s] ", fwd.remotePeer)
+}
+
+func (fwd *overlaySwitchForwarder) error(index int, err error) {
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+
+	log.Info(fwd.logPrefix(), fwd.forwarders[index].overlayName, " ", err)
+	fwd.forwarders[index].fwd = nil
+	fwd.chooseBest()
+}
+
+func (fwd *overlaySwitchForwarder) stopFrom(index int) {
+	for index < len(fwd.forwarders) {
+		subFwd := &fwd.forwarders[index]
+		if subFwd.fwd != nil {
+			subFwd.fwd = nil
+			close(subFwd.stopChan)
+		}
+		index++
+	}
+}
+
+func (fwd *overlaySwitchForwarder) chooseBest() {
+	// the most preferred established forwarder is the best
+	// otherwise, the most preferred working forwarder is the best
+	var bestEstablished, bestWorking *subForwarder
+
+	for i := range fwd.forwarders {
+		subFwd := &fwd.forwarders[i]
+		if subFwd.fwd == nil {
+			continue
+		}
+
+		if bestWorking == nil {
+			bestWorking = subFwd
+		}
+
+		if bestEstablished == nil && subFwd.established {
+			bestEstablished = subFwd
+		}
+	}
+
+	best := bestEstablished
+	if best == nil {
+		if bestWorking == nil {
+			select {
+			case fwd.errorChan <- fmt.Errorf("no working forwarders to %s", fwd.remotePeer):
+			default:
+			}
+
+			return
+		}
+
+		best = bestWorking
+	}
+
+	if fwd.best != best.fwd {
+		fwd.best = best.fwd
+		log.Info(fwd.logPrefix(), "using ", best.overlayName)
+	}
+}
+
+func (fwd *overlaySwitchForwarder) Confirm() {
+	var forwarders []OverlayForwarder
+
+	fwd.lock.Lock()
+	for _, subFwd := range fwd.forwarders {
+		if subFwd.fwd != nil {
+			forwarders = append(forwarders, subFwd.fwd)
+		}
+	}
+	fwd.lock.Unlock()
+
+	for _, subFwd := range forwarders {
+		subFwd.Confirm()
+	}
+}
+
+func (fwd *overlaySwitchForwarder) Forward(pk ForwardPacketKey) FlowOp {
+	fwd.lock.Lock()
+	best := fwd.best
+	fwd.lock.Unlock()
+
+	if best == nil {
+		return nil
+	}
+
+	return best.Forward(pk)
+}
+
+func (fwd *overlaySwitchForwarder) EstablishedChannel() <-chan struct{} {
+	return fwd.establishedChan
+}
+
+func (fwd *overlaySwitchForwarder) ErrorChannel() <-chan error {
+	return fwd.errorChan
+}
+
+func (fwd *overlaySwitchForwarder) Stop() {
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+	fwd.stopFrom(0)
+}
+
+func (fwd *overlaySwitchForwarder) ControlMessage(tag byte, msg []byte) {
+	fwd.lock.Lock()
+	subFwd := fwd.forwarders[msg[0]].fwd
+	fwd.lock.Unlock()
+	if subFwd != nil {
+		subFwd.ControlMessage(msg[1], msg[2:])
+	}
+}

--- a/router/peer.go
+++ b/router/peer.go
@@ -17,11 +17,24 @@ func ParsePeerUID(s string) (PeerUID, error) {
 	return PeerUID(uid), err
 }
 
+// Short IDs exist for the sake of fast datapath.  They are 12 bits,
+// randomly assigned, but we detect and recover from collisions.  This
+// does limit us to 4096 peers, but that should be sufficient for a
+// while.
+type PeerShortID uint16
+
+const PeerShortIDBits = 12
+
+func randomPeerShortID() PeerShortID {
+	return PeerShortID(randUint16() & (1<<PeerShortIDBits - 1))
+}
+
 type PeerSummary struct {
 	NameByte []byte
 	NickName string
 	UID      PeerUID
 	Version  uint64
+	ShortID  PeerShortID
 }
 
 type Peer struct {
@@ -41,12 +54,13 @@ func NewPeerFromSummary(summary PeerSummary) *Peer {
 	}
 }
 
-func NewPeer(name PeerName, nickName string, uid PeerUID, version uint64) *Peer {
+func NewPeer(name PeerName, nickName string, uid PeerUID, version uint64, shortID PeerShortID) *Peer {
 	return NewPeerFromSummary(PeerSummary{
 		NameByte: name.Bin(),
 		NickName: nickName,
 		UID:      uid,
 		Version:  version,
+		ShortID:  shortID,
 	})
 }
 

--- a/router/peers.go
+++ b/router/peers.go
@@ -130,13 +130,19 @@ func (peers *Peers) ApplyUpdate(update []byte) (PeerNameSet, PeerNameSet, error)
 	for _, peer := range decodedUpdate {
 		updateNames[peer.Name] = void
 	}
-	return updateNames, setFromPeersMap(newUpdate), nil
+
+	return updateNames, newUpdate, nil
 }
 
 func (peers *Peers) Names() PeerNameSet {
 	peers.RLock()
 	defer peers.RUnlock()
-	return setFromPeersMap(peers.table)
+
+	names := make(PeerNameSet)
+	for name := range peers.table {
+		names[name] = void
+	}
+	return names
 }
 
 func (peers *Peers) EncodePeers(names PeerNameSet) []byte {
@@ -176,14 +182,6 @@ func (peers *Peers) garbageCollect() []*Peer {
 		}
 	}
 	return removed
-}
-
-func setFromPeersMap(peers map[PeerName]*Peer) PeerNameSet {
-	names := make(PeerNameSet)
-	for name := range peers {
-		names[name] = void
-	}
-	return names
 }
 
 func (peers *Peers) decodeUpdate(update []byte) (newPeers map[PeerName]*Peer, decodedUpdate []*Peer, decodedConns [][]ConnectionSummary, err error) {
@@ -231,8 +229,8 @@ func (peers *Peers) decodeUpdate(update []byte) (newPeers map[PeerName]*Peer, de
 	return
 }
 
-func (peers *Peers) applyUpdate(decodedUpdate []*Peer, decodedConns [][]ConnectionSummary) map[PeerName]*Peer {
-	newUpdate := make(map[PeerName]*Peer)
+func (peers *Peers) applyUpdate(decodedUpdate []*Peer, decodedConns [][]ConnectionSummary) PeerNameSet {
+	newUpdate := make(PeerNameSet)
 	for idx, newPeer := range decodedUpdate {
 		connSummaries := decodedConns[idx]
 		name := newPeer.Name
@@ -257,7 +255,7 @@ func (peers *Peers) applyUpdate(decodedUpdate []*Peer, decodedConns [][]Connecti
 		// the router.Peers, so there can be no race here.
 		peer.Version = newPeer.Version
 		peer.connections = makeConnsMap(peer, connSummaries, peers.table)
-		newUpdate[name] = peer
+		newUpdate[name] = void
 	}
 	return newUpdate
 }

--- a/router/peers.go
+++ b/router/peers.go
@@ -32,7 +32,9 @@ type ConnectionSummary struct {
 }
 
 func NewPeers(ourself *LocalPeer) *Peers {
-	return &Peers{ourself: ourself, table: make(map[PeerName]*Peer)}
+	peers := &Peers{ourself: ourself, table: make(map[PeerName]*Peer)}
+	peers.FetchWithDefault(ourself.Peer)
+	return peers
 }
 
 func (peers *Peers) OnGC(callback func(*Peer)) {

--- a/router/peers_test.go
+++ b/router/peers_test.go
@@ -20,7 +20,6 @@ import (
 func newNode(name PeerName) (*Peer, *Peers) {
 	peer := NewLocalPeer(name, "", nil)
 	peers := NewPeers(peer)
-	peers.FetchWithDefault(peer.Peer)
 	return peer.Peer, peers
 }
 

--- a/router/peers_test.go
+++ b/router/peers_test.go
@@ -71,6 +71,13 @@ func TestPeersEncoding(t *testing.T) {
 	}
 }
 
+func garbageCollect(peers *Peers) []*Peer {
+	var removed []*Peer
+	peers.OnGC(func(peer *Peer) { removed = append(removed, peer) })
+	peers.GarbageCollect()
+	return removed
+}
+
 func TestPeersGarbageCollection(t *testing.T) {
 	const (
 		peer1NameString = "01:00:00:01:00:00"
@@ -97,17 +104,17 @@ func TestPeersGarbageCollection(t *testing.T) {
 	ps2.AddTestRemoteConnection(p3, p1)
 
 	// Every peer is referenced, so nothing should be dropped
-	require.Empty(t, ps1.GarbageCollect(), "peers removed")
-	require.Empty(t, ps2.GarbageCollect(), "peers removed")
-	require.Empty(t, ps3.GarbageCollect(), "peers removed")
+	require.Empty(t, garbageCollect(ps1), "peers removed")
+	require.Empty(t, garbageCollect(ps2), "peers removed")
+	require.Empty(t, garbageCollect(ps3), "peers removed")
 
 	// Drop the connection from 2 to 3, and 3 isn't garbage-collected
 	// because 1 has a connection to 3
 	ps2.DeleteTestConnection(p3)
-	require.Empty(t, ps2.GarbageCollect(), "peers removed")
+	require.Empty(t, garbageCollect(ps2), "peers removed")
 
 	// Drop the connection from 1 to 3, and 3 will get removed by
 	// garbage-collection
 	ps1.DeleteTestConnection(p3)
-	checkPeerArray(t, ps1.GarbageCollect(), p3)
+	checkPeerArray(t, garbageCollect(ps1), p3)
 }

--- a/router/protocol.go
+++ b/router/protocol.go
@@ -328,7 +328,7 @@ func (res *ProtocolIntroResults) setupCrypto(params ProtocolIntroParams, remoteP
 type ProtocolTag byte
 
 const (
-	ProtocolHeartbeat ProtocolTag = iota
+	ProtocolHeartbeat = iota
 	ProtocolConnectionEstablished
 	ProtocolFragmentationReceived
 	ProtocolPMTUVerified

--- a/router/router.go
+++ b/router/router.go
@@ -73,7 +73,6 @@ func NewRouter(config Config, name PeerName, nickName string) *Router {
 	router.Macs = NewMacCache(macMaxAge, onMacExpiry)
 	router.Peers = NewPeers(router.Ourself)
 	router.Peers.OnGC(onPeerGC)
-	router.Peers.FetchWithDefault(router.Ourself.Peer)
 	router.Routes = NewRoutes(router.Ourself, router.Peers, router.Overlay.InvalidateRoutes)
 	router.ConnectionMaker = NewConnectionMaker(router.Ourself, router.Peers, router.Port, router.PeerDiscovery)
 	router.TopologyGossip = router.NewGossip("topology", router)

--- a/router/router.go
+++ b/router/router.go
@@ -260,12 +260,16 @@ type TopologyGossipData struct {
 	update PeerNameSet
 }
 
-func NewTopologyGossipData(peers *Peers, update ...*Peer) *TopologyGossipData {
+func (router *Router) BroadcastTopologyUpdate(update []*Peer) {
 	names := make(PeerNameSet)
 	for _, p := range update {
 		names[p.Name] = void
 	}
-	return &TopologyGossipData{peers: peers, update: names}
+
+	router.TopologyGossip.GossipBroadcast(&TopologyGossipData{
+		peers:  router.Peers,
+		update: names,
+	})
 }
 
 func (d *TopologyGossipData) Merge(other GossipData) {

--- a/router/routes.go
+++ b/router/routes.go
@@ -200,7 +200,7 @@ func (routes *Routes) calculateUnicast(establishedAndSymmetric bool) unicastRout
 // where <= is the subset relationship on keys of the returned map.
 func (routes *Routes) calculateBroadcast(establishedAndSymmetric bool) broadcastRoutes {
 	broadcast := make(broadcastRoutes)
-	for _, peer := range routes.peers.table {
+	for _, peer := range routes.peers.byName {
 		hops := []PeerName{}
 		if found, reached := peer.Routes(routes.ourself.Peer, establishedAndSymmetric); found {
 			routes.ourself.ForEachConnectedPeer(establishedAndSymmetric, reached,

--- a/router/routes.go
+++ b/router/routes.go
@@ -65,21 +65,13 @@ func (routes *Routes) UnicastAll(name PeerName) (PeerName, bool) {
 func (routes *Routes) Broadcast(name PeerName) []PeerName {
 	routes.RLock()
 	defer routes.RUnlock()
-	hops, found := routes.broadcast[name]
-	if !found {
-		return []PeerName{}
-	}
-	return hops
+	return routes.broadcast[name]
 }
 
 func (routes *Routes) BroadcastAll(name PeerName) []PeerName {
 	routes.RLock()
 	defer routes.RUnlock()
-	hops, found := routes.broadcastAll[name]
-	if !found {
-		return []PeerName{}
-	}
-	return hops
+	return routes.broadcastAll[name]
 }
 
 // Choose min(log2(n_peers), n_neighbouring_peers) neighbours, with a

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -45,18 +45,14 @@ import (
 // sleeveForwarder.mtu                     <-------------------------->
 
 const (
-	EthernetOverhead    = 14
-	UDPOverhead         = 28 // 20 bytes for IPv4, 8 bytes for UDP
-	DefaultMTU          = 65535
-	FragTestSize        = 60001
-	PMTUDiscoverySize   = 60000
-	FastHeartbeat       = 500 * time.Millisecond
-	SlowHeartbeat       = 10 * time.Second
-	FragTestInterval    = 5 * time.Minute
-	MTUVerifyAttempts   = 8
-	MTUVerifyTimeout    = 10 * time.Millisecond // doubled with each attempt
-	MaxMissedHeartbeats = 6
-	HeartbeatTimeout    = MaxMissedHeartbeats * SlowHeartbeat
+	EthernetOverhead  = 14
+	UDPOverhead       = 28 // 20 bytes for IPv4, 8 bytes for UDP
+	DefaultMTU        = 65535
+	FragTestSize      = 60001
+	PMTUDiscoverySize = 60000
+	FragTestInterval  = 5 * time.Minute
+	MTUVerifyAttempts = 8
+	MTUVerifyTimeout  = 10 * time.Millisecond // doubled with each attempt
 )
 
 type SleeveOverlay struct {

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -129,6 +129,10 @@ func (*SleeveOverlay) InvalidateRoutes() {
 	// no cached information, so nothing to do
 }
 
+func (*SleeveOverlay) InvalidateShortIDs() {
+	// no cached information, so nothing to do
+}
+
 func (sleeve *SleeveOverlay) lookupForwarder(peer PeerName) *sleeveForwarder {
 	sleeve.lock.Lock()
 	defer sleeve.lock.Unlock()

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -399,7 +399,7 @@ func (sleeve *SleeveOverlay) MakeForwarder(params ForwarderParams) (OverlayForwa
 }
 
 func (fwd *sleeveForwarder) logPrefixFor(sender *net.UDPAddr) string {
-	return fmt.Sprintf("->[%s|%s]: ", sender, fwd.remotePeer)
+	return fmt.Sprintf("sleeve ->[%s|%s]: ", sender, fwd.remotePeer)
 }
 
 func (fwd *sleeveForwarder) logPrefix() string {

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -133,6 +133,10 @@ func (*SleeveOverlay) InvalidateShortIDs() {
 	// no cached information, so nothing to do
 }
 
+func (*SleeveOverlay) AddFeaturesTo(map[string]string) {
+	// No features to be provided, to facilitate compatibility
+}
+
 func (sleeve *SleeveOverlay) lookupForwarder(peer PeerName) *sleeveForwarder {
 	sleeve.lock.Lock()
 	defer sleeve.lock.Unlock()
@@ -281,7 +285,7 @@ type sleeveForwarder struct {
 	sleeve         *SleeveOverlay
 	remotePeer     *Peer
 	remotePeerBin  []byte
-	sendControlMsg func(ProtocolTag, []byte) error
+	sendControlMsg func(byte, []byte) error
 	connUID        uint64
 
 	// Channels to communicate with the aggregator goroutine
@@ -342,7 +346,7 @@ type specialFrame struct {
 
 // A control message
 type controlMessage struct {
-	tag ProtocolTag
+	tag byte
 	msg []byte
 }
 
@@ -586,7 +590,7 @@ func frameTooBig(frame []byte, mtu int) bool {
 	return len(frame) > mtu+EthernetOverhead
 }
 
-func (fwd *sleeveForwarder) ControlMessage(tag ProtocolTag, msg []byte) {
+func (fwd *sleeveForwarder) ControlMessage(tag byte, msg []byte) {
 	select {
 	case fwd.controlMsgChan <- controlMessage{tag, msg}:
 	case <-fwd.finishedChan:

--- a/router/utils.go
+++ b/router/utils.go
@@ -3,6 +3,7 @@ package router
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/gob"
 	"fmt"
 	"net"
@@ -62,15 +63,19 @@ func Concat(elems ...[]byte) []byte {
 	return res
 }
 
-func randUint64() (r uint64) {
-	buf := make([]byte, 8)
+func randBytes(n int) []byte {
+	buf := make([]byte, n)
 	_, err := rand.Read(buf)
 	checkFatal(err)
-	for _, v := range buf {
-		r <<= 8
-		r |= uint64(v)
-	}
-	return
+	return buf
+}
+
+func randUint64() (r uint64) {
+	return binary.LittleEndian.Uint64(randBytes(8))
+}
+
+func randUint16() (r uint16) {
+	return binary.LittleEndian.Uint16(randBytes(2))
 }
 
 func GobEncode(items ...interface{}) []byte {

--- a/test/190_no_fastdp_2_test.sh
+++ b/test/190_no_fastdp_2_test.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+. ./config.sh
+
+C1=10.2.1.46
+C2=10.2.1.47
+
+start_suite "WEAVE_NO_FASTDP operation"
+
+WEAVE_NO_FASTDP=1 weave_on $HOST1 launch
+WEAVE_NO_FASTDP=1 weave_on $HOST2 launch $HOST1
+
+start_container $HOST1 $C1/24 --name=c1
+start_container $HOST2 $C2/24 --name=c2
+
+# Without fastdp, ethwe should have an MTU of 65535
+assert_raises "exec_on $HOST1 c1 sh -c 'ip link show ethwe | grep \ mtu\ 65535\ >/dev/null'"
+
+# Pump some data over a TCP socket between the containers.  This
+# should cause PMTU discovery on the overlay network, and hence
+# exercise the sleeve code to generate an ICMP frag-needed.
+assert_raises "exec_on $HOST1 c1 sh -c 'nc -l -p 5555 >/tmp/foo'" &
+sleep 5
+assert_raises "exec_on $HOST2 c2 sh -c 'dd if=/dev/zero bs=10k count=1 | nc $C1 5555'"
+assert_raises "exec_on $HOST1 c1 sh -c 'test \$(stat -c %s /tmp/foo) -eq 10240'"
+
+end_suite

--- a/weave
+++ b/weave
@@ -107,6 +107,8 @@ exec_remote() {
         -e WEAVE_PASSWORD \
         -e WEAVE_PORT \
         -e WEAVE_CONTAINER_NAME \
+        -e WEAVE_MTU \
+        -e WEAVE_NO_FASTDP \
         -e DOCKER_BRIDGE \
         -e DOCKER_CLIENT_HOST="$DOCKER_CLIENT_HOST" \
         -e DOCKER_CLIENT_TLS_VERIFY="$DOCKER_CLIENT_TLS_VERIFY" \
@@ -263,7 +265,8 @@ DOCKER_BRIDGE=${DOCKER_BRIDGE:-docker0}
 CONTAINER_NAME=${WEAVE_CONTAINER_NAME:-weave}
 BRIDGE=weave
 CONTAINER_IFNAME=ethwe
-MTU=65535
+# ROUTER_HOSTNETNS_IFNAME is only used for fastdp with encryption
+ROUTER_HOSTNETNS_IFNAME=weave2
 PORT=${WEAVE_PORT:-6783}
 HTTP_PORT=6784
 PROXY_PORT=12375
@@ -366,33 +369,57 @@ random_mac() {
 ######################################################################
 
 create_bridge() {
+    BRIDGE_TYPE=
+
     if [ ! -d /sys/class/net/$BRIDGE ] ; then
-        ip link add name $BRIDGE type bridge
-        # Set a random MAC address on the bridge.  Current Linux
-        # kernels already do this when creating a bridge, but there
-        # are rumours it was not always so.
-        ip link set dev $BRIDGE address $(random_mac)
-        # Attempting to set the bridge MTU to a high value directly
-        # fails. Bridges take the lowest MTU of their interfaces. So
-        # instead we create a temporary interface with the desired
-        # MTU, attach that to the bridge, and then remove it again.
-        ip link add name v${CONTAINER_IFNAME}du mtu $MTU type dummy
-        ip link set dev v${CONTAINER_IFNAME}du master $BRIDGE
-        ip link del dev v${CONTAINER_IFNAME}du
-        # Drop traffic from Docker bridge to Weave; it can break subnet isolation
+        if [ -n "$WEAVE_NO_FASTDP" ] ; then
+            BRIDGE_TYPE=bridge
+        elif docker run --rm --privileged --net=host $IMAGE $COVERAGE_ARGS --create-datapath --datapath=$BRIDGE ; then
+            BRIDGE_TYPE=fastdp
+        elif [ $? = 17 ] ; then
+            # Exit status of 17 means the kernel doesn't have ODP
+            BRIDGE_TYPE=bridge
+        else
+            return 1
+        fi
+
+        init_bridge_$BRIDGE_TYPE
+
+        # Drop traffic from Docker bridge to Weave; it can break
+        # subnet isolation
         if [ "$DOCKER_BRIDGE" != "$BRIDGE" ] ; then
             # Note using -I to insert ahead of Docker's bridge rules
             run_iptables -t filter -I FORWARD -i $DOCKER_BRIDGE -o $BRIDGE -j DROP
         fi
+
         # Work around the situation where there are no rules allowing traffic
         # across our bridge. E.g. ufw
         add_iptables_rule filter FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT
+
         # create a chain for masquerading
         run_iptables -t nat -N WEAVE >/dev/null 2>&1 || true
         add_iptables_rule nat POSTROUTING -j WEAVE
+    else
+        # Detect whether fast datapath is in use on
+        # $BRIDGE. Unfortunately there's no simple way to positively
+        # check whether $BRIDGE is a ODP netdev, so we have to check
+        # whether it is a bridge instead.
+        if [ -d /sys/class/net/$BRIDGE/bridge ] ; then
+            BRIDGE_TYPE=bridge
+        else
+            BRIDGE_TYPE=fastdp
+        fi
+
+        # WEAVE_MTU may have been specified when the bridge was
+        # created (perhaps implicitly with WEAVE_NO_FASTDP).  So take
+        # the MTU from the bridge unless it is explicitly specified
+        # for this invocation.
+        MTU=${WEAVE_MTU:-$(cat /sys/class/net/$BRIDGE/mtu)}
     fi
 
-    [ "$1" != "--without-ethtool" ] && ethtool -K $BRIDGE tx off >/dev/null
+    if [ "$1" != "--without-ethtool" ] ; then
+        ethtool_tx_off_$BRIDGE_TYPE $BRIDGE
+    fi
 
     ip link set dev $BRIDGE up
 
@@ -401,11 +428,58 @@ create_bridge() {
     configure_arp_cache $BRIDGE
 }
 
+init_bridge_fastdp () {
+    # GCE has the lowest underlay network MTU we're likely to encounter on
+    # a local network, at 1460 bytes.  To get the overlay MTU from that we
+    # subtract 20 bytes for the outer IPv4 header, 8 bytes for the outer
+    # UDP header, 8 bytes for the vxlan header, and 14 bytes for the inner
+    # ethernet header.
+    MTU=${WEAVE_MTU:-1410}
+
+    # create_bridge already created the datapath netdev
+    ip link set dev $BRIDGE mtu $MTU
+}
+
+init_bridge_bridge () {
+    MTU=${WEAVE_MTU:-65535}
+
+    ip link add name $BRIDGE type bridge
+
+    # Set a random MAC address on the bridge.  Current Linux
+    # kernels already do this when creating a bridge, but there
+    # are rumours it was not always so.
+    ip link set dev $BRIDGE address $(random_mac)
+
+    # Attempting to set the bridge MTU to a high value directly
+    # fails. Bridges take the lowest MTU of their interfaces. So
+    # instead we create a temporary interface with the desired
+    # MTU, attach that to the bridge, and then remove it again.
+    ip link add name v${CONTAINER_IFNAME}du mtu $MTU type dummy
+    ip link set dev v${CONTAINER_IFNAME}du master $BRIDGE
+    ip link del dev v${CONTAINER_IFNAME}du
+}
+
+ethtool_tx_off_fastdp () {
+    true
+}
+
+ethtool_tx_off_bridge () {
+    ethtool -K $1 tx off >/dev/null
+}
+
 destroy_bridge() {
-    [ -d /sys/class/net/$BRIDGE ] && ip link del dev $BRIDGE
+    if [ -d /sys/class/net/$BRIDGE ] ; then
+        if [ -d /sys/class/net/$BRIDGE/bridge ] ; then
+            ip link del dev $BRIDGE
+        else
+            docker run --rm --privileged --net=host $IMAGE $COVERAGE_ARGS --delete-datapath --datapath=$BRIDGE
+        fi
+    fi
+
     if [ "$DOCKER_BRIDGE" != "$BRIDGE" ] ; then
         run_iptables -t filter -D FORWARD -i $DOCKER_BRIDGE -o $BRIDGE -j DROP 2>/dev/null || true
     fi
+
     run_iptables -t filter -D FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT 2>/dev/null || true
     run_iptables -t nat -F WEAVE >/dev/null 2>&1 || true
     run_iptables -t nat -D POSTROUTING -j WEAVE >/dev/null 2>&1 || true
@@ -474,17 +548,11 @@ netnsenter() {
     nsenter --net=$PROCFS/$CONTAINER_PID/ns/net "$@"
 }
 
+# connect_container_to_bridge <container inteface name>
 connect_container_to_bridge() {
-    if [ -h "$PROCFS/$CONTAINER_PID/ns/net" -a -h "/proc/$$/ns/net" -a "$(readlink $PROCFS/$CONTAINER_PID/ns/net)" = "$(readlink /proc/$$/ns/net)" ] ; then
-        echo "Container is running in the host network namespace, and therefore cannot be" >&2
-        echo "connected to weave. Perhaps the container was started with --net=host." >&2
-        return 1
-    fi
     ip link add name $LOCAL_IFNAME mtu $MTU type veth peer name $GUEST_IFNAME mtu $MTU || return 1
 
-    if ! ethtool -K $GUEST_IFNAME tx off >/dev/null ||
-        ! ip link set $LOCAL_IFNAME master $BRIDGE ||
-        ! ip link set $LOCAL_IFNAME up ||
+    if ! ethtool_tx_off_$BRIDGE_TYPE $GUEST_IFNAME ||
         ! ip link set $GUEST_IFNAME netns $PROCFS/$CONTAINER_PID/ns/net ; then
         # failed before we assigned the veth to the container's
         # namespace
@@ -492,10 +560,28 @@ connect_container_to_bridge() {
         return 1
     fi
 
-    if ! netnsenter ip link set $GUEST_IFNAME name $CONTAINER_IFNAME ||
-       ! configure_arp_cache $CONTAINER_IFNAME "netnsenter" ; then
+    # Versions of the 'ip' command differ in whether they create a
+    # veth pair in the 'up' or 'down' state.  Furthermore, moving one
+    # end into a netns normally sets them to 'down'.  But, moving an
+    # end into the default netns is a null operation, so they stay up,
+    # which leads to errors later on.  So to get a consistent result,
+    # we have to be explicit in setting them 'up' or 'down' as
+    # necessary.
+    if ! netnsenter ip link set $GUEST_IFNAME down ||
+       ! netnsenter ip link set $GUEST_IFNAME name $1 up ||
+       ! ip link set $LOCAL_IFNAME up ||
+       ! add_iface_$BRIDGE_TYPE $LOCAL_IFNAME ||
+       ! configure_arp_cache $1 "netnsenter" ; then
         return 1
     fi
+}
+
+add_iface_fastdp () {
+    docker run --rm --privileged --net=host $IMAGE $COVERAGE_ARGS --datapath=$BRIDGE --add-datapath-iface=$1
+}
+
+add_iface_bridge () {
+    ip link set $1 master $BRIDGE
 }
 
 ask_version() {
@@ -507,23 +593,65 @@ ask_version() {
     [ -n "$DOCKERIMAGE" ] && docker run --rm -e WEAVE_CIDR=none $3 $DOCKERIMAGE $COVERAGE_ARGS --version
 }
 
+router_opts_fastdp () {
+    if [ -z "$WEAVE_PASSWORD" ] ; then
+        echo "--datapath $BRIDGE"
+    else
+        # When using encryption, we still do bridging on the ODP
+        # datapath, because you can 'weave launch' without encryption
+        # and then later restart the router with encryption, or vice
+        # versa.  Encryption disables the use of the fastdp Overlay,
+        # but the router could still use the fastdp Bridge to receive
+        # packets.  However, pcap has better performance when sniffing
+        # every packet.  So we pass --iface to use the pcap Bridge.
+        #
+        # Why don't we simply pass "--iface $BRIDGE".  We could,
+        # except for the fact that NetworkManager likes to down the
+        # odp $BRIDGE netdev (at least under ubuntu), and you can only
+        # use pcap on an interface that is up.  We avoid that by use
+        # pcap via a veth pair (NetworkManager leaves them alone).
+        # Having a netdev in the host netns called "ethwe" might
+        # surprise people, so it is called $ROUTER_HOSTNETNS_IFNAME
+        # instead.
+        echo "--datapath $BRIDGE --iface $ROUTER_HOSTNETNS_IFNAME"
+    fi
+}
+
+router_opts_bridge () {
+    echo "--iface $CONTAINER_IFNAME"
+}
+
 ######################################################################
 # functions invoked through with_container_netns
 ######################################################################
 
-launch() {
+setup_router_iface_fastdp() {
+    if [ -n "$WEAVE_PASSWORD" ] ; then
+        # See router_opts_fastdp
+        connect_container_to_bridge $ROUTER_HOSTNETNS_IFNAME &&
+            ip link set $ROUTER_HOSTNETNS_IFNAME up
+    fi
+}
+
+setup_router_iface_bridge() {
     if ! netnsenter ip link show eth0 >/dev/null ; then
         echo "Perhaps you are running the docker daemon with container networking disabled (-b=none)." >&2
         return 1
     fi
-    connect_container_to_bridge &&
+    connect_container_to_bridge $CONTAINER_IFNAME &&
         netnsenter ethtool -K eth0 tx off >/dev/null &&
         netnsenter ip link set $CONTAINER_IFNAME up
 }
 
 attach() {
+    if [ -h "$PROCFS/$CONTAINER_PID/ns/net" -a -h "/proc/$$/ns/net" -a "$(readlink $PROCFS/$CONTAINER_PID/ns/net)" = "$(readlink /proc/$$/ns/net)" ] ; then
+        echo "Container is running in the host network namespace, and therefore cannot be" >&2
+        echo "connected to weave. Perhaps the container was started with --net=host." >&2
+        return 1
+    fi
+
     if ! netnsenter ip link show $CONTAINER_IFNAME >/dev/null 2>&1 ; then
-        connect_container_to_bridge || return 1
+        connect_container_to_bridge $CONTAINER_IFNAME || return 1
     fi
 
     NEW_ADDRS=
@@ -645,8 +773,8 @@ container_ip() {
     fi
     case "$status" in
         "true ")
-            echo "$1 container has no IP address; is Docker networking enabled?" >&2
-            return 1
+            #echo "$1 container has no IP address; is Docker networking enabled?" >&2
+            CONTAINER_IP=127.0.0.1
             ;;
         true*)
             CONTAINER_IP="${status#true }"
@@ -1127,10 +1255,17 @@ launch_router() {
         shift 1
     fi
     CONTAINER_PORT=$PORT
-    ARGS=""
+    ARGS=
     IPRANGE=
     IPRANGE_SPECIFIED=
+
+    # DNS_PORT_MAPPING is only used if the router runs in a container
+    # netns.  DNS_ROUTER_OPTS is only used if the router runs in the
+    # host netns.
     DNS_PORT_MAPPING="-p $DOCKER_BRIDGE_IP:53:53/udp -p $DOCKER_BRIDGE_IP:53:53/tcp"
+    DNS_ROUTER_OPTS="--dns-listen-address $DOCKER_BRIDGE_IP:53"
+    NO_DNS_OPT=
+
     while [ $# -gt 0 ] ; do
         case "$1" in
             -password|--password)
@@ -1163,6 +1298,8 @@ launch_router() {
                 ;;
             --no-dns)
                 DNS_PORT_MAPPING=
+                DNS_ROUTER_OPTS=
+                NO_DNS_OPT="--no-dns"
                 ARGS="$ARGS $1"
                 ;;
             *)
@@ -1185,16 +1322,28 @@ launch_router() {
                 echo "Unless this is deliberate, you must pick another range and set it on all hosts." >&2
         fi
     fi
+
+    if [ "$BRIDGE_TYPE" = fastdp ] ; then
+        NETHOST_OPT="--net=host"
+    fi
+
     # Set WEAVE_DOCKER_ARGS in the environment in order to supply
     # additional parameters, such as resource limits, to docker
     # when launching the weave container.
     ROUTER_CONTAINER=$(docker run --privileged -d --name=$CONTAINER_NAME \
-        -p $PORT:$CONTAINER_PORT/tcp -p $PORT:$CONTAINER_PORT/udp $DNS_PORT_MAPPING \
         -v /var/run/docker.sock:/var/run/docker.sock \
+        -p $PORT:$CONTAINER_PORT/tcp -p $PORT:$CONTAINER_PORT/udp \
+        ${NETHOST_OPT:-$DNS_PORT_MAPPING} \
         -e WEAVE_PASSWORD \
         -e WEAVE_CIDR=none \
-        $WEAVE_DOCKER_ARGS $IMAGE $COVERAGE_ARGS --iface $CONTAINER_IFNAME --port $CONTAINER_PORT --name "$PEERNAME" --nickname "$(hostname)" --ipalloc-range "$IPRANGE" --dns-effective-listen-address "$DOCKER_BRIDGE_IP" --docker-api "unix:///var/run/docker.sock" "$@")
-    with_container_netns_or_die $ROUTER_CONTAINER launch
+        $WEAVE_DOCKER_ARGS $IMAGE $COVERAGE_ARGS \
+        --port $CONTAINER_PORT --name "$PEERNAME" --nickname "$(hostname)" \
+        $(router_opts_$BRIDGE_TYPE) \
+        --ipalloc-range "$IPRANGE" \
+        --dns-effective-listen-address $DOCKER_BRIDGE_IP \
+        ${NETHOST_OPT:+$DNS_ROUTER_OPTS} $NO_DNS_OPT \
+        --docker-api "unix:///var/run/docker.sock" "$@")
+    with_container_netns_or_die $ROUTER_CONTAINER setup_router_iface_$BRIDGE_TYPE
     err_msg=$(death_msg $CONTAINER_NAME)
     container_ip $CONTAINER_NAME "$err_msg" "$err_msg" || return 1
     wait_for_status $CONTAINER_NAME http_call $CONTAINER_IP:$HTTP_PORT
@@ -1202,7 +1351,7 @@ launch_router() {
         # Tell the newly-started weave IP allocator about existing weave IPs
         with_container_addresses ipam_reclaim weave:expose $(docker ps -q --no-trunc)
     fi
-    if [ -n "$DNS_PORT_MAPPING" ] ; then
+    if [ -z "$NO_DNS_OPT" ] ; then
         # Tell the newly-started weaveDNS about existing weave IPs
         for CONTAINER in $(docker ps -q --no-trunc) ; do
             if CONTAINER_IPS=$(with_container_netns $CONTAINER container_weave_addrs 2>&1 | sed -n -e 's/inet \([^/]*\)\/\(.*\)/\1/p') ; then

--- a/weave
+++ b/weave
@@ -1381,6 +1381,8 @@ launch_proxy() {
         -e PROCFS=/hostproc \
         -e WEAVE_CIDR=none \
         -e DOCKER_BRIDGE \
+        -e WEAVE_DEBUG \
+        -e COVERAGE \
         --entrypoint=/home/weave/weaveproxy \
         $WEAVEPROXY_DOCKER_ARGS $EXEC_IMAGE $COVERAGE_ARGS $PROXY_ARGS)
     wait_for_status $PROXY_CONTAINER_NAME http_call_unix $PROXY_CONTAINER_NAME status.sock


### PR DESCRIPTION
Smoke tests pass (modulo the one that is broken on master), so I think this is fit for a review pass.

Things still to do:

* The `weave` script changes are still a bit grotty.  But...
* I think there needs to be a "disable it all" option to weave, which disables fastdp, `--net=host`, and the MTU change.
* I haven't modified architecture.txt. To be honest, most of the contents are more like implementation notes that belong as comments in the code.  If the fast datapath code requires additional notes of that nature, I'd be happy to add them as comments. A high-level overview of fast datapath would be a good thing, but I think I'll need to re-write the whole of architecture.txt to match.
* 1.1 compatibility support.  That will be a separate issue.  Short ids is the tricky part here.
* I need to check out a kernel oops I saw when testing with ubuntu 12.04 a few days ago.