### PR TITLE
Handle the case where Forward returns nil

### DIFF
--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -674,7 +674,10 @@ func (fwd *fastDatapathForwarder) sendHeartbeat() {
 		DstPeer:   fwd.remotePeer,
 	}
 	fwd.lock.RUnlock()
-	fwd.Forward(pk).Process(buf, dec, false)
+
+	if fop := fwd.Forward(pk); fop != nil {
+		fop.Process(buf, dec, false)
+	}
 }
 
 const (


### PR DESCRIPTION
Forward can return nil if the remote peer has HasShortID false.  That
can happen if we learn about a 1.2 peer from a 1.1  peer and attempt to
connect to it.

This change just fixes the panic.  HasShortID will never be set, so we'll
fall back to sleeve.  But if that occurs, if can be fixed by a restart of
the affected routers.

Addresses #1661.