### PR TITLE
remove UnknownPeerError for quicker convergence and efficiency

### DIFF
--- a/mesh/local_peer.go
+++ b/mesh/local_peer.go
@@ -157,7 +157,7 @@ func (peer *LocalPeer) handleAddConnection(conn Connection) error {
 	}
 
 	peer.router.Routes.Recalculate()
-	peer.broadcastPeerUpdate(conn.Remote())
+	peer.broadcastPeerUpdate()
 
 	return nil
 }
@@ -199,13 +199,13 @@ func (peer *LocalPeer) handleDeleteConnection(conn Connection) {
 
 // helpers
 
-func (peer *LocalPeer) broadcastPeerUpdate(peers ...*Peer) {
+func (peer *LocalPeer) broadcastPeerUpdate() {
 	// Some tests run without a router.  This should be fixed so
 	// that the relevant part of Router can be easily run in the
 	// context of a test, but that will involve significant
 	// reworking of tests.
 	if peer.router != nil {
-		peer.router.BroadcastTopologyUpdate(append(peers, peer.Peer))
+		peer.router.BroadcastTopologyUpdate([]*Peer{peer.Peer})
 	}
 }
 

--- a/mesh/peer.go
+++ b/mesh/peer.go
@@ -26,7 +26,12 @@ func randUint16() (r uint16) {
 type PeerUID uint64
 
 func randomPeerUID() PeerUID {
-	return PeerUID(randUint64())
+	for {
+		uid := randUint64()
+		if uid != 0 { // uid 0 is reserved for peer placeholder
+			return PeerUID(uid)
+		}
+	}
 }
 
 func ParsePeerUID(s string) (PeerUID, error) {
@@ -93,6 +98,10 @@ func NewPeer(name PeerName, nickName string, uid PeerUID, version uint64, shortI
 		ShortID:    shortID,
 		HasShortID: true,
 	})
+}
+
+func NewPeerPlaceholder(name PeerName) *Peer {
+	return NewPeerFromSummary(PeerSummary{NameByte: name.Bin()})
 }
 
 func NewPeerFrom(peer *Peer) *Peer {

--- a/mesh/router.go
+++ b/mesh/router.go
@@ -172,14 +172,6 @@ func (router *Router) OnGossip(update []byte) (GossipData, error) {
 
 func (router *Router) applyTopologyUpdate(update []byte) (PeerNameSet, PeerNameSet, error) {
 	origUpdate, newUpdate, err := router.Peers.ApplyUpdate(update)
-	if _, ok := err.(UnknownPeerError); err != nil && ok {
-		// That update contained a reference to a peer which wasn't
-		// itself included in the update, and we didn't know about
-		// already. We ignore this; eventually we should receive an
-		// update containing a complete topology.
-		log.Println("Topology gossip:", err)
-		return nil, nil, nil
-	}
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
When encountering an unknown peer in received gossip, rather than ignoring the entire gossip we create a placeholder Peer. This has version 0 and uid 0, which means it will be replaced by any complete peer information subsequently received via gossip.

Not ignoring the gossip results in quicker convergence.

We also no longer need to broadcast about the remote peer when adding a connection, since we only did that in order to reduce the occurrence of `UnknownPeerError`s. Not needing to do this is is more efficient, since the broadcast was strictly redundant.