### PR TITLE
Pin docker version in vagrant VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ require './vagrant-common.rb'
 vm_ip = "172.16.0.3" # arbitrary private IP
 
 pkgs = %w(
-  docker-engine
+  docker-engine=1.10.2-0~wily
   aufs-tools
   build-essential
   ethtool


### PR DESCRIPTION
Otherwise it will always install the latest docker version, which will be
undesirable when new major releases are done, until they are well tested.

For instance, docker 1.9 was killing my VM when spawning a kubernetes cluster,
due to a high CPU consumption, probably due to
https://github.com/docker/docker/issues/17720

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/weaveworks/weave/1672)
<!-- Reviewable:end -->
