### PR TITLE
Remove 'defer' line that can never execute

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -148,7 +148,6 @@ func (router *Router) listenTCP(localPort int) {
 	ln, err := net.ListenTCP("tcp4", localAddr)
 	checkFatal(err)
 	go func() {
-		defer ln.Close()
 		for {
 			tcpConn, err := ln.AcceptTCP()
 			if err != nil {


### PR DESCRIPTION
The loop entered just after this line has no `break` or `return` statements, so the function never exits.

(barring `panic`, and we do not use `recover`)