### PR TITLE
Improved detection of router container restart

### DIFF
--- a/proxy/common.go
+++ b/proxy/common.go
@@ -21,6 +21,7 @@ var (
 	containerIDRegexp   = regexp.MustCompile("^(/v[0-9\\.]*)?/containers/([^/]*)/.*")
 	weaveWaitEntrypoint = []string{"/w/w"}
 	weaveEntrypoint     = "/home/weave/weaver"
+	weaveContainerName  = "/weave"
 )
 
 func callWeave(args ...string) ([]byte, []byte, error) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -315,7 +315,8 @@ func containerShouldAttach(container *docker.Container) bool {
 }
 
 func containerIsWeaveRouter(container *docker.Container) bool {
-	return len(container.Config.Entrypoint) > 0 && container.Config.Entrypoint[0] == weaveEntrypoint
+	return container.Name == weaveContainerName &&
+		len(container.Config.Entrypoint) > 0 && container.Config.Entrypoint[0] == weaveEntrypoint
 }
 
 func (proxy *Proxy) createWait(r *http.Request, ident string) {


### PR DESCRIPTION
Use the container name in addition to the entrypoint to avoid triggering
reattachment unnecessarily.

Fixes #1584.