### PR TITLE
Observers for DNS names

### DIFF
--- a/nameserver/http_test.go
+++ b/nameserver/http_test.go
@@ -1,0 +1,111 @@
+package nameserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
+
+	"github.com/weaveworks/weave/net/address"
+	"github.com/weaveworks/weave/router"
+)
+
+func randRange(min, max int) int {
+	rand.Seed(time.Now().Unix())
+	return rand.Intn(max-min) + min
+}
+
+func TestHTTPWebSocket(t *testing.T) {
+	const (
+		name   = "some_host.weave.local."
+		origin = "http://localhost"
+	)
+
+	var (
+		port  = randRange(18080, 28080)
+		wsURL = fmt.Sprintf("ws://127.0.0.1:%d/name/ws", port)
+	)
+
+	// create the DNS server
+	peername, err := router.PeerNameFromString("00:00:00:02:00:00")
+	require.Nil(t, err)
+	nameserver := New(peername, "", func(router.PeerName) bool { return true })
+
+	// ... and the web server
+	muxRouter := mux.NewRouter()
+	nameserver.HandleHTTP(muxRouter, nil)
+	httpServer := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: muxRouter}
+	go func() {
+		err := httpServer.ListenAndServe()
+		require.Nil(t, err)
+	}()
+
+	time.Sleep(1 * time.Second) // give some time to the webserver to start up...
+
+	ws, err := websocket.Dial(wsURL, "", origin)
+	require.Nil(t, err)
+
+	waitForUpdates := func() []address.Address {
+		var msg = make([]byte, 512)
+		l, err := ws.Read(msg)
+		require.Nil(t, err)
+
+		var update struct {
+			Addresses []string
+		}
+		err = json.Unmarshal(msg[:l], &update)
+		if err == io.EOF {
+			ws.WriteClose(0)
+			return nil
+		}
+		require.Nil(t, err)
+
+		// convert the strings to address.Address
+		res := []address.Address{}
+		for _, v := range update.Addresses {
+			ipStr, err := address.ParseIP(v)
+			require.Nil(t, err)
+			res = append(res, ipStr)
+		}
+		return res
+	}
+
+	addr1 := address.Address(123456)
+	addr2 := address.Address(776688)
+
+	checkAddresses := func(have, expected []address.Address) {
+		if !reflect.DeepEqual(have, expected) {
+			t.Fail()
+		}
+	}
+
+	// Add an entry
+	err = nameserver.AddEntry(name, "containerid", peername, addr1)
+	require.Nil(t, err)
+
+	// ... send a "observe" request and get the current IPs
+	err = websocket.JSON.Send(ws, ObserveRequest{Name: name})
+	require.Nil(t, err)
+	have := waitForUpdates()
+	checkAddresses(have, []address.Address{addr1})
+
+	// ... add another IP to the same name
+	err = nameserver.AddEntry(name, "containerid", peername, addr2)
+	require.Nil(t, err)
+	have = waitForUpdates()
+	checkAddresses(have, []address.Address{addr1, addr2})
+
+	// ... and then we remove the entry
+	nameserver.ContainerDied("containerid")
+	require.Equal(t, []address.Address{}, nameserver.Lookup(name))
+	have = waitForUpdates()
+	checkAddresses(have, []address.Address{})
+}

