### PR TITLE
Proxy retry attaching containers

### DIFF
--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -72,6 +72,7 @@ func main() {
 	if err != nil {
 		Log.Fatalf("Could not start proxy: %s", err)
 	}
+	defer p.Stop()
 
 	listeners := p.Listen()
 	p.AttachExistingContainers()


### PR DESCRIPTION
First experimental pass at having the proxy retry attaching containers if the attach fails.

Nice to haves:
* Detect if there are causes where a container will *never* successfully attach, and handle those.
* Some sort of back-off
* Should also combine multiple requests to attach the same container (by name or id).

Fixes #1556