### PR TITLE
Proxy restart shouldn't kill containers

### DIFF
--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -25,6 +25,12 @@ run_on $HOST1 sudo kill -KILL $(docker_on $HOST1 inspect --format='{{.State.Pid}
 sleep 1
 check_attached
 
+# Restarting proxy shouldn't kill unattachable containers
+proxy_start_container $HOST1 -di --name=c3 --restart=always # Use ipam, so it won't be attachable w/o weave
+weave_on $HOST1 stop
+weave_on $HOST1 launch-proxy
+assert_raises "proxy exec_on $HOST1 c3 $CHECK_ETHWE_UP"
+
 # Restart docker itself, using different commands for systemd- and upstart-managed.
 run_on $HOST1 sh -c "command -v systemctl >/dev/null && sudo systemctl restart docker || sudo service docker restart"
 sleep 1


### PR DESCRIPTION
Fixes #1547.

First commit stops it killing containers when restarting the proxy.

Second adds a first pass at an attachment retry mechanism. Thoughts on that? I need to have a think about how to test it.