### PR TITLE
[proxy] Fix bug in weave env/config when passing multiple -H flags

### DIFF
--- a/test/650_proxy_env_test.sh
+++ b/test/650_proxy_env_test.sh
@@ -2,6 +2,13 @@
 
 . ./config.sh
 
+CMD="run -e WEAVE_CIDR=10.2.1.4/24 $SMALL_IMAGE $CHECK_ETHWE_UP"
+
+check() {
+  assert_raises "eval '$(weave_on $HOST1 env)' ; docker $CMD"
+  assert_raises "docker $(weave_on $HOST1 config) $CMD"
+}
+
 start_suite "Configure the docker daemon for the proxy"
 
 # No output when nothing running
@@ -9,14 +16,16 @@ assert "weave_on $HOST1 env" ""
 assert "weave_on $HOST1 config" ""
 
 weave_on $HOST1 launch-proxy
-
-CMD="run -e WEAVE_CIDR=10.2.1.4/24 $SMALL_IMAGE $CHECK_ETHWE_UP"
-assert_raises "eval '$(weave_on $HOST1 env)' ; docker $CMD"
-assert_raises "docker $(weave_on $HOST1 config) $CMD"
+check
 
 # Check we can use the weave script through the proxy
 assert_raises "eval '$(weave_on $HOST1 env)' ; $WEAVE version"
 assert_raises "eval '$(weave_on $HOST1 env)' ; $WEAVE ps"
 assert_raises "eval '$(weave_on $HOST1 env)' ; $WEAVE launch-router"
+
+# Check we can use weave env/config with multiple -Hs specified
+weave_on $HOST1 stop
+weave_on $HOST1 launch-proxy -H tcp://0.0.0.0:12375 -H unix:///var/run/weave/weave.sock
+check
 
 end_suite

--- a/weave
+++ b/weave
@@ -1072,13 +1072,19 @@ proxy_args() {
     fi
 }
 
-proxy_addr() {
-    if addr=$(http_call_unix $PROXY_CONTAINER_NAME status.sock GET /status 2>&1) ; then
-      echo "$addr" | head -n1 | sed "s/0.0.0.0/$PROXY_HOST/g"
+proxy_addrs() {
+    if addr="$(http_call_unix $PROXY_CONTAINER_NAME status.sock GET /status 2>&1)" ; then
+      echo "$addr" | sed "s/0.0.0.0/$PROXY_HOST/g"
+
     else
       echo "$PROXY_CONTAINER_NAME container is not present. Have you launched it?" >&2
       return 1
     fi
+}
+
+proxy_addr() {
+    addr=$(proxy_addrs) || return 1
+    echo "$addr" | cut -d ' ' -f1
 }
 
 warn_if_stopping_proxy_in_env() {
@@ -1377,8 +1383,8 @@ case "$COMMAND" in
         ;;
     config|proxy-config)
         [ "$COMMAND" = "config" ] || deprecation_warning "$COMMAND" "'weave config'"
-        if PROXY_addr=$(proxy_addr) ; then
-            echo "-H=$PROXY_addr"
+        if PROXY_ADDR=$(proxy_addr) ; then
+            echo "-H=$PROXY_ADDR"
         fi
         ;;
     connect)
@@ -1419,10 +1425,10 @@ case "$COMMAND" in
         else
             res=1
         fi
-        if [ -z "$SUB_STATUS" ] && check_running $PROXY_CONTAINER_NAME 2>/dev/null && PROXY_ADDR=$(proxy_addr) ; then
+        if [ -z "$SUB_STATUS" ] && check_running $PROXY_CONTAINER_NAME 2>/dev/null && PROXY_ADDRS=$(proxy_addrs) ; then
             echo
             echo "       Service: proxy"
-            echo "       Address: $PROXY_ADDR"
+            echo "       Address: $PROXY_ADDRS"
         fi
         [ -n "$SUB_STATUS" ] || echo
         [ $res -eq 0 ]


### PR DESCRIPTION
The echo in proxy_addr was not preserving newlines, so the multiple
addrs were all getting returned.

Fixes #1527