### PR TITLE
Bind router HTTP listener to localhost when fastdp enabled

### DIFF
--- a/site/features.md
+++ b/site/features.md
@@ -219,7 +219,7 @@ NB: By default docker permits communication between containers on the
 same host, via their docker-assigned IP addresses. For complete
 isolation between application containers, that feature needs to be
 disabled by
-[setting `--icc=false`](https://docs.docker.com/articles/networking/#between-containers)
+[setting `--icc=false`](https://docs.docker.com/engine/userguide/networking/default_network/container-communication/#communication-between-containers)
 in the docker daemon configuration. Furthermore, containers should be
 prevented from capturing and injecting raw network packets - this can
 be accomplished by starting them with the `--cap-drop net_raw` option.
@@ -306,6 +306,14 @@ The same password must be specified for all weave peers. Note that
 supplying a password will [cause weave to fall back to a slower
 method](#fast-data-path) for transporting data between
 peers.
+
+Be aware that:
+
+* Containers will be able to access the router REST API if you have
+  disabled fast datapath. You can prevent this by setting
+  [`--icc=false`](https://docs.docker.com/engine/userguide/networking/default_network/container-communication/#communication-between-containers)
+* Containers are able to access the router control and data plane
+  ports, but you can mitigate this by enabling encryption
 
 ### <a name="host-network-integration"></a>Host network integration
 

--- a/weave
+++ b/weave
@@ -1481,7 +1481,7 @@ launch_router() {
         $(router_opts_$BRIDGE_TYPE) \
         --ipalloc-range "$IPRANGE" \
         --dns-effective-listen-address $DOCKER_BRIDGE_IP \
-        ${NETHOST_OPT:+$DNS_ROUTER_OPTS} $NO_DNS_OPT \
+        ${NETHOST_OPT:+$DNS_ROUTER_OPTS --http-addr 127.0.0.1:$HTTP_PORT} $NO_DNS_OPT \
         --docker-api "unix:///var/run/docker.sock" "$@")
     with_container_netns_or_die $CONTAINER_NAME setup_router_iface_$BRIDGE_TYPE
     attach_router


### PR DESCRIPTION
Prevent containers from accessing the weave router control port when fast datapath is in use.

Fixes #1632.