### PR TITLE
Raise minimum Docker version to 1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ IMAGES=$(WEAVER_IMAGE) $(WEAVEEXEC_IMAGE)
 
 WEAVE_EXPORT=weave.tar.gz
 
-WEAVEEXEC_DOCKER_VERSION=1.3.1
+WEAVEEXEC_DOCKER_VERSION=1.6.2
 DOCKER_DISTRIB=prog/weaveexec/docker-$(WEAVEEXEC_DOCKER_VERSION).tgz
 DOCKER_DISTRIB_URL=https://get.docker.com/builds/Linux/x86_64/docker-$(WEAVEEXEC_DOCKER_VERSION).tgz
 NETGO_CHECK=@strings $@ | grep cgo_stub\\\.go >/dev/null || { \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ capabilities, so these can continue to be used by containers.
 ## Installation
 
 Ensure you are running Linux (kernel 3.8 or later) and have Docker
-(version 1.3.1 or later) installed. Then install weave with
+(version 1.6.0 or later) installed. Then install weave with
 
     sudo curl -L git.io/weave -o /usr/local/bin/weave
     sudo chmod a+x /usr/local/bin/weave

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu
 RUN apt-get -y update && apt-get -y install --no-install-recommends ca-certificates apt-transport-https
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
-RUN apt-get -y update && apt-get -y install --no-install-recommends build-essential git lxc-docker-1.3.1 mercurial libpcap-dev curl make pkg-config gcc bison flex python-requests
+RUN apt-get -y update && apt-get -y install --no-install-recommends build-essential git lxc-docker-1.6.2 mercurial libpcap-dev curl make pkg-config gcc bison flex python-requests
 
 # When doing a build in a container, "apt-get update" happens twice,
 # which can be a very significant overhead for incremental builds.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -81,12 +81,12 @@ func NewProxy(c Config) (*Proxy, error) {
 		Log.Fatalf("Could not configure tls for proxy: %s", err)
 	}
 
-	// We pin the protocol version to 1.15 (which corresponds to
-	// Docker 1.3.x; the earliest version supported by weave) in order
+	// We pin the protocol version to 1.18 (which corresponds to
+	// Docker 1.6.x; the earliest version supported by weave) in order
 	// to insulate ourselves from breaking changes to the API, as
 	// happened in 1.20 (Docker 1.8.0) when the presentation of
 	// volumes changed in `inspect`.
-	client, err := weavedocker.NewVersionedClient(dockerSockUnix, "1.15")
+	client, err := weavedocker.NewVersionedClient(dockerSockUnix, "1.18")
 	if err != nil {
 		return nil, err
 	}

--- a/site/building.md
+++ b/site/building.md
@@ -11,7 +11,7 @@ You only need to build weave if you want to work on the weave codebase
 Apart from the `weave` shell script, weave is delivered as a set of
 container images.  There is no distribution-specific packaging, so in
 principle it shouldn't matter which Linux distribution you build
-under.  But naturally, Docker is a prerequisite (version 1.3.1 or
+under.  But naturally, Docker is a prerequisite (version 1.6.0 or
 later).  And it is difficult to build under Fedora because [Fedora
 does not include static
 libraries](http://fedoraproject.org/wiki/Packaging:Guidelines#Packaging_Static_Libraries).

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@ This directory contains integration tests for weave.
 
 ## Requirements
 
-You need two VMs with docker >=1.3.1 installed and listening on TCP
+You need two VMs with docker >=1.6.0 installed and listening on TCP
 port 2375 (see below). You also need to be able to ssh to these VMs,
 preferably without having to input anything.
 

--- a/weave
+++ b/weave
@@ -11,19 +11,14 @@ else
 fi
 IMAGE_VERSION=${WEAVE_VERSION:-$IMAGE_VERSION}
 
-# - Docker versions prior to 1.2.0 cannot parse `--dns-search=.`
-# - Docker versions prior to 1.3.0 fail to include the domain when
-#   setting the hostname, so lookups for non-fq names fail.
-# - Docker version 1.3.0 contains the severe bug
-#   https://github.com/docker/docker/issues/8632
-# - The weavexec image embeds a Docker 1.3.1 client. Misleading
-#   version mismatch errors are produced if the user is running with a
-#   client *and* server with a lower version.
-# - Docker will complain if you run a client against a server older
-#   than that client.
+# - Docker versions prior to 1.6 cannot pull images from DockerHub
+# - The weavexec image embeds a Docker 1.6.2 client. Docker will give
+#   a "client is newer than server error" if the daemon has an older
+#   API version, which could be confusing if the user's Docker client
+#   is correctly matched with that older version.
 #
-# We therefore check that the user's Docker *client* is >= 1.3.1
-MIN_DOCKER_VERSION=1.3.1
+# We therefore check that the user's Docker *client* is >= 1.6
+MIN_DOCKER_VERSION=1.6.0
 
 # These are needed for remote execs, hence we introduce them here
 DOCKERHUB_USER=${DOCKERHUB_USER:-weaveworks}


### PR DESCRIPTION
Fixes #1683; replaces #1701 which was against wrong branch