--- a/nameserver/observer.go
+++ b/nameserver/observer.go
@@ -1,0 +1,116 @@
+package nameserver
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/miekg/dns"
+
+	"github.com/weaveworks/weave/net/address"
+)
+
+var (
+	errUnknownName = errors.New("unknown name")
+)
+
+func fqdnWithDomain(hostname string, domain string) string {
+	fqdnName := dns.Fqdn(hostname)
+	if !strings.HasSuffix(fqdnName, domain) { // "x." -> "x.weave.local.", "x.y." -> "x.y.weave.local."
+		fqdnName = fqdnName + domain
+	}
+	return fqdnName
+}
+
+// Observer is a name observer
+type Observer struct {
+	ID    string
+	Last  []address.Address
+	Addrs chan []address.Address
+}
+
+// NewObserver is an Observer constructor
+func NewObserver(id string) *Observer {
+	return &Observer{ID: id, Addrs: make(chan []address.Address)}
+}
+
+// Notify is a observer notifier
+func (obs *Observer) Notify(addrs []address.Address) {
+	if !reflect.DeepEqual(obs.Last, addrs) {
+		obs.Addrs <- addrs
+		obs.Last = make([]address.Address, len(addrs))
+		copy(obs.Last, addrs)
+	}
+}
+
+// Observers is the list of names that are being observed
+type Observers struct {
+	sync.RWMutex
+	ns  *Nameserver
+	obs map[string][]*Observer
+}
+
+// NewObservers is a Observers constructor
+func NewObservers(ns *Nameserver) *Observers {
+	return &Observers{
+		ns:  ns,
+		obs: make(map[string][]*Observer),
+	}
+}
+
+// Observe starts observing a name
+func (nobs *Observers) Observe(hostname, id string) (chan []address.Address, error) {
+	nobs.Lock()
+	defer nobs.Unlock()
+
+	hostname = fqdnWithDomain(hostname, nobs.ns.domain)
+
+	nobs.ns.debugf("%s is observing %s", id, hostname)
+	observer := NewObserver(id)
+	if _, found := nobs.obs[hostname]; found {
+		// TODO: check the (hostname, id) does not exist
+		nobs.obs[hostname] = append(nobs.obs[hostname], observer)
+	} else {
+		nobs.obs[hostname] = []*Observer{observer}
+	}
+	return observer.Addrs, nil
+}
+
+// Forget disconnects an observer from a name
+func (nobs *Observers) Forget(hostname, id string) {
+	nobs.Lock()
+	defer nobs.Unlock()
+
+	hostname = fqdnWithDomain(hostname, nobs.ns.domain)
+
+	observers, found := nobs.obs[hostname]
+	if !found {
+		return
+	}
+
+	// filter out the `id`
+	var newObservers []*Observer
+	for _, v := range observers {
+		if v.ID != id {
+			newObservers = append(newObservers, v)
+		}
+	}
+	nobs.obs[hostname] = newObservers
+}
+
+// Notify is a observers notifier
+func (nobs *Observers) Notify() {
+	nobs.Lock()
+	defer nobs.Unlock()
+
+	// we do not expect many observers (probably just a couple), so we just
+	// perform a lookups for all observed names...
+	// TODO: implement a proper observation mechanism
+	for hostname, observers := range nobs.obs {
+		for _, observer := range observers {
+			nobs.ns.debugf("Notifying observers of %s", hostname)
+			observer.Notify(nobs.ns.Lookup(hostname))
+		}
+	}
+}

--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -3,15 +3,17 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+	"text/template"
+
 	"github.com/gorilla/mux"
+
 	. "github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/ipam"
 	"github.com/weaveworks/weave/nameserver"
 	"github.com/weaveworks/weave/net/address"
 	weave "github.com/weaveworks/weave/router"
-	"net/http"
-	"strings"
-	"text/template"
 )
 
 var rootTemplate = template.New("root").Funcs(map[string]interface{}{


### PR DESCRIPTION
This PR implements 
- a simple mechanism for observing names in the DNS database.
- a websockets interface on the nameserver HTTP router for registering clients that want to observe names as well as for receiving updates.

I have taken several _short paths_ in this PR:
- updates are sent not as _diffs_ but as the whole list of IPs for the name being observed. This should not be a problem as we do not expect too many IPs for a name and it is a local TCP connection anyway, and _diffs_ would make things much harder on the client side.
- observers notifications are triggered after every DNS database modification. I didn't want to do invasive changes in the database code, and this shouldn't be a problem as we do not expect many observers anyway. This adds `n*lookup()` to `add`/`remove` operations in the database, where `n` is the number of different hostnames being observed...

Related to inercia/weave-nginx#3 (nginx side of things)

Closes #1591
