### PR TITLE
[proxy] unmount /var/run after boot, so the kernel can GC veth pairs

### DIFF
--- a/test/690_proxy_autoconfig_test.sh
+++ b/test/690_proxy_autoconfig_test.sh
@@ -28,8 +28,8 @@ assert_raises "DOCKER_CLIENT_ARGS='--tls' weave_on $HOST1 launch-proxy" 1
 assert_raises "DOCKER_CERT_PATH='./tls' DOCKER_TLS_VERIFY=1 weave_on $HOST1 launch-proxy" 1
 
 # Booting it with a specific -H overrides defaults
-weave_on $HOST1 launch-proxy -H unix:///var/run/weave2.sock
-assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave2.sock ps"
+weave_on $HOST1 launch-proxy -H tcp://0.0.0.0:12345
+assert_raises "run_on $HOST1 sudo docker -H tcp://$HOST1:12345 ps"
 assert_raises "proxy docker_on $HOST1 ps" 1
 weave_on $HOST1 stop-proxy
 

--- a/weave
+++ b/weave
@@ -96,7 +96,7 @@ usage() {
 
 exec_remote() {
     docker $DOCKER_CLIENT_ARGS run --rm --privileged --net=host \
-        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /var/run:/var/run \
         -v /proc:/hostproc \
         -e PROCFS=/hostproc \
         -e DOCKERHUB_USER="$DOCKERHUB_USER" \
@@ -1041,7 +1041,7 @@ proxy_args() {
     if [ -z "$PROXY_HOST" ] ; then
       case "$DOCKER_CLIENT_HOST" in
         ""|unix://*)
-          PROXY_HOST="unix:///var/run/weave.sock"
+          PROXY_HOST="unix:///var/run/weave/weave.sock"
           ;;
         *)
           PROXY_HOST="tcp://0.0.0.0:12375"
@@ -1203,7 +1203,8 @@ launch_proxy() {
     PROXY_CONTAINER=$(docker run --privileged -d --name=$PROXY_CONTAINER_NAME --net=host \
         $PROXY_VOLUMES \
         -v "$CONTAINERS_PATH":"$CONTAINERS_PATH" \
-        -v /var/run:/var/run \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /var/run/weave:/var/run/weave \
         -v /proc:/hostproc \
         -e PROCFS=/hostproc \
         -e WEAVE_CIDR=none \
@@ -1211,6 +1212,8 @@ launch_proxy() {
         --entrypoint=/home/weave/weaveproxy \
         $WEAVEPROXY_DOCKER_ARGS $EXEC_IMAGE $COVERAGE_ARGS $PROXY_ARGS)
     wait_for_log $PROXY_CONTAINER_NAME "proxy listening"
+    # backward compatibility
+    ln -sf -T /var/run/weave/weave.sock /var/run/weave.sock
 }
 
 ##########################################################################################


### PR DESCRIPTION
Change default unix listener to `unix:///var/run/weave/weave.sock`, and always make a symlink from `/var/run/weave.sock` to `/var/run/weave/weave/sock`

Fixes #1455. Pretty ugly hack, but...

Not sure if there's a good way to test this which represents something a user would do/care about, but when I've broken it 690 has failed, so...