### PR TITLE
Add FDP miss counter to reports

### DIFF
--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -218,6 +218,9 @@ func (fastdp fastDatapathBridge) String() string {
 }
 
 func (fastdp fastDatapathBridge) Stats() map[string]int {
+	lock := fastdp.startLock()
+	defer lock.unlock()
+
 	return map[string]int{
 		"FlowMisses": int(fastdp.missCount),
 	}

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -40,6 +40,7 @@ type FastDatapath struct {
 	dpif             *odp.Dpif
 	dp               odp.DatapathHandle
 	deleteFlowsCount uint64
+	missCount        uint64
 	missHandlers     map[odp.VportID]missHandler
 	localPeer        *mesh.Peer
 	peers            *mesh.Peers
@@ -216,8 +217,10 @@ func (fastdp fastDatapathBridge) String() string {
 	return fmt.Sprint(fastdp.dpname, " (via ODP)")
 }
 
-func (fastDatapathBridge) Stats() map[string]int {
-	return nil
+func (fastdp fastDatapathBridge) Stats() map[string]int {
+	return map[string]int{
+		"FlowMisses": int(fastdp.missCount),
+	}
 }
 
 var routerBridgePortID = bridgePortID{router: true}
@@ -936,6 +939,8 @@ func (fastdp *FastDatapath) Miss(packet []byte, fks odp.FlowKeys) error {
 
 	lock := fastdp.startLock()
 	defer lock.unlock()
+
+	fastdp.missCount++
 
 	handler := fastdp.getMissHandler(ingress)
 	if handler == nil {


### PR DESCRIPTION
Get some stats for `weave report` when using the FDP. This prints the number of _upcalls_ (ie, misses) as well as the number of flows in the datapath.

Fixes #1592

