### PR TITLE
Remove /var/run mount from exec_remote. Proxy uses /var/run/weave/weave.sock

### DIFF
--- a/site/proxy.md
+++ b/site/proxy.md
@@ -38,7 +38,7 @@ modify the default behaviour you will have to use the latter.
 
 By default, the proxy decides where to listen based on how the
 launching client connects to docker. If the launching client connected
-over a unix socket, the proxy will listen on /var/run/weave.sock. If
+over a unix socket, the proxy will listen on /var/run/weave/weave.sock. If
 the launching client connected over TCP, the proxy will listen on port
 12375, on all network interfaces. This can be adjusted with the `-H`
 argument, e.g.

--- a/test/690_proxy_autoconfig_test.sh
+++ b/test/690_proxy_autoconfig_test.sh
@@ -6,19 +6,19 @@ start_suite "Boot the proxy should only listen on client's interface"
 
 # Booting it over unix socket listens on unix socket
 run_on $HOST1 COVERAGE=$COVERAGE sudo -E weave launch-proxy
-assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave.sock ps"
+assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave/weave.sock ps"
 assert_raises "proxy docker_on $HOST1 ps" 1
 weave_on $HOST1 stop-proxy
 
 # Booting it over tcp listens on tcp
 weave_on $HOST1 launch-proxy
-assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave.sock ps" 1
+assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave/weave.sock ps" 1
 assert_raises "proxy docker_on $HOST1 ps"
 weave_on $HOST1 stop-proxy
 
 # Booting it over tcp (no prefix) listens on tcp
 DOCKER_CLIENT_ARGS="-H $HOST1:$DOCKER_PORT" $WEAVE launch-proxy
-assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave.sock ps" 1
+assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave/weave.sock ps" 1
 assert_raises "proxy docker_on $HOST1 ps"
 weave_on $HOST1 stop-proxy
 

--- a/weave
+++ b/weave
@@ -96,7 +96,7 @@ usage() {
 
 exec_remote() {
     docker $DOCKER_CLIENT_ARGS run --rm --privileged --net=host \
-        -v /var/run:/var/run \
+        -v /var/run/docker.sock:/var/run/docker.sock \
         -v /proc:/hostproc \
         -e PROCFS=/hostproc \
         -e DOCKERHUB_USER="$DOCKERHUB_USER" \
@@ -1213,8 +1213,6 @@ launch_proxy() {
         --entrypoint=/home/weave/weaveproxy \
         $WEAVEPROXY_DOCKER_ARGS $EXEC_IMAGE $COVERAGE_ARGS $PROXY_ARGS)
     wait_for_status $PROXY_CONTAINER_NAME http_call_unix $PROXY_CONTAINER_NAME status.sock
-    # backward compatibility
-    ln -sf -T /var/run/weave/weave.sock /var/run/weave.sock
 }
 
 ##########################################################################################


### PR DESCRIPTION
It was left in for backwards compatibility, in 1.1.

This resolves #1492