### PR TITLE
backoff late connection failures

### DIFF
--- a/router/status.go
+++ b/router/status.go
@@ -175,6 +175,8 @@ func NewLocalConnectionStatusSlice(cm *ConnectionMaker) []LocalConnectionStatus 
 		for address, target := range cm.targets {
 			var state, info string
 			switch {
+			case target.connected:
+				continue
 			case target.lastError == nil:
 				state = "connecting"
 				info = ""

--- a/router/status.go
+++ b/router/status.go
@@ -175,12 +175,12 @@ func NewLocalConnectionStatusSlice(cm *ConnectionMaker) []LocalConnectionStatus 
 		for address, target := range cm.targets {
 			var state, info string
 			switch {
-			case target.connected:
+			case target.state == TargetConnected:
 				continue
 			case target.lastError == nil:
 				state = "connecting"
 				info = ""
-			case target.attempting:
+			case target.state == TargetAttempting:
 				state = "retrying"
 				info = target.lastError.Error()
 			default:


### PR DESCRIPTION
If a connection gets through all the handshake and subsequent checks - i.e. it ends up getting added to the LocalPeer's connection list - but gets terminated within one minute (of the start of the successful connection attempt), then we apply the existing backoff logic to schedule a retry, instead of retrying immediately.

In order to do this we retain the 'Target' data structure for such connections, marking it as 'connected' instead of deleting it (as we did previously).

Fixes #953.