### PR TITLE
Output the docker logs when docker-py fails

### DIFF
--- a/test/600_proxy_docker_py.sh
+++ b/test/600_proxy_docker_py.sh
@@ -36,6 +36,9 @@ docker_py_test() {
         assert_raises "true"
     else
         assert_raises "false"
+        echo "\n-----[begin docker logs]-----" 2>&1
+        run_on $HOST1 "/bin/sh -c 'sudo grep docker /var/log/syslog | tail -n 20'" 2>&1
+        echo "-----[end docker logs]-----" 2>&1
     fi
 
     end_suite


### PR DESCRIPTION
We could also try logging into one of the test boxes and running the test repeatedly there, then grabbing logs.

To help catch https://circleci.com/gh/weaveworks/weave/3037

@tomwilkie and/or @rade, please review.