### PR TITLE
Update for docker/machine PR #1729

### DIFF
--- a/test/tls/generate_certs.go
+++ b/test/tls/generate_certs.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/docker/machine/utils"
+	"github.com/docker/machine/libmachine/cert"
 )
 
 const (
@@ -28,7 +28,7 @@ func main() {
 			log.Fatalf("The CA key already exists.  Please remove it or specify a different key/cert.")
 		}
 
-		if err := utils.GenerateCACertificate(caCertPath, caKeyPath, org, bits); err != nil {
+		if err := cert.GenerateCACertificate(caCertPath, caKeyPath, org, bits); err != nil {
 			log.Printf("Error generating CA certificate: %s", err)
 		}
 	}
@@ -41,7 +41,7 @@ func main() {
 			log.Fatalf("The client key already exists.  Please remove it or specify a different key/cert.")
 		}
 
-		err = utils.GenerateCert(
+		err = cert.GenerateCert(
 			[]string{""},
 			clientCertPath,
 			clientKeyPath,
@@ -64,7 +64,7 @@ func main() {
 
 		if _, err := os.Stat(serverCertPath); os.IsNotExist(err) {
 			log.Printf("Creating server certificate: %s", serverCertPath)
-			err = utils.GenerateCert(
+			err = cert.GenerateCert(
 				[]string{ip},
 				serverCertPath,
 				serverKeyPath,


### PR DESCRIPTION
https://github.com/docker/machine/pull/1729

Broke:

```
package github.com/weaveworks/weave/...
	imports github.com/weaveworks/weave/common
	imports github.com/weaveworks/weave/common/docker
	imports github.com/weaveworks/weave/common/mflagext
	imports github.com/docker/docker/pkg/mflag
	imports github.com/docker/docker/pkg/homedir
	imports github.com/weaveworks/weave/ipam
	imports github.com/andybalholm/go-bit
	imports github.com/google/gopacket
	imports github.com/google/gopacket/layers
	imports github.com/google/gopacket/pcap
	imports github.com/gorilla/mux
	imports github.com/gorilla/context
	imports golang.org/x/crypto/nacl/box
	imports github.com/weaveworks/weave/nameserver
	imports github.com/weaveworks/weave/net
	imports github.com/vishvananda/netlink
	imports github.com/weaveworks/weave/prog/weaver
	imports github.com/weaveworks/weave/test/tls
	imports github.com/docker/machine/utils
	imports github.com/docker/machine/utils
	imports github.com/docker/machine/utils: cannot find package "github.com/docker/machine/utils" in any of:
	/usr/local/go/src/github.com/docker/machine/utils (from $GOROOT)
	/home/ubuntu/src/github.com/docker/machine/utils (from $GOPATH)
	/home/ubuntu/.go_workspace/src/github.com/docker/machine/utils
```