### PR TITLE
Fix erroneously hyphenated Docker TLS arguments

### DIFF
--- a/site/proxy.md
+++ b/site/proxy.md
@@ -237,8 +237,8 @@ supplied to the docker daemon. For example, if you have generated your
 certificates and keys into the docker host's `/tls` directory, we can
 launch the proxy with:
 
-    host1$ weave launch-proxy --tls-verify --tls-cacert=/tls/ca.pem \
-             --tls-cert=/tls/server-cert.pem --tls-key=/tls/server-key.pem
+    host1$ weave launch-proxy --tlsverify --tlscacert=/tls/ca.pem \
+             --tlscert=/tls/server-cert.pem --tlskey=/tls/server-key.pem
 
 The paths to your certificates and key must be provided as absolute
 paths which exist on the docker host.
@@ -254,8 +254,8 @@ for an example.
 With the proxy running over TLS, we can configure our regular docker
 client to use TLS on a per-invocation basis with
 
-    $ docker --tls-verify --tls-cacert=ca.pem --tls-cert=cert.pem \
-         --tls-key=key.pem -H=tcp://host1:12375 version
+    $ docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem \
+         --tlskey=key.pem -H=tcp://host1:12375 version
     ...
 
 or,


### PR DESCRIPTION
Need to manually merge `latest_release_doc_updates`->`1.3`->`master` after PR merge.

Fixes #1693.