### PR TITLE
Hold DNS entries sorted case-insensitively until just before sending

### DIFF
--- a/nameserver/entry.go
+++ b/nameserver/entry.go
@@ -241,6 +241,15 @@ func (g *GossipData) Merge(o router.GossipData) {
 	}
 }
 
+func (g *GossipData) Decode(msg []byte) error {
+	if err := gob.NewDecoder(bytes.NewReader(msg)).Decode(g); err != nil {
+		return err
+	}
+
+	sort.Sort(CaseInsensitive(g.Entries))
+	return nil
+}
+
 func (g *GossipData) Encode() [][]byte {
 	// Make a copy so we can sort: all outgoing data is sent in case-sensitive order
 	g2 := GossipData{Timestamp: g.Timestamp, Entries: make(Entries, len(g.Entries))}

--- a/nameserver/entry.go
+++ b/nameserver/entry.go
@@ -233,8 +233,8 @@ type GossipData struct {
 }
 
 func (g *GossipData) Merge(o router.GossipData) {
-	checkAndPanic(CaseSensitive(g.Entries))
-	defer func() { checkAndPanic(CaseSensitive(g.Entries)) }()
+	checkAndPanic(CaseInsensitive(g.Entries))
+	defer func() { checkAndPanic(CaseInsensitive(g.Entries)) }()
 	other := o.(*GossipData)
 	g.Entries.merge(other.Entries)
 	if g.Timestamp < other.Timestamp {
@@ -243,9 +243,12 @@ func (g *GossipData) Merge(o router.GossipData) {
 }
 
 func (g *GossipData) Encode() [][]byte {
-	checkAndPanic(CaseSensitive(g.Entries))
+	// Make a copy so we can sort: all outgoing data is sent in case-sensitive order
+	g2 := GossipData{Timestamp: g.Timestamp, Entries: make(Entries, len(g.Entries))}
+	copy(g2.Entries, g.Entries)
+	sort.Sort(CaseSensitive(g2.Entries))
 	buf := &bytes.Buffer{}
-	if err := gob.NewEncoder(buf).Encode(g); err != nil {
+	if err := gob.NewEncoder(buf).Encode(g2); err != nil {
 		panic(err)
 	}
 	return [][]byte{buf.Bytes()}

--- a/nameserver/entry.go
+++ b/nameserver/entry.go
@@ -145,6 +145,7 @@ func (es *Entries) add(hostname, containerid string, origin router.PeerName, add
 
 func (es *Entries) merge(incoming Entries) Entries {
 	defer es.checkAndPanic().checkAndPanic()
+	incoming.checkAndPanic()
 
 	newEntries := Entries{}
 	i := 0
@@ -233,8 +234,6 @@ type GossipData struct {
 }
 
 func (g *GossipData) Merge(o router.GossipData) {
-	checkAndPanic(CaseInsensitive(g.Entries))
-	defer func() { checkAndPanic(CaseInsensitive(g.Entries)) }()
 	other := o.(*GossipData)
 	g.Entries.merge(other.Entries)
 	if g.Timestamp < other.Timestamp {

--- a/nameserver/entry_test.go
+++ b/nameserver/entry_test.go
@@ -130,3 +130,31 @@ func TestLookup(t *testing.T) {
 	}
 	require.Equal(t, have, want)
 }
+
+func TestGossipDataMerge(t *testing.T) {
+	g1 := GossipData{Entries: Entries{
+		Entry{Hostname: "A"},
+		Entry{Hostname: "c"},
+		Entry{Hostname: "D"},
+		Entry{Hostname: "f"},
+	}}
+
+	g2 := GossipData{Entries: Entries{
+		Entry{Hostname: "B"},
+		Entry{Hostname: "E"},
+		Entry{Hostname: "f"},
+	}}
+
+	g1.Merge(&g2)
+
+	expected := GossipData{Entries: Entries{
+		Entry{Hostname: "A"},
+		Entry{Hostname: "B"},
+		Entry{Hostname: "c"},
+		Entry{Hostname: "D"},
+		Entry{Hostname: "E"},
+		Entry{Hostname: "f"},
+	}}
+
+	require.Equal(t, expected, g1)
+}

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -196,7 +196,6 @@ func (n *Nameserver) Gossip() router.GossipData {
 		Timestamp: now(),
 	}
 	copy(gossip.Entries, n.entries)
-	sort.Sort(CaseSensitive(gossip.Entries))
 	return gossip
 }
 

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -1,10 +1,7 @@
 package nameserver
 
 import (
-	"bytes"
-	"encoding/gob"
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 
@@ -205,15 +202,12 @@ func (n *Nameserver) OnGossipUnicast(sender router.PeerName, msg []byte) error {
 
 func (n *Nameserver) receiveGossip(msg []byte) (router.GossipData, router.GossipData, error) {
 	var gossip GossipData
-	if err := gob.NewDecoder(bytes.NewReader(msg)).Decode(&gossip); err != nil {
+	if err := gossip.Decode(msg); err != nil {
 		return nil, nil, err
 	}
-
 	if delta := gossip.Timestamp - now(); delta > gossipWindow || delta < -gossipWindow {
 		return nil, nil, fmt.Errorf("clock skew of %d detected", delta)
 	}
-
-	sort.Sort(CaseInsensitive(gossip.Entries))
 
 	n.Lock()
 	defer n.Unlock()

--- a/nameserver/nameserver_test.go
+++ b/nameserver/nameserver_test.go
@@ -83,6 +83,10 @@ func testNameservers(t *testing.T) {
 	lookupTimeout := 10 // ms
 	nameservers, grouter := makeNetwork(50)
 	defer stopNetwork(nameservers, grouter)
+	// This subset will sometimes lose touch with some of the others
+	badNameservers := nameservers[45:]
+	// This subset will remain well-connected, and we will deal mainly with them
+	nameservers = nameservers[:45]
 	nameserversByName := map[router.PeerName]*Nameserver{}
 	for _, n := range nameservers {
 		nameserversByName[n.ourName] = n
@@ -106,7 +110,13 @@ func testNameservers(t *testing.T) {
 	addMapping := func() {
 		nameserver := nameservers[rand.Intn(len(nameservers))]
 		addr := address.Address(rand.Int31())
-		hostname := fmt.Sprintf("hostname%d", rand.Int63())
+		// Create a hostname which has some upper and lowercase letters,
+		// and a unique number so we don't have to check if we allocated it already
+		randomBits := rand.Int63()
+		firstLetter := 'H' + (randomBits&1)*32
+		secondLetter := 'O' + (randomBits&2)*16
+		randomBits = randomBits >> 2
+		hostname := fmt.Sprintf("%c%cstname%d", firstLetter, secondLetter, randomBits)
 		mapping := mapping{hostname, []pair{{nameserver.ourName, addr}}}
 		mappings = append(mappings, mapping)
 
@@ -127,6 +137,12 @@ func testNameservers(t *testing.T) {
 
 		require.Nil(t, nameserver.AddEntry(mapping.hostname, "", nameserver.ourName, addr))
 		check(nameserver, mapping)
+	}
+
+	loseConnection := func() {
+		nameserver1 := badNameservers[rand.Intn(len(badNameservers))]
+		nameserver2 := nameservers[rand.Intn(len(nameservers))]
+		nameserver1.PeerGone(&router.Peer{Name: nameserver2.ourName})
 	}
 
 	deleteMapping := func() {
@@ -191,7 +207,10 @@ func testNameservers(t *testing.T) {
 		case 0.2 <= r && r < 0.3:
 			deleteMapping()
 
-		case 0.3 <= r && r < 0.9:
+		case 0.3 <= r && r < 0.35:
+			loseConnection()
+
+		case 0.35 <= r && r < 0.9:
 			doLookup()
 
 		case 0.9 <= r:

--- a/testing/gossip/mocks.go
+++ b/testing/gossip/mocks.go
@@ -97,7 +97,7 @@ type TestRouterClient struct {
 }
 
 func (grouter *TestRouter) run(sender router.PeerName, gossiper router.Gossiper, gossipChan chan interface{}) {
-	gossipTimer := time.Tick(10 * time.Second)
+	gossipTimer := time.Tick(2 * time.Second)
 	for {
 		select {
 		case gossip := <-gossipChan:


### PR DESCRIPTION
Instead of sorting when creating the outbound `GossipData` object, we sort in `Encode()`.
Fixes #1603 and #1610 