### PR TITLE
Do InvalidateRoutes when a forwarded packet updates a MAC cache entry

### DIFF
--- a/router/mac_cache.go
+++ b/router/mac_cache.go
@@ -68,9 +68,8 @@ func (cache *MacCache) Add(mac net.HardwareAddr, peer *Peer) (bool, *Peer) {
 	return cache.add(mac, peer, false)
 }
 
-func (cache *MacCache) AddForced(mac net.HardwareAddr, peer *Peer) bool {
-	newMac, _ := cache.add(mac, peer, true)
-	return newMac
+func (cache *MacCache) AddForced(mac net.HardwareAddr, peer *Peer) (bool, *Peer) {
+	return cache.add(mac, peer, true)
 }
 
 func (cache *MacCache) Lookup(mac net.HardwareAddr) *Peer {


### PR DESCRIPTION
When we get a forwarded packet, we put its source MAC into the MAC cache,
overriding any existing entry.  But we could have a flow which says
to forward packets destined to that MAC based on the old entry.  Such
a flow could be prolonged indefinitely by attempts to send to the MAC.
This is obviously bad, so do InvalidateRoutes in such cases.