### PR TITLE
[proxy] dynamically mount -H dirs into the proxy when launching

### DIFF
--- a/test/690_proxy_config_test.sh
+++ b/test/690_proxy_config_test.sh
@@ -2,7 +2,7 @@
 
 . ./config.sh
 
-start_suite "Boot the proxy should only listen on client's interface"
+start_suite "Various launch-proxy configurations"
 
 # Booting it over unix socket listens on unix socket
 run_on $HOST1 COVERAGE=$COVERAGE sudo -E weave launch-proxy
@@ -22,6 +22,11 @@ assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave/weave.sock ps"
 assert_raises "proxy docker_on $HOST1 ps"
 weave_on $HOST1 stop-proxy
 
+# Booting it with -H outside /var/run/weave, still works
+socket="$(mktemp -d)/weave.sock"
+weave_on $HOST1 launch-proxy -H unix://$socket
+assert_raises "run_on $HOST1 sudo docker -H unix:///$socket ps" 0
+weave_on $HOST1 stop-proxy
 
 # Booting it over tls errors
 assert_raises "DOCKER_CLIENT_ARGS='--tls' weave_on $HOST1 launch-proxy" 1

--- a/weave
+++ b/weave
@@ -1277,12 +1277,11 @@ host_arg() {
       exit 1
     fi
     if [ "$host" = "/var/run" ]; then
-      echo "WARNING: When launching the proxy, unix sockets directly in /var/run can lead to a bug with net namespace cleanup." >&2
+      echo "WARNING: Proxying sockets whose immediate parent directory is /var/run is unreliable." >&2
       echo "To work around this, put the unix socket in a subdirectory of /var/run, and symlink it into place." >&2
-      echo "For more info, see https://github.com/weaveworks/weave/issues/1455" >&2
     fi
     PROXY_VOLUMES="$PROXY_VOLUMES -v $host:/host$host"
-    PROXY_ARGS="$PROXY_ARGS -H /host$host/$(basename ${PROXY_HOST#unix://})"
+    PROXY_ARGS="$PROXY_ARGS -H unix:///host$host/$(basename ${PROXY_HOST#unix://})"
   else
     PROXY_ARGS="$PROXY_ARGS -H $1"
   fi

--- a/weave
+++ b/weave
@@ -1278,6 +1278,7 @@ host_arg() {
     fi
     if [ "$host" = "/var/run" ]; then
       echo "WARNING: When launching the proxy, unix sockets directly in /var/run can lead to a bug with net namespace cleanup." >&2
+      echo "To work around this, put the unix socket in a subdirectory of /var/run, and symlink it into place." >&2
       echo "For more info, see https://github.com/weaveworks/weave/issues/1455" >&2
     fi
     PROXY_VOLUMES="$PROXY_VOLUMES -v $host:/host$host"

--- a/weave
+++ b/weave
@@ -1266,17 +1266,36 @@ tls_arg() {
     PROXY_ARGS="$PROXY_ARGS $1 /home/weave/tls/$3.pem"
 }
 
+# TODO: Handle relative paths for args
+# TODO: Handle args with spaces
+host_arg() {
+  PROXY_HOST="$1"
+  if [ "$PROXY_HOST" != "${PROXY_HOST#unix://}" ]; then
+    host=$(dirname ${PROXY_HOST#unix://})
+    if [ "$host" = "${host#/}" ]; then
+      echo "When launching the proxy, unix sockets must be specified as an absolute path." >&2
+      exit 1
+    fi
+    if [ "$host" = "/var/run" ]; then
+      echo "WARNING: When launching the proxy, unix sockets directly in /var/run can lead to a bug with net namespace cleanup." >&2
+      echo "For more info, see https://github.com/weaveworks/weave/issues/1455" >&2
+    fi
+    PROXY_VOLUMES="$PROXY_VOLUMES -v $host:/host$host"
+    PROXY_ARGS="$PROXY_ARGS -H /host$host/$(basename ${PROXY_HOST#unix://})"
+  else
+    PROXY_ARGS="$PROXY_ARGS -H $1"
+  fi
+}
+
 proxy_parse_args() {
     while [ $# -gt 0 ]; do
         case "$1" in
           -H)
-            PROXY_HOST="$2"
-            PROXY_ARGS="$PROXY_ARGS $1 $2"
+            host_arg "$2"
             shift
             ;;
           -H=*)
-            PROXY_HOST="${1#*=}"
-            PROXY_ARGS="$PROXY_ARGS $1"
+            host_arg "${1#*=}"
             ;;
           -tls|--tls|-tlsverify|--tlsverify)
             PROXY_TLS_ENABLED=1
@@ -1333,7 +1352,7 @@ proxy_args() {
           PROXY_HOST="tcp://0.0.0.0:12375"
           ;;
       esac
-      PROXY_ARGS="$PROXY_ARGS -H $PROXY_HOST"
+      host_arg "$PROXY_HOST"
     fi
 }
 


### PR DESCRIPTION
This lets you use -H unix://*.sock outside /var/run/weave.

The giant gotcha is that if you use `-H /var/run/foo.sock`, you will reintroduce the bug with
namespaces not being GCed. We could make passing a socket in `/var/run`, an error...

Still working on the test...

Fixes #1579 