### PR TITLE
Make inspect-rewrite wait for start

### DIFF
--- a/proxy/inspect_container_interceptor.go
+++ b/proxy/inspect_container_interceptor.go
@@ -22,19 +22,20 @@ func (i *inspectContainerInterceptor) InterceptResponse(r *http.Response) error 
 		return err
 	}
 
-	if err := updateContainerNetworkSettings(container); err != nil {
+	if err := updateContainerNetworkSettings(container, i.proxy); err != nil {
 		Log.Warningf("Inspecting container %s failed: %s", container["Id"], err)
 	}
 
 	return marshalResponseBody(r, container)
 }
 
-func updateContainerNetworkSettings(container jsonObject) error {
+func updateContainerNetworkSettings(container jsonObject, proxy *Proxy) error {
 	containerID, err := container.String("Id")
 	if err != nil {
 		return err
 	}
 
+	proxy.waitForStartByIdent(containerID)
 	mac, ips, nets, err := weaveContainerIPs(containerID)
 	if err != nil || len(ips) == 0 {
 		return err

--- a/proxy/inspect_container_interceptor.go
+++ b/proxy/inspect_container_interceptor.go
@@ -22,31 +22,9 @@ func (i *inspectContainerInterceptor) InterceptResponse(r *http.Response) error 
 		return err
 	}
 
-	if err := updateContainerNetworkSettings(container, i.proxy); err != nil {
+	if err := i.proxy.updateContainerNetworkSettings(container); err != nil {
 		Log.Warningf("Inspecting container %s failed: %s", container["Id"], err)
 	}
 
 	return marshalResponseBody(r, container)
-}
-
-func updateContainerNetworkSettings(container jsonObject, proxy *Proxy) error {
-	containerID, err := container.String("Id")
-	if err != nil {
-		return err
-	}
-
-	proxy.waitForStartByIdent(containerID)
-	mac, ips, nets, err := weaveContainerIPs(containerID)
-	if err != nil || len(ips) == 0 {
-		return err
-	}
-
-	networkSettings, err := container.Object("NetworkSettings")
-	if err != nil {
-		return err
-	}
-	networkSettings["MacAddress"] = mac
-	networkSettings["IPAddress"] = ips[0].String()
-	networkSettings["IPPrefixLen"], _ = nets[0].Mask.Size()
-	return nil
 }

--- a/proxy/inspect_exec_interceptor.go
+++ b/proxy/inspect_exec_interceptor.go
@@ -27,7 +27,7 @@ func (i *inspectExecInterceptor) InterceptResponse(r *http.Response) error {
 		return err
 	}
 
-	if err := updateContainerNetworkSettings(container); err != nil {
+	if err := updateContainerNetworkSettings(container, i.proxy); err != nil {
 		Log.Warningf("Inspecting exec %s failed: %s", exec["Id"], err)
 	}
 

--- a/proxy/inspect_exec_interceptor.go
+++ b/proxy/inspect_exec_interceptor.go
@@ -27,7 +27,7 @@ func (i *inspectExecInterceptor) InterceptResponse(r *http.Response) error {
 		return err
 	}
 
-	if err := updateContainerNetworkSettings(container, i.proxy); err != nil {
+	if err := i.proxy.updateContainerNetworkSettings(container); err != nil {
 		Log.Warningf("Inspecting exec %s failed: %s", exec["Id"], err)
 	}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -512,3 +512,25 @@ func (proxy *Proxy) getDNSDomain() (domain string) {
 
 	return string(b)
 }
+
+func (proxy *Proxy) updateContainerNetworkSettings(container jsonObject) error {
+	containerID, err := container.String("Id")
+	if err != nil {
+		return err
+	}
+
+	proxy.waitForStartByIdent(containerID)
+	mac, ips, nets, err := weaveContainerIPs(containerID)
+	if err != nil || len(ips) == 0 {
+		return err
+	}
+
+	networkSettings, err := container.Object("NetworkSettings")
+	if err != nil {
+		return err
+	}
+	networkSettings["MacAddress"] = mac
+	networkSettings["IPAddress"] = ips[0].String()
+	networkSettings["IPPrefixLen"], _ = nets[0].Mask.Size()
+	return nil
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -358,6 +358,23 @@ func (proxy *Proxy) waitForStart(r *http.Request) error {
 	return nil
 }
 
+// If some other operation is waiting for a container to start, join in the wait
+func (proxy *Proxy) waitForStartByIdent(ident string) {
+	var ch chan struct{}
+	proxy.Lock()
+	for _, wait := range proxy.waiters {
+		if ident == wait.ident {
+			ch = wait.ch
+			break
+		}
+	}
+	proxy.Unlock()
+	if ch != nil {
+		Log.Debugf("Wait for start of container %s", ident)
+		<-ch
+	}
+}
+
 func (proxy *Proxy) ContainerDied(ident string) {
 }
 


### PR DESCRIPTION
Fixes #1549

This seems difficult to write a smoke-test for, as `docker start` won't return until the start is finished; the issue shows up if you react to the 'start' event and do an inspect straight away.