### PR TITLE
update Peer.HasShortID as part of topology merge

### DIFF
--- a/mesh/peers.go
+++ b/mesh/peers.go
@@ -476,16 +476,20 @@ func (peers *Peers) applyUpdate(decodedUpdate []*Peer, decodedConns [][]Connecti
 			newUpdate[name] = void
 		default: // existing peer
 			if newPeer.Version < peer.Version ||
-				(newPeer.Version == peer.Version && newPeer.UID <= peer.UID) {
+				(newPeer.Version == peer.Version &&
+					(newPeer.UID < peer.UID ||
+						(newPeer.UID == peer.UID &&
+							(!newPeer.HasShortID || peer.HasShortID)))) {
 				continue
 			}
 			peer.Version = newPeer.Version
 			peer.UID = newPeer.UID
 			peer.connections = makeConnsMap(peer, connSummaries, peers.byName)
 
-			if newPeer.ShortID != peer.ShortID {
+			if newPeer.ShortID != peer.ShortID || newPeer.HasShortID != peer.HasShortID {
 				peers.deleteByShortID(peer, pending)
 				peer.ShortID = newPeer.ShortID
+				peer.HasShortID = newPeer.HasShortID
 				peers.addByShortID(peer, pending)
 			}
 			newUpdate[name] = void


### PR DESCRIPTION
This was missing.

There are two parts to this change:

1. updating the Peers.byName mapping when HasShortID changed (in addition to the existing update on ShortID change). We need to be careful about the sequencing here - both ShortID and HasShortID must be set between the calls to deleteByShortID and addByShortID, since the former is meant to delete the existing entry (hence use the old values) and the latter add the new entry (hence use the new values).

2. update a peer when the received info has the same version and UID but the current record has HasShortID=false, and the received info has HasShortID=true. This caters for the case where we receive an update about a weave 1.2+ peer first via a pre-1.2 peer (which does not transmit ShortIDs, and always sets HasShortID=false) and subsequently via a 1.2+ peer. The former update will force us to communicate with that peer over the 'sleeve' overlay. We want to accept the latter update, even though the version is the same, in order to update the ShortID and HasShortID, so we can switch to fastdp.

Fixes #1731.