### PR TITLE
Fast datapath weave status

### DIFF
--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -161,7 +161,12 @@ func HandleHTTP(muxRouter *mux.Router, version string, router *weave.Router, all
 	}
 	muxRouter.Methods("GET").Path("/report").Headers("Accept", "application/json").HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			json, _ := json.MarshalIndent(status(), "", "    ")
+			json, err := json.MarshalIndent(status(), "", "    ")
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				Log.Error("Error during report marshalling: ", err)
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(json)
 		})

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -662,6 +662,10 @@ func (fwd *fastDatapathForwarder) ControlMessage(tag byte, msg []byte) {
 	}
 }
 
+func (fwd *fastDatapathForwarder) OverlayType() string {
+	return "fastdp"
+}
+
 func (fwd *fastDatapathForwarder) handleHeartbeatAck() {
 	log.Debug(fwd.logPrefix(), "handleHeartbeatAck")
 

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -21,6 +21,9 @@ type Overlay interface {
 
 	// Enhance a features map with overlay-related features
 	AddFeaturesTo(map[string]string)
+
+	// Obtain diagnostic information specific to the overlay
+	Diagnostics() interface{}
 }
 
 type ForwarderParams struct {
@@ -135,4 +138,8 @@ func (NullOverlay) ControlMessage(byte, []byte) {
 
 func (NullOverlay) OverlayType() string {
 	return "null"
+}
+
+func (NullOverlay) Diagnostics() interface{} {
+	return nil
 }

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -88,6 +88,9 @@ type OverlayForwarder interface {
 	// compatibility, and should always be
 	// ProtocolOverlayControlMessage for non-sleeve overlays.
 	ControlMessage(tag byte, msg []byte)
+
+	// Type of overlay this forwarder belongs to
+	OverlayType() string
 }
 
 type NullOverlay struct{}
@@ -128,4 +131,8 @@ func (NullOverlay) Stop() {
 }
 
 func (NullOverlay) ControlMessage(byte, []byte) {
+}
+
+func (NullOverlay) OverlayType() string {
+	return "null"
 }

--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -35,6 +35,14 @@ func (osw *OverlaySwitch) AddFeaturesTo(features map[string]string) {
 	features["Overlays"] = strings.Join(osw.overlayNames, " ")
 }
 
+func (osw *OverlaySwitch) Diagnostics() interface{} {
+	diagnostics := make(map[string]interface{})
+	for name, overlay := range osw.overlays {
+		diagnostics[name] = overlay.Diagnostics()
+	}
+	return diagnostics
+}
+
 func (osw *OverlaySwitch) InvalidateRoutes() {
 	for _, overlay := range osw.overlays {
 		overlay.InvalidateRoutes()

--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -393,3 +393,15 @@ func (fwd *overlaySwitchForwarder) ControlMessage(tag byte, msg []byte) {
 		subFwd.ControlMessage(msg[1], msg[2:])
 	}
 }
+
+func (fwd *overlaySwitchForwarder) OverlayType() string {
+	fwd.lock.Lock()
+	best := fwd.best
+	fwd.lock.Unlock()
+
+	if best == nil {
+		return "none"
+	}
+
+	return best.OverlayType()
+}

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -133,6 +133,10 @@ func (*SleeveOverlay) AddFeaturesTo(map[string]string) {
 	// No features to be provided, to facilitate compatibility
 }
 
+func (*SleeveOverlay) Diagnostics() interface{} {
+	return nil
+}
+
 func (sleeve *SleeveOverlay) lookupForwarder(peer PeerName) *sleeveForwarder {
 	sleeve.lock.Lock()
 	defer sleeve.lock.Unlock()

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -593,6 +593,10 @@ func (fwd *sleeveForwarder) ControlMessage(tag byte, msg []byte) {
 	}
 }
 
+func (fwd *sleeveForwarder) OverlayType() string {
+	return "sleeve"
+}
+
 func (fwd *sleeveForwarder) Stop() {
 	fwd.sleeve.removeForwarder(fwd.remotePeer.Name, fwd)
 

--- a/router/status.go
+++ b/router/status.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -170,7 +171,9 @@ func NewLocalConnectionStatusSlice(cm *ConnectionMaker) []LocalConnectionStatus 
 			if conn.Established() {
 				state = "established"
 			}
-			slice = append(slice, LocalConnectionStatus{conn.RemoteTCPAddr(), conn.Outbound(), state, conn.Remote().String()})
+			lc, _ := conn.(*LocalConnection)
+			info := fmt.Sprintf("%-6v %v", lc.forwarder.OverlayType(), conn.Remote())
+			slice = append(slice, LocalConnectionStatus{conn.RemoteTCPAddr(), conn.Outbound(), state, info})
 		}
 		for address, target := range cm.targets {
 			add := func(state, info string) {

--- a/router/status.go
+++ b/router/status.go
@@ -36,6 +36,7 @@ type PeerStatus struct {
 	Name        string
 	NickName    string
 	UID         PeerUID
+	ShortID     PeerShortID
 	Version     uint64
 	Connections []ConnectionStatus
 }
@@ -122,6 +123,7 @@ func NewPeerStatusSlice(peers *Peers) []PeerStatus {
 			peer.Name.String(),
 			peer.NickName,
 			peer.UID,
+			peer.ShortID,
 			peer.Version,
 			connections})
 	})

--- a/router/status.go
+++ b/router/status.go
@@ -22,6 +22,7 @@ type Status struct {
 	BroadcastRoutes    []BroadcastRouteStatus
 	Connections        []LocalConnectionStatus
 	Targets            []string
+	OverlayDiagnostics interface{}
 }
 
 type MACStatus struct {
@@ -80,7 +81,8 @@ func NewStatus(router *Router) *Status {
 		NewUnicastRouteStatusSlice(router.Routes),
 		NewBroadcastRouteStatusSlice(router.Routes),
 		NewLocalConnectionStatusSlice(router.ConnectionMaker),
-		NewTargetSlice(router.ConnectionMaker)}
+		NewTargetSlice(router.ConnectionMaker),
+		router.Overlay.Diagnostics()}
 }
 
 func NewMACStatusSlice(cache *MacCache) []MACStatus {


### PR DESCRIPTION
Fixes #1505.

````
$ weave status connections
<- 192.168.48.12:39316   established vxlan        d2:80:69:fe:6a:b5(host2)
-> 192.168.48.15:6783    connecting  undetermined 
````

````
$ weave report
{
    "Version": "git-819b0cbccb46",
    "Router": {
        "Protocol": "weave",
        "ProtocolMinVersion": 1,
        "ProtocolMaxVersion": 2,
        "Encryption": false,
        "PeerDiscovery": true,
        "Name": "2a:0e:71:cf:b5:e1",
        "NickName": "host1",
        "Port": 6783,
        "Interface": "weave (via ODP)",
        "CaptureStats": null,
        "MACs": [
            {
                "Mac": "82:72:04:78:39:7c",
                "Name": "2a:0e:71:cf:b5:e1",
                "NickName": "host1",
                "LastSeen": "2015-10-07T17:03:55.129115227Z"
            },
            {
                "Mac": "2a:30:c2:41:98:f3",
                "Name": "d2:80:69:fe:6a:b5",
                "NickName": "host2",
                "LastSeen": "2015-10-07T17:03:55.129053768Z"
            }
        ],
        "Peers": [
            {
                "Name": "2a:0e:71:cf:b5:e1",
                "NickName": "host1",
                "UID": 13490210014865600209,
                "Version": 2,
                "Connections": [
                    {
                        "Name": "d2:80:69:fe:6a:b5",
                        "NickName": "host2",
                        "Address": "192.168.48.12:39316",
                        "Outbound": false,
                        "Established": true
                    }
                ]
            },
            {
                "Name": "d2:80:69:fe:6a:b5",
                "NickName": "host2",
                "UID": 14328624370048807465,
                "Version": 2,
                "Connections": [
                    {
                        "Name": "2a:0e:71:cf:b5:e1",
                        "NickName": "host1",
                        "Address": "192.168.48.11:6783",
                        "Outbound": true,
                        "Established": true
                    }
                ]
            }
        ],
        "UnicastRoutes": [
            {
                "Dest": "2a:0e:71:cf:b5:e1",
                "Via": "00:00:00:00:00:00"
            },
            {
                "Dest": "d2:80:69:fe:6a:b5",
                "Via": "d2:80:69:fe:6a:b5"
            }
        ],
        "BroadcastRoutes": [
            {
                "Source": "d2:80:69:fe:6a:b5",
                "Via": null
            },
            {
                "Source": "2a:0e:71:cf:b5:e1",
                "Via": [
                    "d2:80:69:fe:6a:b5"
                ]
            }
        ],
        "Connections": [
            {
                "Address": "192.168.48.12:39316",
                "Outbound": false,
                "State": "established",
                "Info": "d2:80:69:fe:6a:b5(host2)",
                "OverlayType": "vxlan"
            },
            {
                "Address": "192.168.48.15:6783",
                "Outbound": true,
                "State": "failed",
                "Info": "dial tcp4 192.168.48.15:6783: no route to host, retry: 2015-10-07 17:08:39.096516208 +0000 UTC",
                "OverlayType": "undetermined"
            }
        ],
        "Targets": [
            "192.168.48.15"
        ],
        "OverlayDiagnostics": {
            "fastdp": {
                "Vports": [
                    {
                        "ID": 0,
                        "Name": "weave",
                        "TypeName": "internal"
                    },
                    {
                        "ID": 1,
                        "Name": "vxlan",
                        "TypeName": "vxlan"
                    },
                    {
                        "ID": 2,
                        "Name": "vethwepl7973",
                        "TypeName": "netdev"
                    }
                ],
                "Flows": [
                    {
                        "FlowKeys": [
                            "TunnelFlowKey(id: 0000000000ac8f92, ipv4src: 192.168.48.12, ipv4dst: 192.168.48.11}",
                            "InPortFlowKey{vport: 1}",
                            "EthernetFlowKey{src: 2a:30:c2:41:98:f3, dst: 82:72:04:78:39:7c}"
                        ],
                        "Actions": [
                            "OutputAction{vport: 2}"
                        ],
                        "Packets": 343,
                        "Bytes": 30142,
                        "Used": 28205473
                    },
                    {
                        "FlowKeys": [
                            "EthernetFlowKey{src: 82:72:04:78:39:7c, dst: 2a:30:c2:41:98:f3}",
                            "InPortFlowKey{vport: 2}"
                        ],
                        "Actions": [
                            "SetTunnelAction{id: 0000000000f92ac8, ipv4src: 192.168.48.11, ipv4dst: 192.168.48.12, ttl: 64, df: true}",
                            "OutputAction{vport: 1}"
                        ],
                        "Packets": 343,
                        "Bytes": 30142,
                        "Used": 28205473
                    }
                ]
            },
            "sleeve": null
        }
    },
    "IPAM": {
        "Paxos": null,
        "Range": "[10.32.0.0-10.48.0.0)",
        "DefaultSubnet": "10.32.0.0/12",
        "Entries": [
            {
                "Token": "10.32.0.0",
                "Peer": "2a:0e:71:cf:b5:e1",
                "Version": 3
            },
            {
                "Token": "10.40.0.0",
                "Peer": "d2:80:69:fe:6a:b5",
                "Version": 1
            },
            {
                "Token": "10.47.255.255",
                "Peer": "2a:0e:71:cf:b5:e1",
                "Version": 0
            }
        ],
        "PendingClaims": null,
        "PendingAllocates": null
    },
    "DNS": {
        "Domain": "weave.local.",
        "Address": "172.17.42.1:53",
        "TTL": 1,
        "Entries": [
            {
                "Hostname": "bar.weave.local.",
                "Origin": "d2:80:69:fe:6a:b5",
                "ContainerID": "9deba5cce8a350166622c9a99012789c4ca1e82e25bb90111a51cd3d385625d9",
                "Address": "10.40.0.0",
                "Version": 0,
                "Tombstone": 0
            },
            {
                "Hostname": "foo.weave.local.",
                "Origin": "2a:0e:71:cf:b5:e1",
                "ContainerID": "d12c6ab22bcaf3496deb673cb4d4c8d6ad3c42ab8429b3657d53d2ffc7e1b975",
                "Address": "10.32.0.1",
                "Version": 0,
                "Tombstone": 0
            }
        ]
    }
}
````
