### PR TITLE
`dns-{add,remove}` can add/remove non-container DNS records

### DIFF
--- a/site/weavedns.md
+++ b/site/weavedns.md
@@ -164,6 +164,18 @@ command:
 $ weave dns-remove $C
 ```
 
+By omitting the container name it is possible to add/remove DNS
+records that associate names in the weaveDNS domain with IP addresses
+that do not belong to containers, e.g. non-weave addresses of external
+services:
+
+```bash
+$ weave dns-add 192.128.16.45 -h db.weave.local
+```
+
+Note that such records get removed when stopping the weave peer on
+which they were added.
+
 ## <a name="resolve-weavedns-entries-from-host"></a>Resolve weaveDNS entries from host
 
 You can resolve entries from any host running weaveDNS with `weave

--- a/test/240_dns_add_name_test.sh
+++ b/test/240_dns_add_name_test.sh
@@ -4,6 +4,7 @@
 
 C1=10.2.0.78
 C2=10.2.0.34
+C3=10.2.0.12
 NAME1=seeone.weave.local
 NAME2=seetwo.weave.local
 NAME3=seethree.weave.local
@@ -33,5 +34,11 @@ assert_dns_a_record $HOST1 c1 $NAME3 $C1
 weave_on $HOST1 dns-remove c1 -h $NAME3
 
 assert_no_dns_record $HOST1 c1 $NAME3
+
+weave_on $HOST1 dns-add $C3 -h $NAME1
+assert_dns_record $HOST1 c1 $NAME1 $C3
+
+weave_on $HOST1 dns-remove $C3 -h $NAME1
+assert_no_dns_record $HOST1 c1 $NAME1
 
 end_suite

--- a/weave
+++ b/weave
@@ -69,8 +69,10 @@ weave run           [--with-dns | --without-dns] [<addr> ...]
 weave start         [<addr> ...] <container_id>
 weave attach        [<addr> ...] <container_id>
 weave detach        [<addr> ...] <container_id>
-weave dns-add       [<ip_address> ...] <container_id> [-h <fqdn>]
-weave dns-remove    [<ip_address> ...] <container_id> [-h <fqdn>]
+weave dns-add       [<ip_address> ...] <container_id> [-h <fqdn>] |
+                    <ip_address> ... -h <fqdn>
+weave dns-remove    [<ip_address> ...] <container_id> [-h <fqdn>] |
+                    <ip_address> ... -h <fqdn>
 weave dns-lookup    <unqualified_name>
 weave expose        [<addr> ...] [-h <fqdn>]
 weave hide          [<addr> ...]
@@ -881,6 +883,26 @@ delete_dns_fqdn() {
     done
 }
 
