### PR TITLE
separate the control and data planes

### DIFF
--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -151,7 +151,7 @@ type WeaveStatus struct {
 	DNS     *nameserver.Status `json:"DNS,omitempty"`
 }
 
-func HandleHTTP(muxRouter *mux.Router, version string, router *weave.Router, allocator *ipam.Allocator, defaultSubnet address.CIDR, ns *nameserver.Nameserver, dnsserver *nameserver.DNSServer) {
+func HandleHTTP(muxRouter *mux.Router, version string, router *weave.NetworkRouter, allocator *ipam.Allocator, defaultSubnet address.CIDR, ns *nameserver.Nameserver, dnsserver *nameserver.DNSServer) {
 	status := func() WeaveStatus {
 		return WeaveStatus{
 			version,

--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -146,16 +146,16 @@ var dnsEntriesTemplate = defTemplate("dnsEntries", `\
 
 type WeaveStatus struct {
 	Version string
-	Router  *weave.Status      `json:"Router,omitempty"`
-	IPAM    *ipam.Status       `json:"IPAM,omitempty"`
-	DNS     *nameserver.Status `json:"DNS,omitempty"`
+	Router  *weave.NetworkRouterStatus `json:"Router,omitempty"`
+	IPAM    *ipam.Status               `json:"IPAM,omitempty"`
+	DNS     *nameserver.Status         `json:"DNS,omitempty"`
 }
 
 func HandleHTTP(muxRouter *mux.Router, version string, router *weave.NetworkRouter, allocator *ipam.Allocator, defaultSubnet address.CIDR, ns *nameserver.Nameserver, dnsserver *nameserver.DNSServer) {
 	status := func() WeaveStatus {
 		return WeaveStatus{
 			version,
-			weave.NewStatus(router),
+			weave.NewNetworkRouterStatus(router),
 			ipam.NewStatus(allocator, defaultSubnet),
 			nameserver.NewStatus(ns, dnsserver)}
 	}

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -150,7 +150,7 @@ func main() {
 	}
 	config.ProtocolMinVersion = byte(protocolMinVersion)
 
-	var fastDPOverlay weave.Overlay
+	var fastDPOverlay weave.NetworkOverlay
 	if datapathName != "" {
 		// A datapath name implies that "Bridge" and "Overlay"
 		// packet handling use fast datapath, although other

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -506,7 +506,7 @@ type fastDatapathForwarder struct {
 	errorChan       chan error
 }
 
-func (fastdp fastDatapathOverlay) MakeForwarder(params ForwarderParams) (OverlayForwarder, error) {
+func (fastdp fastDatapathOverlay) PrepareConnection(params OverlayConnectionParams) (OverlayConnection, error) {
 	if params.SessionKey != nil {
 		// No encryption suport in fastdp.  The weaver main.go
 		// is responsible for ensuring this doesn't happen.

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -297,7 +297,7 @@ type fastDatapathOverlay struct {
 	*FastDatapath
 }
 
-func (fastdp *FastDatapath) Overlay() Overlay {
+func (fastdp *FastDatapath) Overlay() NetworkOverlay {
 	return fastDatapathOverlay{fastdp}
 }
 

--- a/router/network_overlay.go
+++ b/router/network_overlay.go
@@ -1,0 +1,46 @@
+package router
+
+// Interface to overlay network packet handling
+type NetworkOverlay interface {
+	Overlay
+
+	// The routes have changed, so any cached information should
+	// be discarded.
+	InvalidateRoutes()
+
+	// A mapping of a short id to a peer has changed
+	InvalidateShortIDs()
+
+	// Start consuming forwarded packets.
+	StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error
+}
+
+// When a consumer is called, the decoder will already have been used
+// to decode the frame.
+type OverlayConsumer func(ForwardPacketKey) FlowOp
+
+// All of the machinery to forward packets to a particular peer
+type OverlayForwarder interface {
+	OverlayConnection
+	// Forward a packet across the connection.  May be called as soon
+	// as the overlay connection is created, in particular before
+	// Confirm().  The return value nil means the key could not be
+	// handled by this forwarder.
+	Forward(ForwardPacketKey) FlowOp
+}
+
+type NullNetworkOverlay struct{ NullOverlay }
+
+func (NullNetworkOverlay) InvalidateRoutes() {
+}
+
+func (NullNetworkOverlay) InvalidateShortIDs() {
+}
+
+func (NullNetworkOverlay) StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error {
+	return nil
+}
+
+func (NullNetworkOverlay) Forward(ForwardPacketKey) FlowOp {
+	return DiscardingFlowOp{}
+}

--- a/router/network_router.go
+++ b/router/network_router.go
@@ -1,0 +1,196 @@
+package router
+
+import (
+	"net"
+	"time"
+)
+
+const (
+	MaxUDPPacketSize    = 65535
+	FastHeartbeat       = 500 * time.Millisecond
+	SlowHeartbeat       = 10 * time.Second
+	MaxMissedHeartbeats = 6
+	HeartbeatTimeout    = MaxMissedHeartbeats * SlowHeartbeat
+	// should be greater than typical ARP cache expiries, i.e. > 3/2 *
+	// /proc/sys/net/ipv4_neigh/*/base_reachable_time_ms on Linux
+	macMaxAge = 10 * time.Minute
+)
+
+type NetworkConfig struct {
+	BufSz         int
+	PacketLogging PacketLogging
+	Bridge        Bridge
+}
+
+type PacketLogging interface {
+	LogPacket(string, PacketKey)
+	LogForwardPacket(string, ForwardPacketKey)
+}
+
+type NetworkRouter struct {
+	*Router
+	NetworkConfig
+	Macs *MacCache
+}
+
+func NewNetworkRouter(config Config, networkConfig NetworkConfig, name PeerName, nickName string, overlay NetworkOverlay) *NetworkRouter {
+	if overlay == nil {
+		overlay = NullNetworkOverlay{}
+	}
+	if networkConfig.Bridge == nil {
+		networkConfig.Bridge = NullBridge{}
+	}
+
+	router := &NetworkRouter{Router: NewRouter(config, name, nickName, overlay), NetworkConfig: networkConfig}
+	router.Peers.OnInvalidateShortIDs(overlay.InvalidateShortIDs)
+	router.Routes.OnChange(overlay.InvalidateRoutes)
+	router.Macs = NewMacCache(macMaxAge,
+		func(mac net.HardwareAddr, peer *Peer) {
+			log.Println("Expired MAC", mac, "at", peer)
+		})
+	router.Peers.OnGC(func(peer *Peer) { router.Macs.Delete(peer) })
+	return router
+}
+
+// Start listening for TCP connections, locally captured packets, and
+// forwarded packets.
+func (router *NetworkRouter) Start() {
+	log.Println("Sniffing traffic on", router.Bridge)
+	checkFatal(router.Bridge.StartConsumingPackets(router.handleCapturedPacket))
+	checkFatal(router.Overlay.(NetworkOverlay).StartConsumingPackets(router.Ourself.Peer, router.Peers, router.handleForwardedPacket))
+	router.Router.Start()
+}
+
+func (router *NetworkRouter) handleCapturedPacket(key PacketKey) FlowOp {
+	router.PacketLogging.LogPacket("Captured", key)
+	srcMac := net.HardwareAddr(key.SrcMAC[:])
+
+	switch newSrcMac, conflictPeer := router.Macs.Add(srcMac, router.Ourself.Peer); {
+	case newSrcMac:
+		log.Println("Discovered local MAC", srcMac)
+
+	case conflictPeer != nil:
+		// The MAC cache has an entry for the source MAC
+		// associated with another peer.  This probably means
+		// we are seeing a frame we injected ourself.  That
+		// shouldn't happen, but discard it just in case.
+		log.Error("Captured frame from MAC (", srcMac, ") associated with another peer ", conflictPeer)
+		return DiscardingFlowOp{}
+	}
+
+	// Discard STP broadcasts
+	if key.DstMAC == [...]byte{0x01, 0x80, 0xC2, 0x00, 0x00, 0x00} {
+		return DiscardingFlowOp{}
+	}
+
+	dstMac := net.HardwareAddr(key.DstMAC[:])
+	switch dstPeer := router.Macs.Lookup(dstMac); dstPeer {
+	case router.Ourself.Peer:
+		// The packet is destined for a local MAC.  The bridge
+		// won't normally send us such packets, and if it does
+		// it's likely to be broadcasting the packet to all
+		// ports.  So if it happens, just drop the packet to
+		// avoid warnings if we try to forward it.
+		return DiscardingFlowOp{}
+	case nil:
+		// If we don't know which peer corresponds to the dest
+		// MAC, broadcast it.
+		router.PacketLogging.LogPacket("Broadcasting", key)
+		return router.relayBroadcast(router.Ourself.Peer, key)
+	default:
+		router.PacketLogging.LogPacket("Forwarding", key)
+		return router.relay(ForwardPacketKey{
+			PacketKey: key,
+			SrcPeer:   router.Ourself.Peer,
+			DstPeer:   dstPeer})
+	}
+}
+
+func (router *NetworkRouter) handleForwardedPacket(key ForwardPacketKey) FlowOp {
+	if key.DstPeer != router.Ourself.Peer {
+		// it's not for us, we're just relaying it
+		router.PacketLogging.LogForwardPacket("Relaying", key)
+		return router.relay(key)
+	}
+
+	// At this point, it's either unicast to us, or a broadcast
+	// (because the DstPeer on a forwarded broadcast packet is
+	// always set to the peer being forwarded to)
+
+	srcMac := net.HardwareAddr(key.SrcMAC[:])
+	dstMac := net.HardwareAddr(key.DstMAC[:])
+
+	switch newSrcMac, conflictPeer := router.Macs.AddForced(srcMac, key.SrcPeer); {
+	case newSrcMac:
+		log.Print("Discovered remote MAC ", srcMac, " at ", key.SrcPeer)
+
+	case conflictPeer != nil:
+		log.Print("Discovered remote MAC ", srcMac, " at ", key.SrcPeer, " (was at ", conflictPeer, ")")
+
+		// We need to clear out any flows destined to the MAC
+		// that forward to the old peer.
+		router.Overlay.(NetworkOverlay).InvalidateRoutes()
+	}
+
+	router.PacketLogging.LogForwardPacket("Injecting", key)
+	injectFop := router.Bridge.InjectPacket(key.PacketKey)
+	dstPeer := router.Macs.Lookup(dstMac)
+	if dstPeer == router.Ourself.Peer {
+		return injectFop
+	}
+
+	router.PacketLogging.LogForwardPacket("Relaying broadcast", key)
+	relayFop := router.relayBroadcast(key.SrcPeer, key.PacketKey)
+	switch {
+	case injectFop == nil:
+		return relayFop
+
+	case relayFop == nil:
+		return injectFop
+
+	default:
+		mfop := NewMultiFlowOp(false)
+		mfop.Add(injectFop)
+		mfop.Add(relayFop)
+		return mfop
+	}
+}
+
+// Routing
+
+func (router *NetworkRouter) relay(key ForwardPacketKey) FlowOp {
+	relayPeerName, found := router.Routes.Unicast(key.DstPeer.Name)
+	if !found {
+		// Not necessarily an error as there could be a race with the
+		// dst disappearing whilst the frame is in flight
+		log.Println("Received packet for unknown destination:", key.DstPeer)
+		return DiscardingFlowOp{}
+	}
+
+	conn, found := router.Ourself.ConnectionTo(relayPeerName)
+	if !found {
+		// Again, could just be a race, not necessarily an error
+		log.Println("Unable to find connection to relay peer", relayPeerName)
+		return DiscardingFlowOp{}
+	}
+
+	return conn.(*LocalConnection).OverlayConn.(OverlayForwarder).Forward(key)
+}
+
+func (router *NetworkRouter) relayBroadcast(srcPeer *Peer, key PacketKey) FlowOp {
+	nextHops := router.Routes.Broadcast(srcPeer.Name)
+	if len(nextHops) == 0 {
+		return DiscardingFlowOp{}
+	}
+
+	op := NewMultiFlowOp(true)
+
+	for _, conn := range router.Ourself.ConnectionsTo(nextHops) {
+		op.Add(conn.(*LocalConnection).OverlayConn.(OverlayForwarder).Forward(ForwardPacketKey{
+			PacketKey: key,
+			SrcPeer:   srcPeer,
+			DstPeer:   conn.Remote()}))
+	}
+
+	return op
+}

--- a/router/network_router_status.go
+++ b/router/network_router_status.go
@@ -1,0 +1,43 @@
+package router
+
+import (
+	"time"
+)
+
+type NetworkRouterStatus struct {
+	*Status
+	Interface    string
+	CaptureStats map[string]int
+	MACs         []MACStatus
+}
+
+type MACStatus struct {
+	Mac      string
+	Name     string
+	NickName string
+	LastSeen time.Time
+}
+
+func NewNetworkRouterStatus(router *NetworkRouter) *NetworkRouterStatus {
+	return &NetworkRouterStatus{
+		NewStatus(router.Router),
+		router.Bridge.String(),
+		router.Bridge.Stats(),
+		NewMACStatusSlice(router.Macs)}
+}
+
+func NewMACStatusSlice(cache *MacCache) []MACStatus {
+	cache.RLock()
+	defer cache.RUnlock()
+
+	var slice []MACStatus
+	for key, entry := range cache.table {
+		slice = append(slice, MACStatus{
+			intmac(key).String(),
+			entry.peer.Name.String(),
+			entry.peer.NickName,
+			entry.lastSeen})
+	}
+
+	return slice
+}

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -16,21 +16,6 @@ type Overlay interface {
 	Diagnostics() interface{}
 }
 
-// Interface to overlay network packet handling
-type NetworkOverlay interface {
-	Overlay
-
-	// The routes have changed, so any cached information should
-	// be discarded.
-	InvalidateRoutes()
-
-	// A mapping of a short id to a peer has changed
-	InvalidateShortIDs()
-
-	// Start consuming forwarded packets.
-	StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error
-}
-
 type OverlayConnectionParams struct {
 	RemotePeer *Peer
 
@@ -62,10 +47,6 @@ type OverlayConnectionParams struct {
 	Features map[string]string
 }
 
-// When a consumer is called, the decoder will already have been used
-// to decode the frame.
-type OverlayConsumer func(ForwardPacketKey) FlowOp
-
 // All of the machinery to manage overlay connectivity to a particular
 // peer
 type OverlayConnection interface {
@@ -93,16 +74,6 @@ type OverlayConnection interface {
 
 	// User facing overlay name
 	DisplayName() string
-}
-
-// All of the machinery to forward packets to a particular peer
-type OverlayForwarder interface {
-	OverlayConnection
-	// Forward a packet across the connection.  May be called as soon
-	// as the overlay connection is created, in particular before
-	// Confirm().  The return value nil means the key could not be
-	// handled by this forwarder.
-	Forward(ForwardPacketKey) FlowOp
 }
 
 type NullOverlay struct{}
@@ -136,20 +107,4 @@ func (NullOverlay) ControlMessage(byte, []byte) {
 
 func (NullOverlay) DisplayName() string {
 	return "null"
-}
-
-type NullNetworkOverlay struct{ NullOverlay }
-
-func (NullNetworkOverlay) InvalidateRoutes() {
-}
-
-func (NullNetworkOverlay) InvalidateShortIDs() {
-}
-
-func (NullNetworkOverlay) StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error {
-	return nil
-}
-
-func (NullNetworkOverlay) Forward(ForwardPacketKey) FlowOp {
-	return DiscardingFlowOp{}
 }

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -4,14 +4,21 @@ import (
 	"net"
 )
 
-// Interface to overlay network packet handling
 type Overlay interface {
-	// Start consuming forwarded packets.
-	StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error
+	// Enhance a features map with overlay-related features
+	AddFeaturesTo(map[string]string)
 
 	// Prepare on overlay connection. The connection should remain
 	// passive until it has been Confirm()ed.
 	PrepareConnection(OverlayConnectionParams) (OverlayConnection, error)
+
+	// Obtain diagnostic information specific to the overlay
+	Diagnostics() interface{}
+}
+
+// Interface to overlay network packet handling
+type NetworkOverlay interface {
+	Overlay
 
 	// The routes have changed, so any cached information should
 	// be discarded.
@@ -20,11 +27,8 @@ type Overlay interface {
 	// A mapping of a short id to a peer has changed
 	InvalidateShortIDs()
 
-	// Enhance a features map with overlay-related features
-	AddFeaturesTo(map[string]string)
-
-	// Obtain diagnostic information specific to the overlay
-	Diagnostics() interface{}
+	// Start consuming forwarded packets.
+	StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error
 }
 
 type OverlayConnectionParams struct {

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -107,20 +107,16 @@ type OverlayForwarder interface {
 
 type NullOverlay struct{}
 
-func (NullOverlay) StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error {
-	return nil
+func (NullOverlay) AddFeaturesTo(map[string]string) {
 }
 
 func (NullOverlay) PrepareConnection(OverlayConnectionParams) (OverlayConnection, error) {
 	return NullOverlay{}, nil
 }
 
-func (NullOverlay) InvalidateRoutes() {
+func (NullOverlay) Diagnostics() interface{} {
+	return nil
 }
-
-func (NullOverlay) InvalidateShortIDs() {
-}
-
 func (NullOverlay) Confirm() {
 }
 
@@ -130,13 +126,6 @@ func (NullOverlay) EstablishedChannel() <-chan struct{} {
 
 func (NullOverlay) ErrorChannel() <-chan error {
 	return nil
-}
-
-func (NullOverlay) AddFeaturesTo(map[string]string) {
-}
-
-func (NullOverlay) Forward(ForwardPacketKey) FlowOp {
-	return DiscardingFlowOp{}
 }
 
 func (NullOverlay) Stop() {
@@ -149,6 +138,18 @@ func (NullOverlay) DisplayName() string {
 	return "null"
 }
 
-func (NullOverlay) Diagnostics() interface{} {
+type NullNetworkOverlay struct{ NullOverlay }
+
+func (NullNetworkOverlay) InvalidateRoutes() {
+}
+
+func (NullNetworkOverlay) InvalidateShortIDs() {
+}
+
+func (NullNetworkOverlay) StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error {
 	return nil
+}
+
+func (NullNetworkOverlay) Forward(ForwardPacketKey) FlowOp {
+	return DiscardingFlowOp{}
 }

--- a/router/overlay.go
+++ b/router/overlay.go
@@ -9,8 +9,9 @@ type Overlay interface {
 	// Start consuming forwarded packets.
 	StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error
 
-	// Form a packet-forwarding connection.
-	MakeForwarder(ForwarderParams) (OverlayForwarder, error)
+	// Prepare on overlay connection. The connection should remain
+	// passive until it has been Confirm()ed.
+	PrepareConnection(OverlayConnectionParams) (OverlayConnection, error)
 
 	// The routes have changed, so any cached information should
 	// be discarded.
@@ -26,12 +27,12 @@ type Overlay interface {
 	Diagnostics() interface{}
 }
 
-type ForwarderParams struct {
+type OverlayConnectionParams struct {
 	RemotePeer *Peer
 
 	// The local address of the corresponding TCP connection. Used to
 	// derive the local IP address for sending. May differ for
-	// different forwarders.
+	// different overlay connections.
 	LocalAddr *net.TCPAddr
 
 	// The remote address of the corresponding TCP connection. Used to
@@ -50,7 +51,7 @@ type ForwarderParams struct {
 	SessionKey *[32]byte
 
 	// Function to send a control message to the counterpart
-	// forwarder.
+	// overlay connection.
 	SendControlMessage func(tag byte, msg []byte) error
 
 	// Features passed at connection initiation
@@ -61,26 +62,22 @@ type ForwarderParams struct {
 // to decode the frame.
 type OverlayConsumer func(ForwardPacketKey) FlowOp
 
-// All of the machinery to forward packets to a particular peer
-type OverlayForwarder interface {
-	// Forward a packet across the connection.  May be called as
-	// soon as the forwarder is created, in particular before
-	// Confirm().  The return value nil means the key could not be
-	// handled by this forwarder.
-	Forward(ForwardPacketKey) FlowOp
-
+// All of the machinery to manage overlay connectivity to a particular
+// peer
+type OverlayConnection interface {
 	// Confirm that the connection is really wanted, and so the
-	// Overlay should begin heartbeats etc. to verify the
-	// operation of the forwarder.
+	// Overlay should begin heartbeats etc. to verify the operation of
+	// the overlay connection.
 	Confirm()
 
-	// A channel indicating that the forwarder is established,
-	// i.e. its operation has been confirmed.
+	// A channel indicating that the overlay connection is
+	// established, i.e. its operation has been confirmed.
 	EstablishedChannel() <-chan struct{}
 
-	// A channel indicating an error from the forwarder.  The
-	// forwarder is not expected to be operational after the first
-	// error, so the channel only needs to buffer a single error.
+	// A channel indicating an error from the overlay connection.  The
+	// overlay connection is not expected to be operational after the
+	// first error, so the channel only needs to buffer a single
+	// error.
 	ErrorChannel() <-chan error
 
 	Stop()
@@ -94,13 +91,23 @@ type OverlayForwarder interface {
 	DisplayName() string
 }
 
+// All of the machinery to forward packets to a particular peer
+type OverlayForwarder interface {
+	OverlayConnection
+	// Forward a packet across the connection.  May be called as soon
+	// as the overlay connection is created, in particular before
+	// Confirm().  The return value nil means the key could not be
+	// handled by this forwarder.
+	Forward(ForwardPacketKey) FlowOp
+}
+
 type NullOverlay struct{}
 
 func (NullOverlay) StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error {
 	return nil
 }
 
-func (NullOverlay) MakeForwarder(ForwarderParams) (OverlayForwarder, error) {
+func (NullOverlay) PrepareConnection(OverlayConnectionParams) (OverlayConnection, error) {
 	return NullOverlay{}, nil
 }
 

--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -13,16 +13,16 @@ import (
 // uses the best one that seems to be working.
 
 type OverlaySwitch struct {
-	overlays      map[string]Overlay
+	overlays      map[string]NetworkOverlay
 	overlayNames  []string
-	compatOverlay Overlay
+	compatOverlay NetworkOverlay
 }
 
 func NewOverlaySwitch() *OverlaySwitch {
-	return &OverlaySwitch{overlays: make(map[string]Overlay)}
+	return &OverlaySwitch{overlays: make(map[string]NetworkOverlay)}
 }
 
-func (osw *OverlaySwitch) Add(name string, overlay Overlay) {
+func (osw *OverlaySwitch) Add(name string, overlay NetworkOverlay) {
 	// check for repeated names
 	if _, present := osw.overlays[name]; present {
 		log.Fatal("OverlaySwitch: repeated overlay name")
@@ -32,7 +32,7 @@ func (osw *OverlaySwitch) Add(name string, overlay Overlay) {
 	osw.overlayNames = append(osw.overlayNames, name)
 }
 
-func (osw *OverlaySwitch) SetCompatOverlay(overlay Overlay) {
+func (osw *OverlaySwitch) SetCompatOverlay(overlay NetworkOverlay) {
 	osw.compatOverlay = overlay
 }
 
@@ -70,7 +70,7 @@ func (osw *OverlaySwitch) StartConsumingPackets(localPeer *Peer, peers *Peers, c
 }
 
 type namedOverlay struct {
-	Overlay
+	NetworkOverlay
 	name string
 }
 
@@ -82,7 +82,7 @@ func (osw *OverlaySwitch) commonOverlays(params OverlayConnectionParams) ([]name
 		peerOverlays = strings.Split(overlaysFeature, " ")
 	}
 
-	common := make(map[string]Overlay)
+	common := make(map[string]NetworkOverlay)
 	for _, name := range peerOverlays {
 		if overlay := osw.overlays[name]; overlay != nil {
 			common[name] = overlay

--- a/router/router.go
+++ b/router/router.go
@@ -78,7 +78,7 @@ func NewRouter(config Config, name PeerName, nickName string, overlay NetworkOve
 	}
 
 	if overlay == nil {
-		overlay = NullOverlay{}
+		overlay = NullNetworkOverlay{}
 	}
 
 	router.Overlay = overlay

--- a/router/router.go
+++ b/router/router.go
@@ -263,7 +263,7 @@ func (router *Router) relay(key ForwardPacketKey) FlowOp {
 		return DiscardingFlowOp{}
 	}
 
-	return conn.(*LocalConnection).forwarder.Forward(key)
+	return conn.(*LocalConnection).OverlayConn.(OverlayForwarder).Forward(key)
 }
 
 func (router *Router) relayBroadcast(srcPeer *Peer, key PacketKey) FlowOp {
@@ -275,7 +275,7 @@ func (router *Router) relayBroadcast(srcPeer *Peer, key PacketKey) FlowOp {
 	op := NewMultiFlowOp(true)
 
 	for _, conn := range router.Ourself.ConnectionsTo(nextHops) {
-		op.Add(conn.(*LocalConnection).forwarder.Forward(ForwardPacketKey{
+		op.Add(conn.(*LocalConnection).OverlayConn.(OverlayForwarder).Forward(ForwardPacketKey{
 			PacketKey: key,
 			SrcPeer:   srcPeer,
 			DstPeer:   conn.Remote()}))

--- a/router/router.go
+++ b/router/router.go
@@ -70,7 +70,7 @@ type Router struct {
 	acceptLimiter   *TokenBucket
 }
 
-func NewRouter(config Config, name PeerName, nickName string, overlay Overlay) *Router {
+func NewRouter(config Config, name PeerName, nickName string, overlay NetworkOverlay) *Router {
 	router := &Router{Config: config, gossipChannels: make(GossipChannels)}
 
 	if router.Bridge == nil {
@@ -108,7 +108,7 @@ func NewRouter(config Config, name PeerName, nickName string, overlay Overlay) *
 func (router *Router) Start() {
 	log.Println("Sniffing traffic on", router.Bridge)
 	checkFatal(router.Bridge.StartConsumingPackets(router.handleCapturedPacket))
-	checkFatal(router.Overlay.StartConsumingPackets(router.Ourself.Peer, router.Peers, router.handleForwardedPacket))
+	checkFatal(router.Overlay.(NetworkOverlay).StartConsumingPackets(router.Ourself.Peer, router.Peers, router.handleForwardedPacket))
 	router.listenTCP(router.Port)
 }
 
@@ -218,7 +218,7 @@ func (router *Router) handleForwardedPacket(key ForwardPacketKey) FlowOp {
 
 		// We need to clear out any flows destined to the MAC
 		// that forward to the old peer.
-		router.Overlay.InvalidateRoutes()
+		router.Overlay.(NetworkOverlay).InvalidateRoutes()
 	}
 
 	router.PacketLogging.LogForwardPacket("Injecting", key)

--- a/router/router.go
+++ b/router/router.go
@@ -11,28 +11,19 @@ import (
 )
 
 const (
-	Port                = 6783
-	MaxUDPPacketSize    = 65535
-	ChannelSize         = 16
-	TCPHeartbeat        = 30 * time.Second
-	GossipInterval      = 30 * time.Second
-	MaxDuration         = time.Duration(math.MaxInt64)
-	FastHeartbeat       = 500 * time.Millisecond
-	SlowHeartbeat       = 10 * time.Second
-	MaxMissedHeartbeats = 6
-	HeartbeatTimeout    = MaxMissedHeartbeats * SlowHeartbeat
+	Port           = 6783
+	ChannelSize    = 16
+	TCPHeartbeat   = 30 * time.Second
+	GossipInterval = 30 * time.Second
+	MaxDuration    = time.Duration(math.MaxInt64)
 
-	macMaxAge        = 10 * time.Minute       // [1]
-	acceptMaxTokens  = 100                    // [2]
-	acceptTokenDelay = 100 * time.Millisecond // [3]
+	acceptMaxTokens  = 100                    // [1]
+	acceptTokenDelay = 100 * time.Millisecond // [2]
 )
 
-// [1] should be greater than typical ARP cache expiries, i.e. > 3/2 *
-// /proc/sys/net/ipv4_neigh/*/base_reachable_time_ms on Linux
+// [1] capacity of token bucket for rate limiting accepts
 
-// [2] capacity of token bucket for rate limiting accepts
-
-// [3] control rate at which new tokens are added to the bucket
+// [2] control rate at which new tokens are added to the bucket
 
 var (
 	log        = common.Log
@@ -46,17 +37,6 @@ type Config struct {
 	Password           []byte
 	ConnLimit          int
 	PeerDiscovery      bool
-}
-
-type NetworkConfig struct {
-	BufSz         int
-	PacketLogging PacketLogging
-	Bridge        Bridge
-}
-
-type PacketLogging interface {
-	LogPacket(string, PacketKey)
-	LogForwardPacket(string, ForwardPacketKey)
 }
 
 type Router struct {
@@ -93,45 +73,11 @@ func NewRouter(config Config, name PeerName, nickName string, overlay Overlay) *
 	return router
 }
 
-type NetworkRouter struct {
-	*Router
-	NetworkConfig
-	Macs *MacCache
-}
-
-func NewNetworkRouter(config Config, networkConfig NetworkConfig, name PeerName, nickName string, overlay NetworkOverlay) *NetworkRouter {
-	if overlay == nil {
-		overlay = NullNetworkOverlay{}
-	}
-	if networkConfig.Bridge == nil {
-		networkConfig.Bridge = NullBridge{}
-	}
-
-	router := &NetworkRouter{Router: NewRouter(config, name, nickName, overlay), NetworkConfig: networkConfig}
-	router.Peers.OnInvalidateShortIDs(overlay.InvalidateShortIDs)
-	router.Routes.OnChange(overlay.InvalidateRoutes)
-	router.Macs = NewMacCache(macMaxAge,
-		func(mac net.HardwareAddr, peer *Peer) {
-			log.Println("Expired MAC", mac, "at", peer)
-		})
-	router.Peers.OnGC(func(peer *Peer) { router.Macs.Delete(peer) })
-	return router
-}
-
 // Start listening for TCP connections. This is separate from
 // NewRouter so that gossipers can register before we start forming
 // connections.
 func (router *Router) Start() {
 	router.listenTCP(router.Port)
-}
-
-// Start listening for TCP connections, locally captured packets, and
-// forwarded packets.
-func (router *NetworkRouter) Start() {
-	log.Println("Sniffing traffic on", router.Bridge)
-	checkFatal(router.Bridge.StartConsumingPackets(router.handleCapturedPacket))
-	checkFatal(router.Overlay.(NetworkOverlay).StartConsumingPackets(router.Ourself.Peer, router.Peers, router.handleForwardedPacket))
-	router.Router.Start()
 }
 
 func (router *Router) Stop() error {
@@ -141,51 +87,6 @@ func (router *Router) Stop() error {
 
 func (router *Router) UsingPassword() bool {
 	return router.Password != nil
-}
-
-func (router *NetworkRouter) handleCapturedPacket(key PacketKey) FlowOp {
-	router.PacketLogging.LogPacket("Captured", key)
-	srcMac := net.HardwareAddr(key.SrcMAC[:])
-
-	switch newSrcMac, conflictPeer := router.Macs.Add(srcMac, router.Ourself.Peer); {
-	case newSrcMac:
-		log.Println("Discovered local MAC", srcMac)
-
-	case conflictPeer != nil:
-		// The MAC cache has an entry for the source MAC
-		// associated with another peer.  This probably means
-		// we are seeing a frame we injected ourself.  That
-		// shouldn't happen, but discard it just in case.
-		log.Error("Captured frame from MAC (", srcMac, ") associated with another peer ", conflictPeer)
-		return DiscardingFlowOp{}
-	}
-
-	// Discard STP broadcasts
-	if key.DstMAC == [...]byte{0x01, 0x80, 0xC2, 0x00, 0x00, 0x00} {
-		return DiscardingFlowOp{}
-	}
-
-	dstMac := net.HardwareAddr(key.DstMAC[:])
-	switch dstPeer := router.Macs.Lookup(dstMac); dstPeer {
-	case router.Ourself.Peer:
-		// The packet is destined for a local MAC.  The bridge
-		// won't normally send us such packets, and if it does
-		// it's likely to be broadcasting the packet to all
-		// ports.  So if it happens, just drop the packet to
-		// avoid warnings if we try to forward it.
-		return DiscardingFlowOp{}
-	case nil:
-		// If we don't know which peer corresponds to the dest
-		// MAC, broadcast it.
-		router.PacketLogging.LogPacket("Broadcasting", key)
-		return router.relayBroadcast(router.Ourself.Peer, key)
-	default:
-		router.PacketLogging.LogPacket("Forwarding", key)
-		return router.relay(ForwardPacketKey{
-			PacketKey: key,
-			SrcPeer:   router.Ourself.Peer,
-			DstPeer:   dstPeer})
-	}
 }
 
 func (router *Router) listenTCP(localPort int) {
@@ -215,95 +116,6 @@ func (router *Router) acceptTCP(tcpConn *net.TCPConn) {
 	log.Printf("->[%s] connection accepted", remoteAddrStr)
 	connRemote := NewRemoteConnection(router.Ourself.Peer, nil, remoteAddrStr, false, false)
 	StartLocalConnection(connRemote, tcpConn, router, true)
-}
-
-func (router *NetworkRouter) handleForwardedPacket(key ForwardPacketKey) FlowOp {
-	if key.DstPeer != router.Ourself.Peer {
-		// it's not for us, we're just relaying it
-		router.PacketLogging.LogForwardPacket("Relaying", key)
-		return router.relay(key)
-	}
-
-	// At this point, it's either unicast to us, or a broadcast
-	// (because the DstPeer on a forwarded broadcast packet is
-	// always set to the peer being forwarded to)
-
-	srcMac := net.HardwareAddr(key.SrcMAC[:])
-	dstMac := net.HardwareAddr(key.DstMAC[:])
-
-	switch newSrcMac, conflictPeer := router.Macs.AddForced(srcMac, key.SrcPeer); {
-	case newSrcMac:
-		log.Print("Discovered remote MAC ", srcMac, " at ", key.SrcPeer)
-
-	case conflictPeer != nil:
-		log.Print("Discovered remote MAC ", srcMac, " at ", key.SrcPeer, " (was at ", conflictPeer, ")")
-
-		// We need to clear out any flows destined to the MAC
-		// that forward to the old peer.
-		router.Overlay.(NetworkOverlay).InvalidateRoutes()
-	}
-
-	router.PacketLogging.LogForwardPacket("Injecting", key)
-	injectFop := router.Bridge.InjectPacket(key.PacketKey)
-	dstPeer := router.Macs.Lookup(dstMac)
-	if dstPeer == router.Ourself.Peer {
-		return injectFop
-	}
-
-	router.PacketLogging.LogForwardPacket("Relaying broadcast", key)
-	relayFop := router.relayBroadcast(key.SrcPeer, key.PacketKey)
-	switch {
-	case injectFop == nil:
-		return relayFop
-
-	case relayFop == nil:
-		return injectFop
-
-	default:
-		mfop := NewMultiFlowOp(false)
-		mfop.Add(injectFop)
-		mfop.Add(relayFop)
-		return mfop
-	}
-}
-
-// Routing
-
-func (router *NetworkRouter) relay(key ForwardPacketKey) FlowOp {
-	relayPeerName, found := router.Routes.Unicast(key.DstPeer.Name)
-	if !found {
-		// Not necessarily an error as there could be a race with the
-		// dst disappearing whilst the frame is in flight
-		log.Println("Received packet for unknown destination:", key.DstPeer)
-		return DiscardingFlowOp{}
-	}
-
-	conn, found := router.Ourself.ConnectionTo(relayPeerName)
-	if !found {
-		// Again, could just be a race, not necessarily an error
-		log.Println("Unable to find connection to relay peer", relayPeerName)
-		return DiscardingFlowOp{}
-	}
-
-	return conn.(*LocalConnection).OverlayConn.(OverlayForwarder).Forward(key)
-}
-
-func (router *NetworkRouter) relayBroadcast(srcPeer *Peer, key PacketKey) FlowOp {
-	nextHops := router.Routes.Broadcast(srcPeer.Name)
-	if len(nextHops) == 0 {
-		return DiscardingFlowOp{}
-	}
-
-	op := NewMultiFlowOp(true)
-
-	for _, conn := range router.Ourself.ConnectionsTo(nextHops) {
-		op.Add(conn.(*LocalConnection).OverlayConn.(OverlayForwarder).Forward(ForwardPacketKey{
-			PacketKey: key,
-			SrcPeer:   srcPeer,
-			DstPeer:   conn.Remote()}))
-	}
-
-	return op
 }
 
 // Gossiper methods - the Router is the topology Gossiper

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -71,7 +71,7 @@ type SleeveOverlay struct {
 	forwarders map[PeerName]*sleeveForwarder
 }
 
-func NewSleeveOverlay(localPort int) Overlay {
+func NewSleeveOverlay(localPort int) NetworkOverlay {
 	return &SleeveOverlay{localPort: localPort}
 }
 

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -349,7 +349,7 @@ type controlMessage struct {
 	msg []byte
 }
 
-func (sleeve *SleeveOverlay) MakeForwarder(params ForwarderParams) (OverlayForwarder, error) {
+func (sleeve *SleeveOverlay) PrepareConnection(params OverlayConnectionParams) (OverlayConnection, error) {
 	name := sleeve.localPeer.NameByte
 	var crypto sleeveCrypto
 	if params.SessionKey != nil {

--- a/router/status.go
+++ b/router/status.go
@@ -176,7 +176,7 @@ func NewLocalConnectionStatusSlice(cm *ConnectionMaker) []LocalConnectionStatus 
 				state = "established"
 			}
 			lc, _ := conn.(*LocalConnection)
-			info := fmt.Sprintf("%-6v %v", lc.forwarder.DisplayName(), conn.Remote())
+			info := fmt.Sprintf("%-6v %v", lc.OverlayConn.DisplayName(), conn.Remote())
 			slice = append(slice, LocalConnectionStatus{conn.RemoteTCPAddr(), conn.Outbound(), state, info})
 		}
 		for address, target := range cm.targets {

--- a/router/status.go
+++ b/router/status.go
@@ -65,7 +65,7 @@ type LocalConnectionStatus struct {
 	Info     string
 }
 
-func NewStatus(router *Router) *Status {
+func NewStatus(router *NetworkRouter) *Status {
 	return &Status{
 		Protocol,
 		ProtocolMinVersion,

--- a/router/status.go
+++ b/router/status.go
@@ -14,15 +14,19 @@ type Status struct {
 	Name               string
 	NickName           string
 	Port               int
-	Interface          string
-	CaptureStats       map[string]int
-	MACs               []MACStatus
 	Peers              []PeerStatus
 	UnicastRoutes      []UnicastRouteStatus
 	BroadcastRoutes    []BroadcastRouteStatus
 	Connections        []LocalConnectionStatus
 	Targets            []string
 	OverlayDiagnostics interface{}
+}
+
+type NetworkRouterStatus struct {
+	*Status
+	Interface    string
+	CaptureStats map[string]int
+	MACs         []MACStatus
 }
 
 type MACStatus struct {
@@ -65,7 +69,7 @@ type LocalConnectionStatus struct {
 	Info     string
 }
 
-func NewStatus(router *NetworkRouter) *Status {
+func NewStatus(router *Router) *Status {
 	return &Status{
 		Protocol,
 		ProtocolMinVersion,
@@ -75,15 +79,20 @@ func NewStatus(router *NetworkRouter) *Status {
 		router.Ourself.Name.String(),
 		router.Ourself.NickName,
 		router.Port,
-		router.Bridge.String(),
-		router.Bridge.Stats(),
-		NewMACStatusSlice(router.Macs),
 		NewPeerStatusSlice(router.Peers),
 		NewUnicastRouteStatusSlice(router.Routes),
 		NewBroadcastRouteStatusSlice(router.Routes),
 		NewLocalConnectionStatusSlice(router.ConnectionMaker),
 		NewTargetSlice(router.ConnectionMaker),
 		router.Overlay.Diagnostics()}
+}
+
+func NewNetworkRouterStatus(router *NetworkRouter) *NetworkRouterStatus {
+	return &NetworkRouterStatus{
+		NewStatus(router.Router),
+		router.Bridge.String(),
+		router.Bridge.Stats(),
+		NewMACStatusSlice(router.Macs)}
 }
 
 func NewMACStatusSlice(cache *MacCache) []MACStatus {

--- a/router/status.go
+++ b/router/status.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"fmt"
-	"time"
 )
 
 type Status struct {
@@ -20,20 +19,6 @@ type Status struct {
 	Connections        []LocalConnectionStatus
 	Targets            []string
 	OverlayDiagnostics interface{}
-}
-
-type NetworkRouterStatus struct {
-	*Status
-	Interface    string
-	CaptureStats map[string]int
-	MACs         []MACStatus
-}
-
-type MACStatus struct {
-	Mac      string
-	Name     string
-	NickName string
-	LastSeen time.Time
 }
 
 type PeerStatus struct {
@@ -85,30 +70,6 @@ func NewStatus(router *Router) *Status {
 		NewLocalConnectionStatusSlice(router.ConnectionMaker),
 		NewTargetSlice(router.ConnectionMaker),
 		router.Overlay.Diagnostics()}
-}
-
-func NewNetworkRouterStatus(router *NetworkRouter) *NetworkRouterStatus {
-	return &NetworkRouterStatus{
-		NewStatus(router.Router),
-		router.Bridge.String(),
-		router.Bridge.Stats(),
-		NewMACStatusSlice(router.Macs)}
-}
-
-func NewMACStatusSlice(cache *MacCache) []MACStatus {
-	cache.RLock()
-	defer cache.RUnlock()
-
-	var slice []MACStatus
-	for key, entry := range cache.table {
-		slice = append(slice, MACStatus{
-			intmac(key).String(),
-			entry.peer.Name.String(),
-			entry.peer.NickName,
-			entry.lastSeen})
-	}
-
-	return slice
 }
 
 func NewPeerStatusSlice(peers *Peers) []PeerStatus {


### PR DESCRIPTION
This is a preparatory step for extracting the control plane as a generic communication substrate into a separate package ('mesh').

The control plane shouldn't have to know what it is being used for, i.e. in our case creating an overlay network. We therefore introduce a more generic notion of an Overlay - something that hooks into the lifecycle of control plane connections and buddies them up with its own logical (or real) OverlayConnections. For weave we then have a specialised NetworkOverlay which represents a data plane, i.e. it knows about (i.e. has methods for) packet forwarding.

There is a similar separation at the Router, i.e. there is a generic control plane Router, and more specialised NetworkRouter - the latter knows about packet capture and forwarding.