### PR TITLE
Fast datapath compatibility with 1.1

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -196,7 +196,9 @@ func main() {
 	if fastDPOverlay != nil {
 		overlays.Add("fastdp", fastDPOverlay)
 	}
-	overlays.Add("sleeve", weave.NewSleeveOverlay(config.Port))
+	sleeve := weave.NewSleeveOverlay(config.Port)
+	overlays.Add("sleeve", sleeve)
+	overlays.SetCompatOverlay(sleeve)
 	config.Overlay = overlays
 
 	if routerName == "" {

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -754,6 +754,10 @@ func (fwd *fastDatapathForwarder) handleHeartbeatAck() {
 }
 
 func (fwd *fastDatapathForwarder) Forward(key ForwardPacketKey) FlowOp {
+	if !key.SrcPeer.HasShortID || !key.DstPeer.HasShortID {
+		return nil
+	}
+
 	fwd.lock.RLock()
 	defer fwd.lock.RUnlock()
 

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -68,7 +68,8 @@ type OverlayCrypto struct {
 type OverlayForwarder interface {
 	// Forward a packet across the connection.  May be called as
 	// soon as the forwarder is created, in particular before
-	// Confirm().
+	// Confirm().  The return value nil means the key could not be
+	// handled by this forwarder.
 	Forward(ForwardPacketKey) FlowOp
 
 	// Confirm that the connection is really wanted, and so the

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -127,7 +127,7 @@ func (NullOverlay) AddFeaturesTo(map[string]string) {
 }
 
 func (NullOverlay) Forward(ForwardPacketKey) FlowOp {
-	return nil
+	return DiscardingFlowOp{}
 }
 
 func (NullOverlay) Stop() {

--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -124,8 +124,8 @@ type overlaySwitchForwarder struct {
 
 	lock sync.Mutex
 
-	// the forwarder to send on
-	best OverlayForwarder
+	// the index of the forwarder to send on
+	best int
 
 	// the subsidiary forwarders
 	forwarders []subForwarder
@@ -183,6 +183,7 @@ func (osw *OverlaySwitch) MakeForwarder(
 	fwd := &overlaySwitchForwarder{
 		remotePeer: params.RemotePeer,
 
+		best:       -1,
 		forwarders: make([]subForwarder, len(overlays)),
 		stopChan:   stopChan,
 
@@ -285,9 +286,6 @@ func (fwd *overlaySwitchForwarder) established(index int) {
 
 	fwd.forwarders[index].established = true
 
-	// less preferred forwarders are no longer needed
-	fwd.stopFrom(index + 1)
-
 	if !fwd.alreadyEstablished {
 		fwd.alreadyEstablished = true
 		close(fwd.establishedChan)
@@ -323,7 +321,8 @@ func (fwd *overlaySwitchForwarder) stopFrom(index int) {
 func (fwd *overlaySwitchForwarder) chooseBest() {
 	// the most preferred established forwarder is the best
 	// otherwise, the most preferred working forwarder is the best
-	var bestEstablished, bestWorking *subForwarder
+	bestEstablished := -1
+	bestWorking := -1
 
 	for i := range fwd.forwarders {
 		subFwd := &fwd.forwarders[i]
@@ -331,18 +330,18 @@ func (fwd *overlaySwitchForwarder) chooseBest() {
 			continue
 		}
 
-		if bestWorking == nil {
-			bestWorking = subFwd
+		if bestWorking < 0 {
+			bestWorking = i
 		}
 
-		if bestEstablished == nil && subFwd.established {
-			bestEstablished = subFwd
+		if bestEstablished < 0 && subFwd.established {
+			bestEstablished = i
 		}
 	}
 
 	best := bestEstablished
-	if best == nil {
-		if bestWorking == nil {
+	if best < 0 {
+		if bestWorking < 0 {
 			select {
 			case fwd.errorChan <- fmt.Errorf("no working forwarders to %s", fwd.remotePeer):
 			default:
@@ -354,9 +353,10 @@ func (fwd *overlaySwitchForwarder) chooseBest() {
 		best = bestWorking
 	}
 
-	if fwd.best != best.fwd {
-		fwd.best = best.fwd
-		log.Info(fwd.logPrefix(), "using ", best.overlayName)
+	if fwd.best != best {
+		fwd.best = best
+		log.Info(fwd.logPrefix(),
+			"using ", fwd.forwarders[best].overlayName)
 	}
 }
 
@@ -378,14 +378,23 @@ func (fwd *overlaySwitchForwarder) Confirm() {
 
 func (fwd *overlaySwitchForwarder) Forward(pk ForwardPacketKey) FlowOp {
 	fwd.lock.Lock()
-	best := fwd.best
-	fwd.lock.Unlock()
 
-	if best == nil {
-		return nil
+	if fwd.best >= 0 {
+		for i := fwd.best; i < len(fwd.forwarders); i++ {
+			best := fwd.forwarders[i].fwd
+			if best != nil {
+				fwd.lock.Unlock()
+				if op := best.Forward(pk); op != nil {
+					return op
+				}
+				fwd.lock.Lock()
+			}
+		}
 	}
 
-	return best.Forward(pk)
+	fwd.lock.Unlock()
+
+	return DiscardingFlowOp{}
 }
 
 func (fwd *overlaySwitchForwarder) EstablishedChannel() <-chan struct{} {
@@ -412,13 +421,17 @@ func (fwd *overlaySwitchForwarder) ControlMessage(tag byte, msg []byte) {
 }
 
 func (fwd *overlaySwitchForwarder) DisplayName() string {
+	var best OverlayForwarder
+
 	fwd.lock.Lock()
-	best := fwd.best
+	if fwd.best > 0 {
+		best = fwd.forwarders[fwd.best].fwd
+	}
 	fwd.lock.Unlock()
 
-	if best == nil {
-		return "none"
+	if best != nil {
+		return best.DisplayName()
 	}
 
-	return best.DisplayName()
+	return "none"
 }

--- a/router/pcap.go
+++ b/router/pcap.go
@@ -9,6 +9,8 @@ import (
 )
 
 type Pcap struct {
+	NonDiscardingFlowOp
+
 	iface *net.Interface
 	bufSz int
 
@@ -131,7 +133,7 @@ func (p *Pcap) sniff(readHandle *pcap.Handle, consumer BridgeConsumer) {
 			continue
 		}
 
-		if fop := consumer(dec.PacketKey()); fop != nil {
+		if fop := consumer(dec.PacketKey()); !fop.Discards() {
 			// We are handing over the frame to
 			// forwarders, so we need to make a copy of it
 			// in order to prevent the next capture from

--- a/router/peer.go
+++ b/router/peer.go
@@ -30,11 +30,12 @@ func randomPeerShortID() PeerShortID {
 }
 
 type PeerSummary struct {
-	NameByte []byte
-	NickName string
-	UID      PeerUID
-	Version  uint64
-	ShortID  PeerShortID
+	NameByte   []byte
+	NickName   string
+	UID        PeerUID
+	Version    uint64
+	ShortID    PeerShortID
+	HasShortID bool
 }
 
 type Peer struct {
@@ -56,11 +57,12 @@ func NewPeerFromSummary(summary PeerSummary) *Peer {
 
 func NewPeer(name PeerName, nickName string, uid PeerUID, version uint64, shortID PeerShortID) *Peer {
 	return NewPeerFromSummary(PeerSummary{
-		NameByte: name.Bin(),
-		NickName: nickName,
-		UID:      uid,
-		Version:  version,
-		ShortID:  shortID,
+		NameByte:   name.Bin(),
+		NickName:   nickName,
+		UID:        uid,
+		Version:    version,
+		ShortID:    shortID,
+		HasShortID: true,
 	})
 }
 

--- a/router/peers.go
+++ b/router/peers.go
@@ -114,6 +114,10 @@ func (peers *Peers) unlockAndNotify(pending *PeersPendingNotifications) {
 }
 
 func (peers *Peers) addByShortID(peer *Peer, pending *PeersPendingNotifications) {
+	if !peer.HasShortID {
+		return
+	}
+
 	entry, ok := peers.byShortID[peer.ShortID]
 	if !ok {
 		entry = ShortIDPeers{peer: peer}
@@ -146,6 +150,10 @@ func (peers *Peers) addByShortID(peer *Peer, pending *PeersPendingNotifications)
 }
 
 func (peers *Peers) deleteByShortID(peer *Peer, pending *PeersPendingNotifications) {
+	if !peer.HasShortID {
+		return
+	}
+
 	entry := peers.byShortID[peer.ShortID]
 	var otherIndex int
 

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -427,12 +427,13 @@ func (fwd *sleeveForwarder) ErrorChannel() <-chan error {
 }
 
 type curriedForward struct {
+	NonDiscardingFlowOp
 	fwd *sleeveForwarder
 	key ForwardPacketKey
 }
 
 func (fwd *sleeveForwarder) Forward(key ForwardPacketKey) FlowOp {
-	return curriedForward{fwd, key}
+	return curriedForward{fwd: fwd, key: key}
 }
 
 func (f curriedForward) Process(frame []byte, dec *EthernetDecoder,


### PR DESCRIPTION
This is stacked on top of the fdp-rebase branch, so should not be merged until after #1438.

Addresses #1448.  Compatibility with 1.1 is intended to "just work", so that we won't need to explain any special procedure for doing rolling upgrades to 1.2.