+collect_dns_add_remove_args() {
+    collect_ip_args "$@"
+    shift $IP_COUNT
+    if [ $# -gt 0 -a "$1" != "-h" ] ; then
+        C="$1"
+        shift
+    fi
+    if [ $# -eq 2 -a "$1" = "-h" ] ; then
+        FQDN="$2"
+        shift 2
+    fi
+    [ $# -eq 0 -a \( -n "$C" -o \( $IP_COUNT -gt 0 -a -n "$FQDN" \) \) ] || usage
+    [ -n "$C" ] || C=$CONTAINER_NAME
+    check_running $CONTAINER_NAME
+    CONTAINER=$(container_id $C)
+    if [ $IP_COUNT -eq 0 ] ; then
+        IP_ARGS=$(with_container_addresses echo_ips $CONTAINER)
+    fi
+}
+
 ######################################################################
 # IP Allocation Management helpers
 ######################################################################
@@ -1510,33 +1532,19 @@ case "$COMMAND" in
         show_addrs $ALL_CIDRS
         ;;
     dns-add)
-        collect_ip_args "$@"
-        shift $IP_COUNT
-        [ $# -eq 1 -o \( $# -eq 3 -a "$2" = "-h" \) ] || usage
-        check_running $CONTAINER_NAME
-        CONTAINER=$(container_id $1)
-        if [ $IP_COUNT -eq 0 ] ; then
-            IP_ARGS=$(with_container_addresses echo_ips $CONTAINER)
-        fi
-        if [ $# -eq 1 ] ; then
-            with_container_fqdn $CONTAINER put_dns_fqdn $IP_ARGS
+        collect_dns_add_remove_args "$@"
+        if [ -n "$FQDN" ] ; then
+            put_dns_fqdn $CONTAINER $FQDN $IP_ARGS
         else
-            put_dns_fqdn $CONTAINER "$3" $IP_ARGS
+            with_container_fqdn $CONTAINER put_dns_fqdn $IP_ARGS
         fi
         ;;
     dns-remove)
-        collect_ip_args "$@"
-        shift $IP_COUNT
-        [ $# -eq 1 -o \( $# -eq 3 -a "$2" = "-h" \) ] || usage
-        check_running $CONTAINER_NAME
-        CONTAINER=$(container_id $1)
-        if [ $IP_COUNT -eq 0 ] ; then
-            IP_ARGS=$(with_container_addresses echo_ips $CONTAINER)
-        fi
-        if [ $# -eq 1 ] ; then
-            delete_dns $CONTAINER $IP_ARGS
+        collect_dns_add_remove_args "$@"
+        if [ -n "$FQDN" ] ; then
+            delete_dns_fqdn $CONTAINER $FQDN $IP_ARGS
         else
-            delete_dns_fqdn $CONTAINER "$3" $IP_ARGS
+            delete_dns $CONTAINER $IP_ARGS
         fi
         ;;
     dns-lookup)

--- a/weave
+++ b/weave
@@ -849,10 +849,15 @@ with_container_fqdn() {
 # Register FQDN in $2 as names for addresses $3.. under full container ID $1
 put_dns_fqdn() {
     CHECK_ALIVE="-d check-alive=true"
-    if [ "$1" = "--no-check-alive" ] ; then
-        CHECK_ALIVE=
-        shift 1
-    fi
+    put_dns_fqdn_helper "$@"
+}
+
+put_dns_fqdn_no_check_alive() {
+    CHECK_ALIVE=
+    put_dns_fqdn_helper "$@"
+}
+
+put_dns_fqdn_helper() {
     CONTAINER_ID="$1"
     FQDN="$2"
     shift 2
@@ -895,11 +900,12 @@ collect_dns_add_remove_args() {
         shift 2
     fi
     [ $# -eq 0 -a \( -n "$C" -o \( $IP_COUNT -gt 0 -a -n "$FQDN" \) \) ] || usage
-    [ -n "$C" ] || C=$CONTAINER_NAME
     check_running $CONTAINER_NAME
-    CONTAINER=$(container_id $C)
-    if [ $IP_COUNT -eq 0 ] ; then
-        IP_ARGS=$(with_container_addresses echo_ips $CONTAINER)
+    if [ -n "$C" ] ; then
+        CONTAINER=$(container_id $C)
+        if [ $IP_COUNT -eq 0 ] ; then
+            IP_ARGS=$(with_container_addresses echo_ips $CONTAINER)
+        fi
     fi
 }
 
@@ -1533,14 +1539,20 @@ case "$COMMAND" in
         ;;
     dns-add)
         collect_dns_add_remove_args "$@"
+        FN=put_dns_fqdn
+        if [ -z "$CONTAINER" ] ; then
+            FN=put_dns_fqdn_no_check_alive
+            CONTAINER=weave:extern
+        fi
         if [ -n "$FQDN" ] ; then
-            put_dns_fqdn $CONTAINER $FQDN $IP_ARGS
+            $FN $CONTAINER $FQDN $IP_ARGS
         else
-            with_container_fqdn $CONTAINER put_dns_fqdn $IP_ARGS
+            with_container_fqdn $CONTAINER $FN $IP_ARGS
         fi
         ;;
     dns-remove)
         collect_dns_add_remove_args "$@"
+        [ -n "$CONTAINER" ] || CONTAINER=weave:extern
         if [ -n "$FQDN" ] ; then
             delete_dns_fqdn $CONTAINER $FQDN $IP_ARGS
         else
@@ -1570,7 +1582,7 @@ case "$COMMAND" in
                 add_iptables_rule nat WEAVE -d $CIDR ! -s $CIDR -j MASQUERADE
                 add_iptables_rule nat WEAVE -s $CIDR ! -d $CIDR -j MASQUERADE
                 if [ -n "$FQDN" ] ; then
-                    when_weave_running put_dns_fqdn --no-check-alive weave:expose $FQDN $CIDR
+                    when_weave_running put_dns_fqdn_no_check_alive weave:expose $FQDN $CIDR
                 fi
             fi
         done


### PR DESCRIPTION
...by omitting the container name

We associate non-container dns entries with 'weave:extern' because typically these entries will refer to external (non-weave) IP addresses. 'weave:extern' also happens to be the same length as the existing 'weave:expose' pseudo-container, which is desirable for 'weave status dns' output layout.

Fixes #1385.