### PR TITLE
Fix weaveproxy silently breaking when weave not running

### DIFF
--- a/proxy/start_container_interceptor.go
+++ b/proxy/start_container_interceptor.go
@@ -53,6 +53,5 @@ func (i *startContainerInterceptor) InterceptResponse(r *http.Response) error {
 	if r.StatusCode < 200 || r.StatusCode >= 300 { // Docker didn't do the start
 		return nil
 	}
-	i.proxy.waitForStart(r.Request)
-	return nil
+	return i.proxy.waitForStart(r.Request)
 }

--- a/test/695_proxy_failure_modes_test.sh
+++ b/test/695_proxy_failure_modes_test.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Proxy failure modes"
+
+# docker run should fail when weave router is not running
+weave_on $HOST1 launch-proxy
+assert_raises "proxy docker_on $HOST1 run --rm $SMALL_IMAGE true" 1
+assert_raises "proxy docker_on $HOST1 run --rm $SMALL_IMAGE true 2>&1 1>/dev/null | grep 'Error response from daemon: weave container is not present. Have you launched it?'"
+
+end_suite


### PR DESCRIPTION
With the new ContainerStarted method were not returning the error back to the requesters.

While fixing it, I believe I found another race condition in the same code, so I've included a fix for that, also. (race condition is documented in the commit).

Fixes #1542 