### PR TITLE
Support weave script running against non-standard DOCKER_HOST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $(WEAVEWAIT_NOOP_EXE): prog/weavewait/*.go
 	go build $(BUILD_FLAGS) -o $@ ./$(@D)
 
 $(WEAVER_UPTODATE): prog/weaver/Dockerfile $(WEAVER_EXE)
-	$(SUDO) docker build -t $(WEAVER_IMAGE) prog/weaver
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -t $(WEAVER_IMAGE) prog/weaver
 	touch $@
 
 $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile prog/weaveexec/symlink $(DOCKER_DISTRIB) weave $(SIGPROXY_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(WEAVEWAIT_NOMCAST_EXE) $(NETCHECK_EXE) $(DOCKERTLSARGS_EXE)
@@ -116,7 +116,7 @@ $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile prog/weaveexec/symlink $(DOCKER
 	cp $(NETCHECK_EXE) prog/weaveexec/netcheck
 	cp $(DOCKERTLSARGS_EXE) prog/weaveexec/docker_tls_args
 	cp $(DOCKER_DISTRIB) prog/weaveexec/docker.tgz
-	$(SUDO) docker build -t $(WEAVEEXEC_IMAGE) prog/weaveexec
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -t $(WEAVEEXEC_IMAGE) prog/weaveexec
 	touch $@
 
 $(DOCKERPLUGIN_UPTODATE): prog/plugin/Dockerfile $(DOCKERPLUGIN_EXE)
@@ -124,7 +124,7 @@ $(DOCKERPLUGIN_UPTODATE): prog/plugin/Dockerfile $(DOCKERPLUGIN_EXE)
 	touch $@
 
 $(WEAVE_EXPORT): $(IMAGES_UPTODATE)
-	$(SUDO) docker save $(addsuffix :latest,$(IMAGES)) | gzip > $@
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker save $(addsuffix :latest,$(IMAGES)) | gzip > $@
 
 $(DOCKER_DISTRIB):
 	curl -o $(DOCKER_DISTRIB) $(DOCKER_DISTRIB_URL)
@@ -142,16 +142,16 @@ $(RUNNER_EXE): tools/.git
 	make -C tools/runner
 
 $(PUBLISH): publish_%: $(IMAGES_UPTODATE)
-	$(SUDO) docker tag -f $(DOCKERHUB_USER)/$* $(DOCKERHUB_USER)/$*:$(WEAVE_VERSION)
-	$(SUDO) docker push   $(DOCKERHUB_USER)/$*:$(WEAVE_VERSION)
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker tag -f $(DOCKERHUB_USER)/$* $(DOCKERHUB_USER)/$*:$(WEAVE_VERSION)
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker push   $(DOCKERHUB_USER)/$*:$(WEAVE_VERSION)
 ifneq ($(UPDATE_LATEST),false)
-	$(SUDO) docker push   $(DOCKERHUB_USER)/$*:latest
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker push   $(DOCKERHUB_USER)/$*:latest
 endif
 
 publish: $(PUBLISH)
 
 clean-bin:
-	-$(SUDO) docker rmi $(IMAGES)
+	-$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker rmi $(IMAGES)
 	go clean -r $(addprefix ./,$(dir $(EXES)))
 	rm -f $(EXES) $(IMAGES_UPTODATE) $(WEAVE_EXPORT)
 

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -2,6 +2,8 @@ package docker
 
 import (
 	"errors"
+	"strings"
+
 	"github.com/fsouza/go-dockerclient"
 
 	. "github.com/weaveworks/weave/common"
@@ -19,6 +21,9 @@ type Client struct {
 
 // NewClient creates a new Docker client and checks we can talk to Docker
 func NewClient(apiPath string) (*Client, error) {
+	if apiPath != "" && !strings.Contains(apiPath, "://") {
+		apiPath = "tcp://" + apiPath
+	}
 	dc, err := docker.NewClient(apiPath)
 	if err != nil {
 		return nil, err
@@ -29,6 +34,9 @@ func NewClient(apiPath string) (*Client, error) {
 }
 
 func NewVersionedClient(apiPath string, apiVersionString string) (*Client, error) {
+	if !strings.Contains(apiPath, "://") {
+		apiPath = "tcp://" + apiPath
+	}
 	dc, err := docker.NewVersionedClient(apiPath, apiVersionString)
 	if err != nil {
 		return nil, err

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -30,7 +30,7 @@ func NewClient(apiPath string) (*Client, error) {
 	}
 	client := &Client{dc}
 
-	return client, client.checkWorking(apiPath)
+	return client, client.checkWorking()
 }
 
 func NewVersionedClient(apiPath string, apiVersionString string) (*Client, error) {
@@ -43,15 +43,25 @@ func NewVersionedClient(apiPath string, apiVersionString string) (*Client, error
 	}
 	client := &Client{dc}
 
-	return client, client.checkWorking(apiPath)
+	return client, client.checkWorking()
 }
 
-func (c *Client) checkWorking(apiPath string) error {
+func NewVersionedClientFromEnv(apiVersionString string) (*Client, error) {
+	dc, err := docker.NewVersionedClientFromEnv(apiVersionString)
+	if err != nil {
+		return nil, err
+	}
+	client := &Client{dc}
+
+	return client, client.checkWorking()
+}
+
+func (c *Client) checkWorking() error {
 	env, err := c.Version()
 	if err != nil {
 		return err
 	}
-	Log.Infof("[docker] Using Docker API on %s: %v", apiPath, env)
+	Log.Infof("[docker] Using Docker API on %s: %v", c.Endpoint(), env)
 	return nil
 }
 

--- a/prog/plugin/main.go
+++ b/prog/plugin/main.go
@@ -49,7 +49,7 @@ func main() {
 	Log.Println("Weave plugin", version, "Command line options:", os.Args[1:])
 
 	// API 1.21 is the first version that supports docker network commands
-	dockerClient, err := docker.NewVersionedClient("unix:///var/run/docker.sock", "1.21")
+	dockerClient, err := docker.NewVersionedClientFromEnv("1.21")
 	if err != nil {
 		Log.Fatalf("unable to connect to docker: %s", err)
 	}

--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	version = "(unreleased version)"
+	version           = "(unreleased version)"
+	defaultDockerHost = "unix:///var/run/docker.sock"
 )
 
 func main() {
@@ -60,6 +61,11 @@ func main() {
 
 	Log.Infoln("weave proxy", version)
 	Log.Infoln("Command line arguments:", strings.Join(os.Args[1:], " "))
+
+	c.DockerHost = defaultDockerHost
+	if dockerHost := os.Getenv("DOCKER_HOST"); dockerHost != "" {
+		c.DockerHost = dockerHost
+	}
 
 	p, err := proxy.NewProxy(c)
 	if err != nil {

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -70,7 +70,13 @@ func main() {
 		iface                     *net.Interface
 		datapathName              string
 		trustedSubnetStr          string
+
+		defaultDockerHost = "unix:///var/run/docker.sock"
 	)
+
+	if val := os.Getenv("DOCKER_HOST"); val != "" {
+		defaultDockerHost = val
+	}
 
 	mflag.BoolVar(&justVersion, []string{"#version", "-version"}, false, "print version and exit")
 	mflag.BoolVar(&createDatapath, []string{"-create-datapath"}, false, "create ODP datapath and exit")
@@ -93,7 +99,7 @@ func main() {
 	mflag.StringVar(&iprangeCIDR, []string{"#iprange", "#-iprange", "-ipalloc-range"}, "", "IP address range reserved for automatic allocation, in CIDR notation")
 	mflag.StringVar(&ipsubnetCIDR, []string{"#ipsubnet", "#-ipsubnet", "-ipalloc-default-subnet"}, "", "subnet to allocate within by default, in CIDR notation")
 	mflag.IntVar(&peerCount, []string{"#initpeercount", "#-initpeercount", "-init-peer-count"}, 0, "number of peers in network (for IP address allocation)")
-	mflag.StringVar(&dockerAPI, []string{"#api", "#-api", "-docker-api"}, "", "Docker API endpoint, e.g. unix:///var/run/docker.sock")
+	mflag.StringVar(&dockerAPI, []string{"#api", "#-api", "-docker-api"}, defaultDockerHost, "Docker API endpoint")
 	mflag.BoolVar(&noDNS, []string{"-no-dns"}, false, "disable DNS server")
 	mflag.StringVar(&dnsDomain, []string{"-dns-domain"}, nameserver.DefaultDomain, "local domain to server requests for")
 	mflag.StringVar(&dnsListenAddress, []string{"-dns-listen-address"}, nameserver.DefaultListenAddress, "address to listen on for DNS requests")

--- a/proxy/common.go
+++ b/proxy/common.go
@@ -39,6 +39,7 @@ func callWeave(args ...string) ([]byte, []byte, error) {
 	}
 
 	propagateEnv("DOCKER_BRIDGE")
+	propagateEnv("DOCKER_HOST")
 
 	// Propogage WEAVE_DEBUG, to make debugging easier.
 	propagateEnv("WEAVE_DEBUG")

--- a/test/650_proxy_env_test.sh
+++ b/test/650_proxy_env_test.sh
@@ -30,7 +30,7 @@ check
 
 # Check we can use weave env/config with unix -Hs specified
 weave_on $HOST1 stop
-weave_on $HOST1 launch-proxy -H unix:///var/run/weave/weave.sock
+run_on $HOST1 "COVERAGE=$COVERAGE weave launch-proxy -H unix:///var/run/weave/weave.sock"
 assert_raises "run_on $HOST1 'eval \$(weave env) ; docker $CMD'"
 assert_raises "run_on $HOST1 'docker \$(weave config) $CMD'"
 

--- a/test/690_proxy_config_test.sh
+++ b/test/690_proxy_config_test.sh
@@ -5,7 +5,7 @@
 start_suite "Various launch-proxy configurations"
 
 # Booting it over unix socket listens on unix socket
-run_on $HOST1 COVERAGE=$COVERAGE sudo -E weave launch-proxy
+run_on $HOST1 COVERAGE=$COVERAGE weave launch-proxy
 assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave/weave.sock ps"
 assert_raises "proxy docker_on $HOST1 ps" 1
 weave_on $HOST1 stop-proxy
@@ -17,15 +17,20 @@ assert_raises "proxy docker_on $HOST1 ps"
 weave_on $HOST1 stop-proxy
 
 # Booting it over tcp (no prefix) listens on tcp
-DOCKER_CLIENT_ARGS="-H $HOST1:$DOCKER_PORT" $WEAVE launch-proxy
+DOCKER_HOST=tcp://$HOST1:$DOCKER_PORT $WEAVE launch-proxy
 assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave/weave.sock ps" 1
 assert_raises "proxy docker_on $HOST1 ps"
 weave_on $HOST1 stop-proxy
 
 # Booting it with -H outside /var/run/weave, still works
-socket="$(mktemp -d)/weave.sock"
+socket="$($SSH $HOST1 mktemp -d)/weave.sock"
 weave_on $HOST1 launch-proxy -H unix://$socket
 assert_raises "run_on $HOST1 sudo docker -H unix:///$socket ps" 0
+weave_on $HOST1 stop-proxy
+
+# Booting it against non-standard docker unix sock
+run_on $HOST1 "DOCKER_HOST=unix:///var/run/alt-docker.sock COVERAGE=$COVERAGE weave launch-proxy -H tcp://0.0.0.0:12375"
+assert_raises "proxy docker_on $HOST1 ps"
 weave_on $HOST1 stop-proxy
 
 # Booting it over tls errors

--- a/test/gce.sh
+++ b/test/gce.sh
@@ -11,7 +11,7 @@ set -e
 : ${SSH_KEY_FILE:=$HOME/.ssh/gce_ssh_key}
 : ${PROJECT:=positive-cocoa-90213}
 : ${IMAGE:=ubuntu-14-04}
-: ${TEMPLATE_NAME:=test-template-8}
+: ${TEMPLATE_NAME:=test-template-9}
 : ${ZONE:=us-central1-a}
 : ${NUM_HOSTS:=5}
 SUFFIX=""
@@ -73,7 +73,7 @@ curl -sSL https://get.docker.com/ | sh
 apt-get update -qq;
 apt-get install -q -y --force-yes --no-install-recommends ethtool;
 usermod -a -G docker vagrant;
-echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375 -s overlay"' >> /etc/default/docker;
+echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock -H unix:///var/run/alt-docker.sock -H tcp://0.0.0.0:2375 -s overlay"' >> /etc/default/docker;
 service docker restart
 EOF
 	# It seems we need a short delay for docker to start up, so I put this in

--- a/vagrant-common.rb
+++ b/vagrant-common.rb
@@ -45,7 +45,7 @@ end
 def tweak_docker_daemon(vm)
   vm.provision :shell, :inline => <<SCRIPT
 usermod -a -G docker vagrant
-sed -i -e's%-H fd://%-H fd:// -H tcp://0.0.0.0:2375 -s overlay%' /lib/systemd/system/docker.service
+sed -i -e's%-H fd://%-H fd:// -H unix:///var/run/alt-docker.sock -H tcp://0.0.0.0:2375 -s overlay%' /lib/systemd/system/docker.service
 systemctl daemon-reload
 systemctl restart docker
 systemctl enable docker

--- a/weave
+++ b/weave
@@ -96,9 +96,21 @@ usage() {
     exit 1
 }
 
+docker_sock() {
+  if echo "$DOCKER_HOST" | grep -q "^unix://" >/dev/null; then
+    echo "${DOCKER_HOST#unix://}"
+  else
+    echo "/var/run/docker.sock"
+  fi
+}
+
+docker_sock_volume_mount() {
+  echo "-v $(docker_sock):$(docker_sock) -e DOCKER_HOST=unix://$(docker_sock)"
+}
+
 exec_remote() {
     docker $DOCKER_CLIENT_ARGS run --rm --privileged --net=host \
-        -v /var/run/docker.sock:/var/run/docker.sock \
+        $(docker_sock_volume_mount) \
         -v /proc:/hostproc \
         -e PROCFS=/hostproc \
         -e DOCKERHUB_USER="$DOCKERHUB_USER" \
@@ -1609,7 +1621,7 @@ launch_router() {
     # additional parameters, such as resource limits, to docker
     # when launching the weave container.
     ROUTER_CONTAINER=$(docker run --privileged -d --name=$CONTAINER_NAME \
-        -v /var/run/docker.sock:/var/run/docker.sock \
+        $(docker_sock_volume_mount) \
         -p $PORT:$CONTAINER_PORT/tcp -p $PORT:$CONTAINER_PORT/udp \
         ${NETHOST_OPT:-$DNS_PORT_MAPPING} \
         -e WEAVE_PASSWORD \
@@ -1621,7 +1633,7 @@ launch_router() {
         --dns-effective-listen-address $DOCKER_BRIDGE_IP \
         ${NETHOST_OPT:+$DNS_ROUTER_OPTS} $NO_DNS_OPT \
         --http-addr $HTTP_IP:$HTTP_PORT \
-        --docker-api "unix:///var/run/docker.sock" "$@")
+        --docker-api "unix://$(docker_sock)" "$@")
     with_container_netns_or_die $CONTAINER_NAME setup_router_iface_$BRIDGE_TYPE
     attach_router
 }
@@ -1666,7 +1678,7 @@ launch_proxy() {
     mkdir -p /var/run/weave
     PROXY_CONTAINER=$(docker run --privileged -d --name=$PROXY_CONTAINER_NAME --net=host \
         $PROXY_VOLUMES \
-        -v /var/run/docker.sock:/var/run/docker.sock \
+        $(docker_sock_volume_mount) \
         -v /var/run/weave:/var/run/weave \
         -v /proc:/hostproc \
         -e PROCFS=/hostproc \
@@ -1689,7 +1701,7 @@ launch_plugin() {
     PLUGIN_CONTAINER=$(docker run --privileged -d --name=$PLUGIN_CONTAINER_NAME \
         --restart=always \
         --net=host \
-        -v /var/run/docker.sock:/var/run/docker.sock \
+        $(docker_sock_volume_mount) \
         -v /run/docker/plugins:/run/docker/plugins \
         $PLUGIN_IMAGE "$@")
 }

--- a/weave
+++ b/weave
@@ -97,15 +97,19 @@ usage() {
 }
 
 docker_sock() {
+  if [ -z "$DOCKER_HOST" ]; then
+    echo "/var/run/docker.sock"
+    return
+  fi
   if echo "$DOCKER_HOST" | grep -q "^unix://" >/dev/null; then
     echo "${DOCKER_HOST#unix://}"
-  else
-    echo "/var/run/docker.sock"
   fi
 }
 
 docker_sock_volume_mount() {
-  echo "-v $(docker_sock):$(docker_sock) -e DOCKER_HOST=unix://$(docker_sock)"
+  if [ -n "$(docker_sock)" ]; then
+    echo "-v $(docker_sock):$(docker_sock)"
+  fi
 }
 
 exec_remote() {
@@ -125,6 +129,7 @@ exec_remote() {
         -e WEAVE_NO_FASTDP \
         -e WEAVE_NO_BRIDGED_FASTDP \
         -e WEAVE_NO_PLUGIN \
+        -e DOCKER_HOST \
         -e DOCKER_BRIDGE \
         -e DOCKER_CLIENT_HOST="$DOCKER_CLIENT_HOST" \
         -e DOCKER_CLIENT_ARGS \
@@ -1624,6 +1629,7 @@ launch_router() {
         $(docker_sock_volume_mount) \
         -p $PORT:$CONTAINER_PORT/tcp -p $PORT:$CONTAINER_PORT/udp \
         ${NETHOST_OPT:-$DNS_PORT_MAPPING} \
+        -e DOCKER_HOST \
         -e WEAVE_PASSWORD \
         -e WEAVE_CIDR=none \
         $WEAVE_DOCKER_ARGS $IMAGE $COVERAGE_ARGS \
@@ -1633,7 +1639,7 @@ launch_router() {
         --dns-effective-listen-address $DOCKER_BRIDGE_IP \
         ${NETHOST_OPT:+$DNS_ROUTER_OPTS} $NO_DNS_OPT \
         --http-addr $HTTP_IP:$HTTP_PORT \
-        --docker-api "unix://$(docker_sock)" "$@")
+        "$@")
     with_container_netns_or_die $CONTAINER_NAME setup_router_iface_$BRIDGE_TYPE
     attach_router
 }
@@ -1683,6 +1689,7 @@ launch_proxy() {
         -v /proc:/hostproc \
         -e PROCFS=/hostproc \
         -e WEAVE_CIDR=none \
+        -e DOCKER_HOST \
         -e DOCKER_BRIDGE \
         -e WEAVE_DEBUG \
         -e COVERAGE \
@@ -1703,6 +1710,7 @@ launch_plugin() {
         --net=host \
         $(docker_sock_volume_mount) \
         -v /run/docker/plugins:/run/docker/plugins \
+        -e DOCKER_HOST \
         $PLUGIN_IMAGE "$@")
 }
 


### PR DESCRIPTION
First part of fixing #1586.

Need to check it works with the plugin, and `DOCKER_HOST=tcp://*` as well. Any docker invocations I've missed, that need `DOCKER_HOST` passed in?