### PR TITLE
Move generic communication substrate into its own 'mesh' package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(NETCHECK_EXE): common/*.go common/*/*.go net/*.go
 	go build $(BUILD_FLAGS) -o $@ ./$(@D)
 	$(NETGO_CHECK)
 
-$(WEAVER_EXE): router/*.go ipam/*.go ipam/*/*.go nameserver/*.go prog/weaver/*.go
+$(WEAVER_EXE): router/*.go mesh/*.go ipam/*.go ipam/*/*.go nameserver/*.go prog/weaver/*.go
 $(WEAVEPROXY_EXE): proxy/*.go prog/weaveproxy/main.go
 $(NETCHECK_EXE): prog/netcheck/netcheck.go
 

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -11,8 +11,8 @@ import (
 	"github.com/weaveworks/weave/ipam/paxos"
 	"github.com/weaveworks/weave/ipam/ring"
 	"github.com/weaveworks/weave/ipam/space"
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 )
 
 // Kinds of message we can unicast to other peers
@@ -43,31 +43,31 @@ type operation interface {
 // are used around data structures.
 type Allocator struct {
 	actionChan       chan<- func()
-	ourName          router.PeerName
+	ourName          mesh.PeerName
 	universe         address.Range                // superset of all ranges
 	ring             *ring.Ring                   // information on ranges owned by all peers
 	space            space.Space                  // more detail on ranges owned by us
 	owned            map[string][]address.Address // who owns what addresses, indexed by container-ID
-	nicknames        map[router.PeerName]string   // so we can map nicknames for rmpeer
+	nicknames        map[mesh.PeerName]string     // so we can map nicknames for rmpeer
 	pendingAllocates []operation                  // held until we get some free space
 	pendingClaims    []operation                  // held until we know who owns the space
-	gossip           router.Gossip                // our link to the outside world for sending messages
+	gossip           mesh.Gossip                  // our link to the outside world for sending messages
 	paxos            *paxos.Node
 	paxosTicker      *time.Ticker
 	shuttingDown     bool // to avoid doing any requests while trying to shut down
-	isKnownPeer      func(router.PeerName) bool
+	isKnownPeer      func(mesh.PeerName) bool
 	now              func() time.Time
 }
 
 // NewAllocator creates and initialises a new Allocator
-func NewAllocator(ourName router.PeerName, ourUID router.PeerUID, ourNickname string, universe address.Range, quorum uint, isKnownPeer func(name router.PeerName) bool) *Allocator {
+func NewAllocator(ourName mesh.PeerName, ourUID mesh.PeerUID, ourNickname string, universe address.Range, quorum uint, isKnownPeer func(name mesh.PeerName) bool) *Allocator {
 	return &Allocator{
 		ourName:     ourName,
 		universe:    universe,
 		ring:        ring.New(universe.Start, universe.End, ourName),
 		owned:       make(map[string][]address.Address),
 		paxos:       paxos.NewNode(ourName, ourUID, quorum),
-		nicknames:   map[router.PeerName]string{ourName: ourNickname},
+		nicknames:   map[mesh.PeerName]string{ourName: ourNickname},
 		isKnownPeer: isKnownPeer,
 		now:         time.Now,
 	}
@@ -75,7 +75,7 @@ func NewAllocator(ourName router.PeerName, ourUID router.PeerUID, ourNickname st
 
 // Start runs the allocator goroutine
 func (alloc *Allocator) Start() {
-	actionChan := make(chan func(), router.ChannelSize)
+	actionChan := make(chan func(), mesh.ChannelSize)
 	alloc.actionChan = actionChan
 	go alloc.actorLoop(actionChan)
 }
@@ -165,7 +165,7 @@ func (alloc *Allocator) tryPendingOps() {
 	}
 }
 
-func (alloc *Allocator) spaceRequestDenied(sender router.PeerName, r address.Range) {
+func (alloc *Allocator) spaceRequestDenied(sender mesh.PeerName, r address.Range) {
 	for i := 0; i < len(alloc.pendingClaims); {
 		claim := alloc.pendingClaims[i].(*claim)
 		if r.Contains(claim.addr) {
@@ -276,27 +276,27 @@ func (alloc *Allocator) Free(ident string, addrToFree address.Address) error {
 	return <-errChan
 }
 
-func (alloc *Allocator) pickPeerFromNicknames(isValid func(router.PeerName) bool) router.PeerName {
+func (alloc *Allocator) pickPeerFromNicknames(isValid func(mesh.PeerName) bool) mesh.PeerName {
 	for name := range alloc.nicknames {
 		if name != alloc.ourName && isValid(name) {
 			return name
 		}
 	}
-	return router.UnknownPeerName
+	return mesh.UnknownPeerName
 }
 
-func (alloc *Allocator) pickPeerForTransfer() router.PeerName {
+func (alloc *Allocator) pickPeerForTransfer() mesh.PeerName {
 	// first try alive peers that actively participate in IPAM (i.e. have entries)
-	if heir := alloc.ring.PickPeerForTransfer(alloc.isKnownPeer); heir != router.UnknownPeerName {
+	if heir := alloc.ring.PickPeerForTransfer(alloc.isKnownPeer); heir != mesh.UnknownPeerName {
 		return heir
 	}
 	// next try alive peers that have IPAM enabled but have no entries
-	if heir := alloc.pickPeerFromNicknames(alloc.isKnownPeer); heir != router.UnknownPeerName {
+	if heir := alloc.pickPeerFromNicknames(alloc.isKnownPeer); heir != mesh.UnknownPeerName {
 		return heir
 	}
 	// next try disappeared peers that still have entries
-	t := func(router.PeerName) bool { return true }
-	if heir := alloc.ring.PickPeerForTransfer(t); heir != router.UnknownPeerName {
+	t := func(mesh.PeerName) bool { return true }
+	if heir := alloc.ring.PickPeerForTransfer(t); heir != mesh.UnknownPeerName {
 		return heir
 	}
 	// finally, disappeared peers that that passively participated in IPAM
@@ -311,7 +311,7 @@ func (alloc *Allocator) Shutdown() {
 		alloc.shuttingDown = true
 		alloc.cancelOps(&alloc.pendingClaims)
 		alloc.cancelOps(&alloc.pendingAllocates)
-		if heir := alloc.pickPeerForTransfer(); heir != router.UnknownPeerName {
+		if heir := alloc.pickPeerForTransfer(); heir != mesh.UnknownPeerName {
 			alloc.ring.Transfer(alloc.ourName, heir)
 			alloc.space.Clear()
 			alloc.gossip.GossipBroadcast(alloc.Gossip())
@@ -350,14 +350,14 @@ func (alloc *Allocator) AdminTakeoverRanges(peerNameOrNickname string) error {
 // call into the router for this because we are interested in peers
 // that have gone away but are still in the ring, which is why we
 // maintain our own nicknames map.
-func (alloc *Allocator) lookupPeername(name string) (router.PeerName, error) {
+func (alloc *Allocator) lookupPeername(name string) (mesh.PeerName, error) {
 	for peername, nickname := range alloc.nicknames {
 		if nickname == name {
 			return peername, nil
 		}
 	}
 
-	return router.PeerNameFromString(name)
+	return mesh.PeerNameFromString(name)
 }
 
 // Restrict the peers in "nicknames" to those in the ring plus peers known to the router
@@ -370,7 +370,7 @@ func (alloc *Allocator) pruneNicknames() {
 	}
 }
 
-func (alloc *Allocator) annotatePeernames(names []router.PeerName) []string {
+func (alloc *Allocator) annotatePeernames(names []mesh.PeerName) []string {
 	var res []string
 	for _, name := range names {
 		if nickname, found := alloc.nicknames[name]; found {
@@ -388,7 +388,7 @@ func decodeRange(msg []byte) (r address.Range, err error) {
 }
 
 // OnGossipUnicast (Sync)
-func (alloc *Allocator) OnGossipUnicast(sender router.PeerName, msg []byte) error {
+func (alloc *Allocator) OnGossipUnicast(sender mesh.PeerName, msg []byte) error {
 	alloc.debugln("OnGossipUnicast from", sender, ": ", len(msg), "bytes")
 	resultChan := make(chan error)
 	alloc.actionChan <- func() {
@@ -414,7 +414,7 @@ func (alloc *Allocator) OnGossipUnicast(sender router.PeerName, msg []byte) erro
 }
 
 // OnGossipBroadcast (Sync)
-func (alloc *Allocator) OnGossipBroadcast(sender router.PeerName, msg []byte) (router.GossipData, error) {
+func (alloc *Allocator) OnGossipBroadcast(sender mesh.PeerName, msg []byte) (mesh.GossipData, error) {
 	alloc.debugln("OnGossipBroadcast from", sender, ":", len(msg), "bytes")
 	resultChan := make(chan error)
 	alloc.actionChan <- func() {
@@ -427,7 +427,7 @@ type gossipState struct {
 	// We send a timstamp along with the information to be
 	// gossipped in order to detect skewed clocks
 	Now       int64
-	Nicknames map[router.PeerName]string
+	Nicknames map[mesh.PeerName]string
 
 	Paxos paxos.GossipState
 	Ring  *ring.Ring
@@ -463,11 +463,11 @@ func (alloc *Allocator) Encode() []byte {
 }
 
 // OnGossip (Sync)
-func (alloc *Allocator) OnGossip(msg []byte) (router.GossipData, error) {
+func (alloc *Allocator) OnGossip(msg []byte) (mesh.GossipData, error) {
 	alloc.debugln("Allocator.OnGossip:", len(msg), "bytes")
 	resultChan := make(chan error)
 	alloc.actionChan <- func() {
-		resultChan <- alloc.update(router.UnknownPeerName, msg)
+		resultChan <- alloc.update(mesh.UnknownPeerName, msg)
 	}
 	return nil, <-resultChan // for now, we never propagate updates. TBD
 }
@@ -478,7 +478,7 @@ type ipamGossipData struct {
 	alloc *Allocator
 }
 
-func (d *ipamGossipData) Merge(other router.GossipData) {
+func (d *ipamGossipData) Merge(other mesh.GossipData) {
 	// no-op
 }
 
@@ -488,12 +488,12 @@ func (d *ipamGossipData) Encode() [][]byte {
 
 // Gossip returns a GossipData implementation, which in this case always
 // returns the latest ring state (and does nothing on merge)
-func (alloc *Allocator) Gossip() router.GossipData {
+func (alloc *Allocator) Gossip() mesh.GossipData {
 	return &ipamGossipData{alloc}
 }
 
 // SetInterfaces gives the allocator two interfaces for talking to the outside world
-func (alloc *Allocator) SetInterfaces(gossip router.Gossip) {
+func (alloc *Allocator) SetInterfaces(gossip mesh.Gossip) {
 	alloc.gossip = gossip
 }
 
@@ -540,7 +540,7 @@ func (alloc *Allocator) establishRing() {
 	}
 }
 
-func (alloc *Allocator) createRing(peers []router.PeerName) {
+func (alloc *Allocator) createRing(peers []mesh.PeerName) {
 	alloc.debugln("Paxos consensus:", peers)
 	alloc.ring.ClaimForPeers(normalizeConsensus(peers))
 	alloc.gossip.GossipBroadcast(alloc.Gossip())
@@ -563,7 +563,7 @@ func (alloc *Allocator) ringUpdated() {
 }
 
 // For compatibility with sort.Interface
-type peerNames []router.PeerName
+type peerNames []mesh.PeerName
 
 func (a peerNames) Len() int           { return len(a) }
 func (a peerNames) Less(i, j int) bool { return a[i] < a[j] }
@@ -572,7 +572,7 @@ func (a peerNames) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 // When we get a consensus from Paxos, the peer names are not in a
 // defined order and may contain duplicates.  This function sorts them
 // and de-dupes.
-func normalizeConsensus(consensus []router.PeerName) []router.PeerName {
+func normalizeConsensus(consensus []mesh.PeerName) []mesh.PeerName {
 	if len(consensus) == 0 {
 		return nil
 	}
@@ -607,22 +607,22 @@ func encodeRange(r address.Range) []byte {
 	return buf.Bytes()
 }
 
-func (alloc *Allocator) sendSpaceRequest(dest router.PeerName, r address.Range) error {
+func (alloc *Allocator) sendSpaceRequest(dest mesh.PeerName, r address.Range) error {
 	msg := append([]byte{msgSpaceRequest}, encodeRange(r)...)
 	return alloc.gossip.GossipUnicast(dest, msg)
 }
 
-func (alloc *Allocator) sendSpaceRequestDenied(dest router.PeerName, r address.Range) error {
+func (alloc *Allocator) sendSpaceRequestDenied(dest mesh.PeerName, r address.Range) error {
 	msg := append([]byte{msgSpaceRequestDenied}, encodeRange(r)...)
 	return alloc.gossip.GossipUnicast(dest, msg)
 }
 
-func (alloc *Allocator) sendRingUpdate(dest router.PeerName) {
+func (alloc *Allocator) sendRingUpdate(dest mesh.PeerName) {
 	msg := append([]byte{msgRingUpdate}, alloc.encode()...)
 	alloc.gossip.GossipUnicast(dest, msg)
 }
 
-func (alloc *Allocator) update(sender router.PeerName, msg []byte) error {
+func (alloc *Allocator) update(sender mesh.PeerName, msg []byte) error {
 	reader := bytes.NewReader(msg)
 	decoder := gob.NewDecoder(reader)
 	var data gossipState
@@ -674,7 +674,7 @@ func (alloc *Allocator) update(sender router.PeerName, msg []byte) error {
 					alloc.createRing(cons.Value)
 				}
 			}
-		} else if sender != router.UnknownPeerName {
+		} else if sender != mesh.UnknownPeerName {
 			// Sender is trying to initialize a ring, but we have one
 			// already - send it straight back
 			alloc.sendRingUpdate(sender)
@@ -684,7 +684,7 @@ func (alloc *Allocator) update(sender router.PeerName, msg []byte) error {
 	return nil
 }
 
-func (alloc *Allocator) donateSpace(r address.Range, to router.PeerName) {
+func (alloc *Allocator) donateSpace(r address.Range, to mesh.PeerName) {
 	// No matter what we do, we'll send a unicast gossip
 	// of our ring back to tha chap who asked for space.
 	// This serves to both tell him of any space we might

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 )
 
 type claim struct {
@@ -43,7 +43,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 	switch owner := alloc.ring.Owner(c.addr); owner {
 	case alloc.ourName:
 		// success
-	case router.UnknownPeerName:
+	case mesh.UnknownPeerName:
 		// If our ring doesn't know, it must be empty.
 		if c.noErrorOnUnknown {
 			alloc.infof("Claim %s for %s: address allocator still initializing; will try later.", c.addr, c.ident)
@@ -86,7 +86,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 	return true
 }
 
-func (c *claim) deniedBy(alloc *Allocator, owner router.PeerName) {
+func (c *claim) deniedBy(alloc *Allocator, owner mesh.PeerName) {
 	name, found := alloc.nicknames[owner]
 	if found {
 		name = " (" + name + ")"

--- a/ipam/paxos/paxos.go
+++ b/ipam/paxos/paxos.go
@@ -1,7 +1,7 @@
 package paxos
 
 import (
-	"github.com/weaveworks/weave/router"
+	"github.com/weaveworks/weave/mesh"
 )
 
 // The node identifier.  The use of the UID here is important: Paxos
@@ -9,8 +9,8 @@ import (
 // node does not restart and lose its Paxos state but claim to have
 // the same ID.
 type NodeID struct {
-	Name router.PeerName
-	UID  router.PeerUID
+	Name mesh.PeerName
+	UID  mesh.PeerUID
 }
 
 // note all fields exported in structs so we can Gob them
@@ -39,7 +39,7 @@ func (a ProposalID) valid() bool {
 }
 
 // For seeding IPAM, the value we want consensus on is a set of peer names
-type Value []router.PeerName
+type Value []mesh.PeerName
 
 // An AcceptedValue is a Value plus the proposal which originated that
 // Value.  The origin is not essential, but makes comparing
@@ -72,7 +72,7 @@ type Node struct {
 	knows  GossipState
 }
 
-func NewNode(name router.PeerName, uid router.PeerUID, quorum uint) *Node {
+func NewNode(name mesh.PeerName, uid mesh.PeerUID, quorum uint) *Node {
 	return &Node{
 		id:     NodeID{name, uid},
 		quorum: quorum,
@@ -223,7 +223,7 @@ func (node *Node) Think() bool {
 // about.  This is not necessarily all peer names, but it is at least
 // a quorum, and so good enough for seeding the ring.
 func (node *Node) pickValue() Value {
-	val := make([]router.PeerName, len(node.knows))
+	val := make([]mesh.PeerName, len(node.knows))
 	i := 0
 	for id := range node.knows {
 		val[i] = id.Name

--- a/ipam/paxos/paxos_test.go
+++ b/ipam/paxos/paxos_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/weaveworks/weave/router"
+	"github.com/weaveworks/weave/mesh"
 )
 
 type TestNode struct {
@@ -97,8 +97,8 @@ func makeRandomModel(params *TestParams, r *rand.Rand, t *testing.T) *Model {
 	}
 
 	for i := range m.nodes {
-		m.nodes[i].Node = NewNode(router.PeerName(i/2+1),
-			router.PeerUID(r.Int63()), m.quorum)
+		m.nodes[i].Node = NewNode(mesh.PeerName(i/2+1),
+			mesh.PeerUID(r.Int63()), m.quorum)
 		m.nodes[i].Propose()
 	}
 
@@ -172,8 +172,8 @@ func (m *Model) isolateNode(node *TestNode) {
 
 // Restart a node
 func (m *Model) restart(node *TestNode) {
-	node.Node = NewNode(router.PeerName(m.nextID),
-		router.PeerUID(m.r.Int63()), m.quorum)
+	node.Node = NewNode(mesh.PeerName(m.nextID),
+		mesh.PeerUID(m.r.Int63()), m.quorum)
 	m.nextID++
 	node.Propose()
 

--- a/ipam/ring/entry.go
+++ b/ipam/ring/entry.go
@@ -4,14 +4,14 @@ import (
 	"sort"
 
 	"github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 )
 
 // Entry represents entries around the ring
 type entry struct {
 	Token   address.Address // The start of this range
-	Peer    router.PeerName // Who owns this range
+	Peer    mesh.PeerName   // Who owns this range
 	Version uint32          // Version of this range
 	Free    address.Offset  // Number of free IPs in this range
 }
@@ -21,7 +21,7 @@ func (e *entry) Equal(e2 *entry) bool {
 		e.Version == e2.Version
 }
 
-func (e *entry) update(peername router.PeerName, free address.Offset) {
+func (e *entry) update(peername mesh.PeerName, free address.Offset) {
 	e.Peer = peername
 	e.Version++
 	e.Free = free

--- a/ipam/ring/ring_test.go
+++ b/ipam/ring/ring_test.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 )
 
 var (
-	peer1name, _ = router.PeerNameFromString("01:00:00:00:02:00")
-	peer2name, _ = router.PeerNameFromString("02:00:00:00:02:00")
-	peer3name, _ = router.PeerNameFromString("03:00:00:00:02:00")
+	peer1name, _ = mesh.PeerNameFromString("01:00:00:00:02:00")
+	peer2name, _ = mesh.PeerNameFromString("02:00:00:00:02:00")
+	peer3name, _ = mesh.PeerNameFromString("03:00:00:00:02:00")
 
 	start, end    = ParseIP("10.0.0.0"), ParseIP("10.0.0.255")
 	dot10, dot245 = ParseIP("10.0.0.10"), ParseIP("10.0.0.245")
@@ -351,7 +351,7 @@ func TestGossip(t *testing.T) {
 	assertRing(ring2, []*entry{{Token: start, Peer: peer1name, Free: 255}})
 }
 
-func assertPeersWithSpace(t *testing.T, ring *Ring, start, end address.Address, expected int) []router.PeerName {
+func assertPeersWithSpace(t *testing.T, ring *Ring, start, end address.Address, expected int) []mesh.PeerName {
 	peers := ring.ChoosePeersToAskForSpace(start, end)
 	require.Equal(t, expected, len(peers))
 	return peers
@@ -375,7 +375,7 @@ func TestFindFree(t *testing.T) {
 	ring1.assertInvariants()
 
 	// We should return others
-	var peers []router.PeerName
+	var peers []mesh.PeerName
 
 	ring1.Entries = []*entry{{Token: start, Peer: peer2name, Free: 1}}
 	peers = assertPeersWithSpace(t, ring1, start, end, 1)
@@ -493,7 +493,7 @@ func TestOwner(t *testing.T) {
 	require.True(t, ring1.Contains(start), "start should be in ring")
 	require.False(t, ring1.Contains(end), "end should not be in ring")
 
-	require.Equal(t, router.UnknownPeerName, ring1.Owner(start))
+	require.Equal(t, mesh.UnknownPeerName, ring1.Owner(start))
 
 	ring1.ClaimItAll()
 	ring1.GrantRangeToHost(middle, end, peer2name)
@@ -517,9 +517,9 @@ func TestFuzzRing(t *testing.T) {
 		iterations = 1000
 	)
 
-	peers := make([]router.PeerName, numPeers)
+	peers := make([]mesh.PeerName, numPeers)
 	for i := 0; i < numPeers; i++ {
-		peer, _ := router.PeerNameFromString(fmt.Sprintf("%02d:00:00:00:02:00", i))
+		peer, _ := mesh.PeerNameFromString(fmt.Sprintf("%02d:00:00:00:02:00", i))
 		peers[i] = peer
 	}
 
@@ -601,13 +601,13 @@ func TestFuzzRingHard(t *testing.T) {
 	var (
 		numPeers   = 100
 		iterations = 3000
-		peers      []router.PeerName
+		peers      []mesh.PeerName
 		rings      []*Ring
 		nextPeerID = 0
 	)
 
 	addPeer := func() {
-		peer, _ := router.PeerNameFromString(fmt.Sprintf("%02d:%02d:00:00:00:00", nextPeerID/10, nextPeerID%10))
+		peer, _ := mesh.PeerNameFromString(fmt.Sprintf("%02d:%02d:00:00:00:00", nextPeerID/10, nextPeerID%10))
 		common.Log.Debugf("%s: Adding peer", peer)
 		nextPeerID++
 		peers = append(peers, peer)
@@ -620,7 +620,7 @@ func TestFuzzRingHard(t *testing.T) {
 
 	rings[0].ClaimItAll()
 
-	randomPeer := func(exclude int) (int, router.PeerName, *Ring) {
+	randomPeer := func(exclude int) (int, mesh.PeerName, *Ring) {
 		var peerIndex int
 		if exclude >= 0 {
 			peerIndex = rand.Intn(len(peers) - 1)
@@ -729,7 +729,7 @@ func TestFuzzRingHard(t *testing.T) {
 }
 
 func (r *Ring) ClaimItAll() {
-	r.ClaimForPeers([]router.PeerName{r.Peer})
+	r.ClaimForPeers([]mesh.PeerName{r.Peer})
 }
 
 func (es entries) String() string {

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 	"github.com/weaveworks/weave/testing/gossip"
 )
 
 type mockMessage struct {
-	dst     router.PeerName
+	dst     mesh.PeerName
 	msgType byte
 	buf     []byte
 }
@@ -48,13 +48,13 @@ func (m *mockGossipComms) String() string {
 // that the contents of messages are never re-ordered.  Which, for instance,
 // requires they are not based off iterating through a map.
 
-func (m *mockGossipComms) GossipBroadcast(update router.GossipData) error {
+func (m *mockGossipComms) GossipBroadcast(update mesh.GossipData) error {
 	m.Lock()
 	defer m.Unlock()
 	buf := []byte{}
 	if len(m.messages) == 0 {
 		require.FailNow(m, fmt.Sprintf("%s: Gossip broadcast message unexpected: \n%x", m.name, buf))
-	} else if msg := m.messages[0]; msg.dst != router.UnknownPeerName {
+	} else if msg := m.messages[0]; msg.dst != mesh.UnknownPeerName {
 		require.FailNow(m, fmt.Sprintf("%s: Expected Gossip message to %s but got broadcast", m.name, msg.dst))
 	} else if msg.buf != nil && !equalByteBuffer(msg.buf, buf) {
 		require.FailNow(m, fmt.Sprintf("%s: Gossip message not sent as expected: \nwant: %x\ngot : %x", m.name, msg.buf, buf))
@@ -77,12 +77,12 @@ func equalByteBuffer(a, b []byte) bool {
 	return true
 }
 
-func (m *mockGossipComms) GossipUnicast(dstPeerName router.PeerName, buf []byte) error {
+func (m *mockGossipComms) GossipUnicast(dstPeerName mesh.PeerName, buf []byte) error {
 	m.Lock()
 	defer m.Unlock()
 	if len(m.messages) == 0 {
 		require.FailNow(m, fmt.Sprintf("%s: Gossip message to %s unexpected: \n%s", m.name, dstPeerName, buf))
-	} else if msg := m.messages[0]; msg.dst == router.UnknownPeerName {
+	} else if msg := m.messages[0]; msg.dst == mesh.UnknownPeerName {
 		require.FailNow(m, fmt.Sprintf("%s: Expected Gossip broadcast message but got dest %s", m.name, dstPeerName))
 	} else if msg.dst != dstPeerName {
 		require.FailNow(m, fmt.Sprintf("%s: Expected Gossip message to %s but got dest %s", m.name, msg.dst, dstPeerName))
@@ -99,7 +99,7 @@ func (m *mockGossipComms) GossipUnicast(dstPeerName router.PeerName, buf []byte)
 
 func ExpectMessage(alloc *Allocator, dst string, msgType byte, buf []byte) {
 	m := alloc.gossip.(*mockGossipComms)
-	dstPeerName, _ := router.PeerNameFromString(dst)
+	dstPeerName, _ := mesh.PeerNameFromString(dst)
 	m.Lock()
 	m.messages = append(m.messages, mockMessage{dstPeerName, msgType, buf})
 	m.Unlock()
@@ -108,7 +108,7 @@ func ExpectMessage(alloc *Allocator, dst string, msgType byte, buf []byte) {
 func ExpectBroadcastMessage(alloc *Allocator, buf []byte) {
 	m := alloc.gossip.(*mockGossipComms)
 	m.Lock()
-	m.messages = append(m.messages, mockMessage{router.UnknownPeerName, 0, buf})
+	m.messages = append(m.messages, mockMessage{mesh.UnknownPeerName, 0, buf})
 	m.Unlock()
 }
 
@@ -124,7 +124,7 @@ func CheckAllExpectedMessagesSent(allocs ...*Allocator) {
 }
 
 func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, address.Range) {
-	peername, err := router.PeerNameFromString(name)
+	peername, err := mesh.PeerNameFromString(name)
 	if err != nil {
 		panic(err)
 	}
@@ -134,8 +134,8 @@ func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, addres
 		panic(err)
 	}
 
-	alloc := NewAllocator(peername, router.PeerUID(rand.Int63()),
-		"nick-"+name, cidr.Range(), quorum, func(router.PeerName) bool { return true })
+	alloc := NewAllocator(peername, mesh.PeerUID(rand.Int63()),
+		"nick-"+name, cidr.Range(), quorum, func(mesh.PeerName) bool { return true })
 
 	return alloc, cidr.HostRange()
 }
@@ -149,7 +149,7 @@ func makeAllocatorWithMockGossip(t *testing.T, name string, universeCIDR string,
 }
 
 func (alloc *Allocator) claimRingForTesting(allocs ...*Allocator) {
-	peers := []router.PeerName{alloc.ourName}
+	peers := []mesh.PeerName{alloc.ourName}
 	for _, alloc2 := range allocs {
 		peers = append(peers, alloc2.ourName)
 	}

--- a/mesh/connection.go
+++ b/mesh/connection.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/connection_maker.go
+++ b/mesh/connection_maker.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/gossip.go
+++ b/mesh/gossip.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/gossip_channel.go
+++ b/mesh/gossip_channel.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"bytes"

--- a/mesh/gossip_test.go
+++ b/mesh/gossip_test.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/local_peer.go
+++ b/mesh/local_peer.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/mocks_test.go
+++ b/mesh/mocks_test.go
@@ -3,7 +3,7 @@
 // It supplies some mock implementations to other unit tests, and is
 // named "...test.go" so it is only compiled under `go test`.
 
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/overlay.go
+++ b/mesh/overlay.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"net"

--- a/mesh/peer.go
+++ b/mesh/peer.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"crypto/rand"

--- a/mesh/peer_name_hash.go
+++ b/mesh/peer_name_hash.go
@@ -3,7 +3,7 @@
 // Let peer names be sha256 hashes...of anything (as long as it's
 // unique).
 
-package router
+package mesh
 
 import (
 	"crypto/sha256"

--- a/mesh/peer_name_mac.go
+++ b/mesh/peer_name_mac.go
@@ -15,7 +15,7 @@
 // name. In particular it doesn't actually have to be the MAC of, say,
 // the network interface the peer is sniffing on.
 
-package router
+package mesh
 
 import (
 	"net"
@@ -55,4 +55,21 @@ func (name PeerName) Bin() []byte {
 
 func (name PeerName) String() string {
 	return intmac(uint64(name)).String()
+}
+
+func macint(mac net.HardwareAddr) (r uint64) {
+	for _, b := range mac {
+		r <<= 8
+		r |= uint64(b)
+	}
+	return
+}
+
+func intmac(key uint64) (r net.HardwareAddr) {
+	r = make([]byte, 6)
+	for i := 5; i >= 0; i-- {
+		r[i] = byte(key)
+		key >>= 8
+	}
+	return
 }

--- a/mesh/peers.go
+++ b/mesh/peers.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"bytes"

--- a/mesh/peers_test.go
+++ b/mesh/peers_test.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/protocol.go
+++ b/mesh/protocol.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"bytes"

--- a/mesh/protocol_crypto.go
+++ b/mesh/protocol_crypto.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"crypto/rand"

--- a/mesh/protocol_test.go
+++ b/mesh/protocol_test.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"io"

--- a/mesh/router.go
+++ b/mesh/router.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/routes.go
+++ b/mesh/routes.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"math"

--- a/mesh/status.go
+++ b/mesh/status.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"fmt"

--- a/mesh/surrogate_gossiper.go
+++ b/mesh/surrogate_gossiper.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 type SurrogateGossipData struct {
 	messages [][]byte

--- a/mesh/token_bucket.go
+++ b/mesh/token_bucket.go
@@ -1,4 +1,4 @@
-package router
+package mesh
 
 import (
 	"time"

--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 )
 
 func startServer(t *testing.T, upstream *dns.ClientConfig) (*DNSServer, *Nameserver, int, int) {
-	peername, err := router.PeerNameFromString("00:00:00:02:00:00")
+	peername, err := mesh.PeerNameFromString("00:00:00:02:00:00")
 	require.Nil(t, err)
-	nameserver := New(peername, "", func(router.PeerName) bool { return true })
+	nameserver := New(peername, "", func(mesh.PeerName) bool { return true })
 	dnsserver, err := NewDNSServer(nameserver, "weave.local.", "0.0.0.0:0", "", 30, 5*time.Second)
 	require.Nil(t, err)
 	udpPort := dnsserver.servers[0].PacketConn.LocalAddr().(*net.UDPAddr).Port
@@ -39,7 +39,7 @@ func TestTruncation(t *testing.T) {
 	addrs := []address.Address{}
 	for i := address.Address(0); i < 100; i++ {
 		addrs = append(addrs, i)
-		nameserver.AddEntry("foo.weave.local.", "", router.UnknownPeerName, i)
+		nameserver.AddEntry("foo.weave.local.", "", mesh.UnknownPeerName, i)
 	}
 
 	doRequest := func(client *dns.Client, request *dns.Msg, port int, expectedErr error) *dns.Msg {

--- a/nameserver/entry.go
+++ b/nameserver/entry.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 )
 
 var now = func() int64 { return time.Now().Unix() }
 
 type Entry struct {
 	ContainerID string
-	Origin      router.PeerName
+	Origin      mesh.PeerName
 	Addr        address.Address
 	Hostname    string // as supplied
 	lHostname   string // lowercased (not exported, so not encoded by gob)
@@ -128,7 +128,7 @@ func (es *Entries) checkAndPanic() *Entries {
 	return es
 }
 
-func (es *Entries) add(hostname, containerid string, origin router.PeerName, addr address.Address) Entry {
+func (es *Entries) add(hostname, containerid string, origin mesh.PeerName, addr address.Address) Entry {
 	defer es.checkAndPanic().checkAndPanic()
 
 	entry := Entry{Hostname: hostname, lHostname: strings.ToLower(hostname),
@@ -176,7 +176,7 @@ func (es *Entries) merge(incoming Entries) Entries {
 }
 
 // f returning true means keep the entry.
-func (es *Entries) tombstone(ourname router.PeerName, f func(*Entry) bool) Entries {
+func (es *Entries) tombstone(ourname mesh.PeerName, f func(*Entry) bool) Entries {
 	defer es.checkAndPanic().checkAndPanic()
 
 	tombstoned := Entries{}
@@ -245,7 +245,7 @@ type GossipData struct {
 	Entries
 }
 
-func (g *GossipData) Merge(o router.GossipData) {
+func (g *GossipData) Merge(o mesh.GossipData) {
 	other := o.(*GossipData)
 	g.Entries.merge(other.Entries)
 	if g.Timestamp < other.Timestamp {

--- a/nameserver/entry_test.go
+++ b/nameserver/entry_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 )
 
 func l(es Entries) Entries {
@@ -28,21 +28,21 @@ func TestAdd(t *testing.T) {
 	now = func() int64 { return 1234 }
 
 	entries := Entries{}
-	entries.add("A", "", router.UnknownPeerName, address.Address(0))
+	entries.add("A", "", mesh.UnknownPeerName, address.Address(0))
 	expected := l(Entries{
-		Entry{Hostname: "A", Origin: router.UnknownPeerName, Addr: address.Address(0)},
+		Entry{Hostname: "A", Origin: mesh.UnknownPeerName, Addr: address.Address(0)},
 	})
 	require.Equal(t, entries, expected)
 
-	entries.tombstone(router.UnknownPeerName, func(e *Entry) bool { return e.Hostname == "A" })
+	entries.tombstone(mesh.UnknownPeerName, func(e *Entry) bool { return e.Hostname == "A" })
 	expected = l(Entries{
-		Entry{Hostname: "A", Origin: router.UnknownPeerName, Addr: address.Address(0), Version: 1, Tombstone: 1234},
+		Entry{Hostname: "A", Origin: mesh.UnknownPeerName, Addr: address.Address(0), Version: 1, Tombstone: 1234},
 	})
 	require.Equal(t, entries, expected)
 
-	entries.add("A", "", router.UnknownPeerName, address.Address(0))
+	entries.add("A", "", mesh.UnknownPeerName, address.Address(0))
 	expected = l(Entries{
-		Entry{Hostname: "A", Origin: router.UnknownPeerName, Addr: address.Address(0), Version: 2},
+		Entry{Hostname: "A", Origin: mesh.UnknownPeerName, Addr: address.Address(0), Version: 2},
 	})
 	require.Equal(t, entries, expected)
 }
@@ -78,7 +78,7 @@ func TestTombstone(t *testing.T) {
 
 	es := makeEntries("AB")
 
-	es.tombstone(router.UnknownPeerName, func(e *Entry) bool {
+	es.tombstone(mesh.UnknownPeerName, func(e *Entry) bool {
 		return e.Hostname == "B"
 	})
 	expected := l(Entries{

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -8,8 +8,8 @@ import (
 	"github.com/miekg/dns"
 
 	. "github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 )
 
 const (
@@ -34,15 +34,15 @@ const (
 // - Update is O(n) for now
 type Nameserver struct {
 	sync.RWMutex
-	ourName     router.PeerName
+	ourName     mesh.PeerName
 	domain      string
-	gossip      router.Gossip
+	gossip      mesh.Gossip
 	entries     Entries
-	isKnownPeer func(router.PeerName) bool
+	isKnownPeer func(mesh.PeerName) bool
 	quit        chan struct{}
 }
 
-func New(ourName router.PeerName, domain string, isKnownPeer func(router.PeerName) bool) *Nameserver {
+func New(ourName mesh.PeerName, domain string, isKnownPeer func(mesh.PeerName) bool) *Nameserver {
 	return &Nameserver{
 		ourName:     ourName,
 		domain:      dns.Fqdn(domain),
@@ -51,7 +51,7 @@ func New(ourName router.PeerName, domain string, isKnownPeer func(router.PeerNam
 	}
 }
 
-func (n *Nameserver) SetGossip(gossip router.Gossip) {
+func (n *Nameserver) SetGossip(gossip mesh.Gossip) {
 	n.gossip = gossip
 }
 
@@ -83,7 +83,7 @@ func (n *Nameserver) broadcastEntries(es ...Entry) error {
 	return nil
 }
 
-func (n *Nameserver) AddEntry(hostname, containerid string, origin router.PeerName, addr address.Address) error {
+func (n *Nameserver) AddEntry(hostname, containerid string, origin mesh.PeerName, addr address.Address) error {
 	n.infof("adding entry %s -> %s", hostname, addr.String())
 	n.Lock()
 	entry := n.entries.add(hostname, containerid, origin, addr)
@@ -140,7 +140,7 @@ func (n *Nameserver) ContainerDied(ident string) {
 	}
 }
 
-func (n *Nameserver) PeerGone(peer router.PeerName) {
+func (n *Nameserver) PeerGone(peer mesh.PeerName) {
 	n.infof("peer %s gone", peer.String())
 	n.Lock()
 	defer n.Unlock()
@@ -181,7 +181,7 @@ func (n *Nameserver) deleteTombstones() {
 	})
 }
 
-func (n *Nameserver) Gossip() router.GossipData {
+func (n *Nameserver) Gossip() mesh.GossipData {
 	n.RLock()
 	defer n.RUnlock()
 	gossip := &GossipData{
@@ -192,11 +192,11 @@ func (n *Nameserver) Gossip() router.GossipData {
 	return gossip
 }
 
-func (n *Nameserver) OnGossipUnicast(sender router.PeerName, msg []byte) error {
+func (n *Nameserver) OnGossipUnicast(sender mesh.PeerName, msg []byte) error {
 	return nil
 }
 
-func (n *Nameserver) receiveGossip(msg []byte) (router.GossipData, router.GossipData, error) {
+func (n *Nameserver) receiveGossip(msg []byte) (mesh.GossipData, mesh.GossipData, error) {
 	var gossip GossipData
 	if err := gossip.Decode(msg); err != nil {
 		return nil, nil, err
@@ -221,14 +221,14 @@ func (n *Nameserver) receiveGossip(msg []byte) (router.GossipData, router.Gossip
 
 // merge received data into state and return "everything new I've
 // just learnt", or nil if nothing in the received data was new
-func (n *Nameserver) OnGossip(msg []byte) (router.GossipData, error) {
+func (n *Nameserver) OnGossip(msg []byte) (mesh.GossipData, error) {
 	newEntries, _, err := n.receiveGossip(msg)
 	return newEntries, err
 }
 
 // merge received data into state and return a representation of
 // the received data, for further propagation
-func (n *Nameserver) OnGossipBroadcast(_ router.PeerName, msg []byte) (router.GossipData, error) {
+func (n *Nameserver) OnGossipBroadcast(_ mesh.PeerName, msg []byte) (mesh.GossipData, error) {
 	_, entries, err := n.receiveGossip(msg)
 	return entries, err
 }

--- a/nameserver/nameserver_test.go
+++ b/nameserver/nameserver_test.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	"github.com/weaveworks/weave/router"
 	wt "github.com/weaveworks/weave/testing"
 	"github.com/weaveworks/weave/testing/gossip"
 )
 
-func makeNameserver(name router.PeerName) *Nameserver {
-	return New(name, "", func(router.PeerName) bool { return true })
+func makeNameserver(name mesh.PeerName) *Nameserver {
+	return New(name, "", func(mesh.PeerName) bool { return true })
 }
 
 func makeNetwork(size int) ([]*Nameserver, *gossip.TestRouter) {
@@ -26,7 +26,7 @@ func makeNetwork(size int) ([]*Nameserver, *gossip.TestRouter) {
 	nameservers := make([]*Nameserver, size)
 
 	for i := 0; i < size; i++ {
-		name, _ := router.PeerNameFromString(fmt.Sprintf("%02d:00:00:02:00:00", i))
+		name, _ := mesh.PeerNameFromString(fmt.Sprintf("%02d:00:00:02:00:00", i))
 		nameserver := makeNameserver(name)
 		nameserver.SetGossip(gossipRouter.Connect(nameserver.ourName, nameserver))
 		nameserver.Start()
@@ -44,7 +44,7 @@ func stopNetwork(nameservers []*Nameserver, grouter *gossip.TestRouter) {
 }
 
 type pair struct {
-	origin router.PeerName
+	origin mesh.PeerName
 	addr   address.Address
 }
 
@@ -91,7 +91,7 @@ func testNameservers(t *testing.T) {
 	badNameservers := nameservers[25:]
 	// This subset will remain well-connected, and we will deal mainly with them
 	nameservers = nameservers[:25]
-	nameserversByName := map[router.PeerName]*Nameserver{}
+	nameserversByName := map[mesh.PeerName]*Nameserver{}
 	for _, n := range nameservers {
 		nameserversByName[n.ourName] = n
 	}
@@ -226,7 +226,7 @@ func testNameservers(t *testing.T) {
 }
 
 func TestContainerAndPeerDeath(t *testing.T) {
-	peername, err := router.PeerNameFromString("00:00:00:02:00:00")
+	peername, err := mesh.PeerNameFromString("00:00:00:02:00:00")
 	require.Nil(t, err)
 	nameserver := makeNameserver(peername)
 
@@ -250,7 +250,7 @@ func TestTombstoneDeletion(t *testing.T) {
 	defer func() { now = oldNow }()
 	now = func() int64 { return 1234 }
 
-	peername, err := router.PeerNameFromString("00:00:00:02:00:00")
+	peername, err := mesh.PeerNameFromString("00:00:00:02:00:00")
 	require.Nil(t, err)
 	nameserver := makeNameserver(peername)
 

--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	. "github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/ipam"
+	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/nameserver"
 	"github.com/weaveworks/weave/net/address"
 	weave "github.com/weaveworks/weave/router"
@@ -24,14 +25,14 @@ var rootTemplate = template.New("root").Funcs(map[string]interface{}{
 		}
 		return count
 	},
-	"printConnectionCounts": func(conns []weave.LocalConnectionStatus) string {
+	"printConnectionCounts": func(conns []mesh.LocalConnectionStatus) string {
 		counts := make(map[string]int)
 		for _, conn := range conns {
 			counts[conn.State]++
 		}
 		return printCounts(counts, []string{"established", "pending", "retrying", "failed", "connecting"})
 	},
-	"printPeerConnectionCounts": func(peers []weave.PeerStatus) string {
+	"printPeerConnectionCounts": func(peers []mesh.PeerStatus) string {
 		counts := make(map[string]int)
 		for _, peer := range peers {
 			for _, conn := range peer.Connections {

--- a/router/flow.go
+++ b/router/flow.go
@@ -1,6 +1,10 @@
 package router
 
-import "net"
+import (
+	"net"
+
+	"github.com/weaveworks/weave/mesh"
+)
 
 // Just enough flow machinery for the weave router
 
@@ -16,8 +20,8 @@ type PacketKey struct {
 }
 
 type ForwardPacketKey struct {
-	SrcPeer *Peer
-	DstPeer *Peer
+	SrcPeer *mesh.Peer
+	DstPeer *mesh.Peer
 	PacketKey
 }
 

--- a/router/http.go
+++ b/router/http.go
@@ -2,12 +2,13 @@ package router
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/gorilla/mux"
 	"github.com/weaveworks/weave/common"
-	"net/http"
 )
 
-func (router *Router) HandleHTTP(muxRouter *mux.Router) {
+func (router *NetworkRouter) HandleHTTP(muxRouter *mux.Router) {
 
 	muxRouter.Methods("POST").Path("/connect").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {

--- a/router/mac_cache.go
+++ b/router/mac_cache.go
@@ -4,11 +4,13 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"github.com/weaveworks/weave/mesh"
 )
 
 type MacCacheEntry struct {
 	lastSeen time.Time
-	peer     *Peer
+	peer     *mesh.Peer
 }
 
 type MacCache struct {
@@ -16,10 +18,10 @@ type MacCache struct {
 	table       map[uint64]*MacCacheEntry
 	maxAge      time.Duration
 	expiryTimer *time.Timer
-	onExpiry    func(net.HardwareAddr, *Peer)
+	onExpiry    func(net.HardwareAddr, *mesh.Peer)
 }
 
-func NewMacCache(maxAge time.Duration, onExpiry func(net.HardwareAddr, *Peer)) *MacCache {
+func NewMacCache(maxAge time.Duration, onExpiry func(net.HardwareAddr, *mesh.Peer)) *MacCache {
 	cache := &MacCache{
 		table:    make(map[uint64]*MacCacheEntry),
 		maxAge:   maxAge,
@@ -28,7 +30,7 @@ func NewMacCache(maxAge time.Duration, onExpiry func(net.HardwareAddr, *Peer)) *
 	return cache
 }
 
-func (cache *MacCache) add(mac net.HardwareAddr, peer *Peer, force bool) (bool, *Peer) {
+func (cache *MacCache) add(mac net.HardwareAddr, peer *mesh.Peer, force bool) (bool, *mesh.Peer) {
 	key := macint(mac)
 	now := time.Now()
 
@@ -64,15 +66,15 @@ func (cache *MacCache) add(mac net.HardwareAddr, peer *Peer, force bool) (bool, 
 	return false, nil
 }
 
-func (cache *MacCache) Add(mac net.HardwareAddr, peer *Peer) (bool, *Peer) {
+func (cache *MacCache) Add(mac net.HardwareAddr, peer *mesh.Peer) (bool, *mesh.Peer) {
 	return cache.add(mac, peer, false)
 }
 
-func (cache *MacCache) AddForced(mac net.HardwareAddr, peer *Peer) (bool, *Peer) {
+func (cache *MacCache) AddForced(mac net.HardwareAddr, peer *mesh.Peer) (bool, *mesh.Peer) {
 	return cache.add(mac, peer, true)
 }
 
-func (cache *MacCache) Lookup(mac net.HardwareAddr) *Peer {
+func (cache *MacCache) Lookup(mac net.HardwareAddr) *mesh.Peer {
 	key := macint(mac)
 	cache.RLock()
 	defer cache.RUnlock()
@@ -83,7 +85,7 @@ func (cache *MacCache) Lookup(mac net.HardwareAddr) *Peer {
 	return entry.peer
 }
 
-func (cache *MacCache) Delete(peer *Peer) bool {
+func (cache *MacCache) Delete(peer *mesh.Peer) bool {
 	found := false
 	cache.Lock()
 	defer cache.Unlock()

--- a/router/network_overlay.go
+++ b/router/network_overlay.go
@@ -1,8 +1,12 @@
 package router
 
+import (
+	"github.com/weaveworks/weave/mesh"
+)
+
 // Interface to overlay network packet handling
 type NetworkOverlay interface {
-	Overlay
+	mesh.Overlay
 
 	// The routes have changed, so any cached information should
 	// be discarded.
@@ -12,7 +16,7 @@ type NetworkOverlay interface {
 	InvalidateShortIDs()
 
 	// Start consuming forwarded packets.
-	StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error
+	StartConsumingPackets(*mesh.Peer, *mesh.Peers, OverlayConsumer) error
 }
 
 // When a consumer is called, the decoder will already have been used
@@ -21,7 +25,7 @@ type OverlayConsumer func(ForwardPacketKey) FlowOp
 
 // All of the machinery to forward packets to a particular peer
 type OverlayForwarder interface {
-	OverlayConnection
+	mesh.OverlayConnection
 	// Forward a packet across the connection.  May be called as soon
 	// as the overlay connection is created, in particular before
 	// Confirm().  The return value nil means the key could not be
@@ -29,7 +33,7 @@ type OverlayForwarder interface {
 	Forward(ForwardPacketKey) FlowOp
 }
 
-type NullNetworkOverlay struct{ NullOverlay }
+type NullNetworkOverlay struct{ mesh.NullOverlay }
 
 func (NullNetworkOverlay) InvalidateRoutes() {
 }
@@ -37,7 +41,7 @@ func (NullNetworkOverlay) InvalidateRoutes() {
 func (NullNetworkOverlay) InvalidateShortIDs() {
 }
 
-func (NullNetworkOverlay) StartConsumingPackets(*Peer, *Peers, OverlayConsumer) error {
+func (NullNetworkOverlay) StartConsumingPackets(*mesh.Peer, *mesh.Peers, OverlayConsumer) error {
 	return nil
 }
 

--- a/router/network_router_status.go
+++ b/router/network_router_status.go
@@ -2,10 +2,12 @@ package router
 
 import (
 	"time"
+
+	"github.com/weaveworks/weave/mesh"
 )
 
 type NetworkRouterStatus struct {
-	*Status
+	*mesh.Status
 	Interface    string
 	CaptureStats map[string]int
 	MACs         []MACStatus
@@ -20,7 +22,7 @@ type MACStatus struct {
 
 func NewNetworkRouterStatus(router *NetworkRouter) *NetworkRouterStatus {
 	return &NetworkRouterStatus{
-		NewStatus(router.Router),
+		mesh.NewStatus(router.Router),
 		router.Bridge.String(),
 		router.Bridge.Stats(),
 		NewMACStatusSlice(router.Macs)}


### PR DESCRIPTION
This is mostly a matter of moving some files, changing package names, changing some imports, and changing some type references.

We duplicate the odd constant & global var, and the intmac/macint functions, since neither 'router' or 'mesh' nor, really,' common' are a natural home for them.