### PR TITLE
trying a fix for the intermittent failure in test/640

### DIFF
--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -31,7 +31,7 @@ sleep 1
 check_attached
 
 # Restart docker itself, using different commands for systemd- and upstart-managed.
-run_on $HOST1 sh -c "command -v systemctl >/dev/null && sudo systemctl restart docker || sudo service docker restart"
+run_on $HOST1 sh -c "systemctl=\$(command -v systemctl) && sudo \$systemctl restart docker || sudo service docker restart"
 sleep 10
 check_attached
 


### PR DESCRIPTION
May fix #1588 

Based on the systemctl error, it looks like sudo can't find the systemctl on it's path, so we could pass in the absolute path to it.

Not sure why this would only happen sometimes on GCE?

Waiting for this to run on circle a couple times...