### PR TITLE
Move test/tls program into Makefile so it builds inside the build container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ WEAVEWAIT_NOOP_EXE=prog/weavewait/weavewait_noop
 NETCHECK_EXE=prog/netcheck/netcheck
 DOCKERTLSARGS_EXE=prog/docker_tls_args/docker_tls_args
 RUNNER_EXE=tools/runner/runner
+TEST_TLS_EXE=test/tls/tls
 
-EXES=$(WEAVER_EXE) $(SIGPROXY_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(NETCHECK_EXE) $(DOCKERTLSARGS_EXE)
+EXES=$(WEAVER_EXE) $(SIGPROXY_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(NETCHECK_EXE) $(DOCKERTLSARGS_EXE) $(TEST_TLS_EXE)
 
 WEAVER_UPTODATE=.weaver.uptodate
 WEAVEEXEC_UPTODATE=.weaveexec.uptodate
@@ -47,7 +48,7 @@ BUILD_FLAGS=-ldflags "-extldflags \"-static\" -X main.version $(WEAVE_VERSION)" 
 
 PACKAGE_BASE=$(shell go list -e ./)
 
-all: $(WEAVE_EXPORT) $(RUNNER_EXE)
+all: $(WEAVE_EXPORT) $(RUNNER_EXE) $(TEST_TLS_EXE)
 
 travis: $(EXES)
 
@@ -79,8 +80,9 @@ $(NETCHECK_EXE): prog/netcheck/netcheck.go
 $(SIGPROXY_EXE): prog/sigproxy/main.go
 $(WEAVEWAIT_EXE): prog/weavewait/*.go net/*.go
 $(DOCKERTLSARGS_EXE): prog/docker_tls_args/*.go
+$(TEST_TLS_EXE): test/tls/*.go
 
-$(WEAVEWAIT_EXE) $(SIGPROXY_EXE) $(DOCKERTLSARGS_EXE):
+$(WEAVEWAIT_EXE) $(SIGPROXY_EXE) $(DOCKERTLSARGS_EXE) $(TEST_TLS_EXE):
 	go get -tags netgo ./$(@D)
 	go build $(BUILD_FLAGS) -o $@ ./$(@D)
 

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 . ./config.sh
 
-(cd ./tls && go get -tags netgo ./... && go run generate_certs.go $HOSTS)
+(cd ./tls && ./tls $HOSTS)
 
 echo "Copying weave images, scripts, and certificates to hosts, and"
 echo "  prefetch test images"
@@ -19,7 +19,7 @@ setup_host() {
     run_on $HOST mkdir -p bin
     upload_executable $HOST ../bin/docker-ns
     upload_executable $HOST ../weave
-    rsync -az -e "$SSH" ./tls/ $HOST:~/tls
+    rsync -az -e "$SSH" --exclude=tls ./tls/ $HOST:~/tls
     for IMG in $TEST_IMAGES ; do
         docker_on $HOST inspect --format=" " $IMG >/dev/null 2>&1 || docker_on $HOST pull $IMG
     done


### PR DESCRIPTION
Building outside the container was breaking the CircleCI build, because CircleCI was variously running Go 1.4 and 1.5.1 which didn't match the build container.

This also saves ~3 seconds on every run of test/setup.sh