### PR TITLE
[proxy] Symlink sockets to /var/run/weave/weave.sock from inside the proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(WEAVER_UPTODATE): prog/weaver/Dockerfile $(WEAVER_EXE)
 	$(SUDO) docker build -t $(WEAVER_IMAGE) prog/weaver
 	touch $@
 
-$(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile $(DOCKER_DISTRIB) weave $(SIGPROXY_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(NETCHECK_EXE) $(DOCKERTLSARGS_EXE)
+$(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile prog/weaveexec/symlink $(DOCKER_DISTRIB) weave $(SIGPROXY_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(NETCHECK_EXE) $(DOCKERTLSARGS_EXE)
 	cp weave prog/weaveexec/weave
 	cp $(SIGPROXY_EXE) prog/weaveexec/sigproxy
 	cp $(WEAVEPROXY_EXE) prog/weaveexec/weaveproxy

--- a/prog/weaveexec/Dockerfile
+++ b/prog/weaveexec/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --update \
     bind-tools \
   && rm -rf /var/cache/apk/*
 
-ADD ./weave ./sigproxy ./weaveproxy /home/weave/
+ADD ./weave ./sigproxy ./weaveproxy ./symlink /home/weave/
 ADD ./netcheck ./docker_tls_args /usr/bin/
 ADD ./weavewait /w/w
 ADD ./weavewait_noop /w-noop/w

--- a/prog/weaveexec/symlink
+++ b/prog/weaveexec/symlink
@@ -4,7 +4,7 @@
 
 set -e
 
-[ -z "$DEBUG" ] || set -x
+[ -z "$WEAVE_DEBUG" ] || set -x
 
 target="$1"
 user="$(stat -c '%u:%g' "$target")"

--- a/prog/weaveexec/symlink
+++ b/prog/weaveexec/symlink
@@ -1,0 +1,18 @@
+#!/bin/sh
+# This lets us force-symlink a bunch of stuff all at once, so we can minimize
+# running containers.
+
+set -e
+
+[ -z "$DEBUG" ] || set -x
+
+target="$1"
+user="$(stat -c '%u:%g' "$target")"
+mode="$(stat -c '%a' "$target")"
+shift 1
+
+for link in "$@" ; do
+  ln -sfT "$target" "$link"
+done
+chown -h "$user" "$@"
+chmod "$mode" "$@"

--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -19,7 +19,7 @@ func main() {
 	var (
 		justVersion bool
 		logLevel    = "info"
-		c           = proxy.Config{ListenAddrs: []string{}}
+		c           = proxy.Config{Image: "weaveworks/weaveexec"}
 	)
 
 	c.Version = version
@@ -52,6 +52,10 @@ func main() {
 	}
 
 	SetLogLevel(logLevel)
+
+	if image := os.Getenv("EXEC_IMAGE"); image != "" {
+		c.Image = image
+	}
 
 	Log.Infoln("weave proxy", version)
 	Log.Infoln("Command line arguments:", strings.Join(os.Args[1:], " "))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -575,8 +575,8 @@ func (proxy *Proxy) symlink(unixAddrs []string) (err error) {
 		"PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}
 
-	if val := os.Getenv("DEBUG"); val != "" {
-		env = append(env, fmt.Sprintf("%s=%s", "DEBUG", val))
+	if val := os.Getenv("WEAVE_DEBUG"); val != "" {
+		env = append(env, fmt.Sprintf("%s=%s", "WEAVE_DEBUG", val))
 	}
 
 	container, err = proxy.client.CreateContainer(docker.CreateContainerOptions{

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -194,7 +194,7 @@ func (proxy *Proxy) Listen() []net.Listener {
 	proxy.normalisedAddrs = []string{}
 	unixAddrs := []string{}
 	for _, addr := range proxy.ListenAddrs {
-		if strings.HasPrefix(addr, "unix://") {
+		if strings.HasPrefix(addr, "unix://") || strings.HasPrefix(addr, "/") {
 			unixAddrs = append(unixAddrs, addr)
 			continue
 		}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -568,7 +568,7 @@ func (proxy *Proxy) symlink(unixAddrs []string) (err error) {
 		proxy.normalisedAddrs = append(proxy.normalisedAddrs, addr)
 	}
 	if len(froms) == 0 {
-		return nil
+		return
 	}
 
 	env := []string{
@@ -589,7 +589,7 @@ func (proxy *Proxy) symlink(unixAddrs []string) (err error) {
 		HostConfig: &docker.HostConfig{Binds: binds},
 	})
 	if err != nil {
-		return err
+		return
 	}
 
 	defer func() {
@@ -599,8 +599,9 @@ func (proxy *Proxy) symlink(unixAddrs []string) (err error) {
 		}
 	}()
 
-	if err := proxy.client.StartContainer(container.ID, nil); err != nil {
-		return err
+	err = proxy.client.StartContainer(container.ID, nil)
+	if err != nil {
+		return
 	}
 
 	var buf bytes.Buffer
@@ -611,15 +612,16 @@ func (proxy *Proxy) symlink(unixAddrs []string) (err error) {
 		Stderr:      true,
 	})
 	if err != nil {
-		return err
+		return
 	}
 
-	rc, err := proxy.client.WaitContainer(container.ID)
+	var rc int
+	rc, err = proxy.client.WaitContainer(container.ID)
 	if err != nil {
-		return err
+		return
 	}
 	if rc != 0 {
-		return errors.New(buf.String())
+		err = errors.New(buf.String())
 	}
-	return nil
+	return
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -25,6 +27,9 @@ const (
 	defaultCertFile = "cert.pem"
 	dockerSock      = "/var/run/docker.sock"
 	dockerSockUnix  = "unix://" + dockerSock
+
+	weaveSock     = "/var/run/weave/weave.sock"
+	weaveSockUnix = "unix://" + weaveSock
 )
 
 var (
@@ -46,6 +51,7 @@ type Config struct {
 	HostnameFromLabel   string
 	HostnameMatch       string
 	HostnameReplacement string
+	Image               string
 	ListenAddrs         []string
 	RewriteInspect      bool
 	NoDefaultIPAM       bool
@@ -186,13 +192,32 @@ func (proxy *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (proxy *Proxy) Listen() []net.Listener {
 	listeners := []net.Listener{}
 	proxy.normalisedAddrs = []string{}
+	unixAddrs := []string{}
 	for _, addr := range proxy.ListenAddrs {
+		if strings.HasPrefix(addr, "unix://") {
+			unixAddrs = append(unixAddrs, addr)
+			continue
+		}
 		listener, normalisedAddr, err := proxy.listen(addr)
 		if err != nil {
 			Log.Fatalf("Cannot listen on %s: %s", addr, err)
 		}
 		listeners = append(listeners, listener)
 		proxy.normalisedAddrs = append(proxy.normalisedAddrs, normalisedAddr)
+	}
+
+	if len(unixAddrs) > 0 {
+		listener, _, err := proxy.listen(weaveSockUnix)
+		if err != nil {
+			Log.Fatalf("Cannot listen on %s: %s", weaveSockUnix, err)
+		}
+		listeners = append(listeners, listener)
+
+		if err := proxy.symlink(unixAddrs); err != nil {
+			Log.Fatalf("Cannot listen on unix sockets: %s", err)
+		}
+
+		proxy.normalisedAddrs = append(proxy.normalisedAddrs, weaveSockUnix)
 	}
 
 	for _, addr := range proxy.normalisedAddrs {
@@ -525,5 +550,76 @@ func (proxy *Proxy) updateContainerNetworkSettings(container jsonObject) error {
 	networkSettings["MacAddress"] = mac
 	networkSettings["IPAddress"] = ips[0].String()
 	networkSettings["IPPrefixLen"], _ = nets[0].Mask.Size()
+	return nil
+}
+
+func (proxy *Proxy) symlink(unixAddrs []string) (err error) {
+	var container *docker.Container
+	binds := []string{"/var/run/weave:/var/run/weave"}
+	froms := []string{}
+	for _, addr := range unixAddrs {
+		if addr == weaveSockUnix {
+			continue
+		}
+		from := strings.TrimPrefix(addr, "unix://")
+		dir := filepath.Dir(from)
+		binds = append(binds, dir+":"+filepath.Join("/host", dir))
+		froms = append(froms, filepath.Join("/host", from))
+		proxy.normalisedAddrs = append(proxy.normalisedAddrs, addr)
+	}
+	if len(froms) == 0 {
+		return nil
+	}
+
+	env := []string{
+		"PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+
+	if val := os.Getenv("DEBUG"); val != "" {
+		env = append(env, fmt.Sprintf("%s=%s", "DEBUG", val))
+	}
+
+	container, err = proxy.client.CreateContainer(docker.CreateContainerOptions{
+		Config: &docker.Config{
+			Image:      proxy.Image,
+			Entrypoint: []string{"/home/weave/symlink", weaveSock},
+			Cmd:        froms,
+			Env:        env,
+		},
+		HostConfig: &docker.HostConfig{Binds: binds},
+	})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err2 := proxy.client.RemoveContainer(docker.RemoveContainerOptions{ID: container.ID})
+		if err == nil {
+			err = err2
+		}
+	}()
+
+	if err := proxy.client.StartContainer(container.ID, nil); err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	err = proxy.client.AttachToContainer(docker.AttachToContainerOptions{
+		Container:   container.ID,
+		ErrorStream: &buf,
+		Logs:        true,
+		Stderr:      true,
+	})
+	if err != nil {
+		return err
+	}
+
+	rc, err := proxy.client.WaitContainer(container.ID)
+	if err != nil {
+		return err
+	}
+	if rc != 0 {
+		return errors.New(buf.String())
+	}
 	return nil
 }

--- a/test/650_proxy_env_test.sh
+++ b/test/650_proxy_env_test.sh
@@ -28,4 +28,10 @@ weave_on $HOST1 stop
 weave_on $HOST1 launch-proxy -H tcp://0.0.0.0:12375 -H unix:///var/run/weave/weave.sock
 check
 
+# Check we can use weave env/config with unix -Hs specified
+weave_on $HOST1 stop
+weave_on $HOST1 launch-proxy -H unix:///var/run/weave/weave.sock
+assert_raises "run_on $HOST1 'eval \$(weave env) ; docker $CMD'"
+assert_raises "run_on $HOST1 'docker \$(weave config) $CMD'"
+
 end_suite

--- a/test/690_proxy_config_test.sh
+++ b/test/690_proxy_config_test.sh
@@ -2,7 +2,7 @@
 
 . ./config.sh
 
-start_suite "Boot the proxy should only listen on client's interface"
+start_suite "Various launch-proxy configurations"
 
 # Booting it over unix socket listens on unix socket
 run_on $HOST1 COVERAGE=$COVERAGE sudo -E weave launch-proxy
@@ -22,6 +22,11 @@ assert_raises "run_on $HOST1 sudo docker -H unix:///var/run/weave/weave.sock ps"
 assert_raises "proxy docker_on $HOST1 ps"
 weave_on $HOST1 stop-proxy
 
+# Booting it with -H outside /var/run/weave, still works
+socket="$(mktemp -d)/weave.sock"
+weave_on $HOST1 launch-proxy -H unix://$socket
+assert_raises "run_on $HOST1 sudo docker -H unix:///$socket ps" 0
+weave_on $HOST1 stop-proxy
 
 # Booting it over tls errors
 assert_raises "DOCKER_CLIENT_ARGS='--tls' weave_on $HOST1 launch-proxy" 1

--- a/weave
+++ b/weave
@@ -1275,17 +1275,30 @@ tls_arg() {
     PROXY_ARGS="$PROXY_ARGS $1 /home/weave/tls/$3.pem"
 }
 
+# TODO: Handle relative paths for args
+# TODO: Handle args with spaces
+host_arg() {
+  PROXY_HOST="$1"
+  if [ "$PROXY_HOST" != "${PROXY_HOST#unix://}" ]; then
+    host=$(dirname ${PROXY_HOST#unix://})
+    if [ "$host" = "${host#/}" ]; then
+      echo "When launching the proxy, unix sockets must be specified as an absolute path." >&2
+      exit 1
+    fi
+    PROXY_VOLUMES="$PROXY_VOLUMES -v /var/run/weave:/var/run/weave"
+  fi
+  PROXY_ARGS="$PROXY_ARGS -H $1"
+}
+
 proxy_parse_args() {
     while [ $# -gt 0 ]; do
         case "$1" in
           -H)
-            PROXY_HOST="$2"
-            PROXY_ARGS="$PROXY_ARGS $1 $2"
+            host_arg "$2"
             shift
             ;;
           -H=*)
-            PROXY_HOST="${1#*=}"
-            PROXY_ARGS="$PROXY_ARGS $1"
+            host_arg "${1#*=}"
             ;;
           -no-detect-tls|--no-detect-tls)
             PROXY_TLS_DETECTION_DISABLED=1
@@ -1346,7 +1359,7 @@ proxy_args() {
           PROXY_HOST="tcp://0.0.0.0:12375"
           ;;
       esac
-      PROXY_ARGS="$PROXY_ARGS -H $PROXY_HOST"
+      host_arg "$PROXY_HOST"
     fi
 }
 
@@ -1559,6 +1572,7 @@ launch_proxy() {
         -e DOCKER_BRIDGE \
         -e WEAVE_DEBUG \
         -e COVERAGE \
+        -e EXEC_IMAGE=$EXEC_IMAGE \
         --entrypoint=/home/weave/weaveproxy \
         $WEAVEPROXY_DOCKER_ARGS $EXEC_IMAGE $COVERAGE_ARGS $PROXY_ARGS)
     wait_for_status $PROXY_CONTAINER_NAME http_call_unix $PROXY_CONTAINER_NAME status.sock


### PR DESCRIPTION
Needs an in-depth review, please.

We copy docker.sock owner to symlinks. Permissions are not copied,
because the permissions will inherit from the target.

Fixes #1694, using option 2 (having the proxy create the symlinks). If the weave script creates the symlinks, `weave env` would break (unless we passed the symlinks in, and that's awkward).

There is a slight change in behaviour of `weave env`. New order of preference is: tcp sockets, custom unix sockets, then `/var/run/weave/weave.sock`.

Most of the awkwardness/code in this is just to run a docker container. :disappointed:

Happy to refactor, any suggestions on ways to clean up the code would be great.