### PR TITLE
ditch RunWithTimeout test helper

### DIFF
--- a/ipam/http_test.go
+++ b/ipam/http_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/net/address"
-	wt "github.com/weaveworks/weave/testing"
 )
 
 func HTTPPost(t *testing.T, url string) string {
@@ -145,12 +144,6 @@ func TestBadHttp(t *testing.T) {
 }
 
 func TestHTTPCancel(t *testing.T) {
-	wt.RunWithTimeout(t, 2*time.Second, func() {
-		impTestHTTPCancel(t)
-	})
-}
-
-func impTestHTTPCancel(t *testing.T) {
 	var (
 		containerID = "deadbeef"
 		testCIDR1   = "10.0.3.0/29"

--- a/mesh/gossip_test.go
+++ b/mesh/gossip_test.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	wt "github.com/weaveworks/weave/testing"
 )
 
 // TODO test gossip unicast; atm we only test topology gossip and
@@ -67,12 +65,6 @@ func (router *Router) DeleteTestChannelConnection(r *Router) {
 	router.Ourself.handleDeleteConnection(conn)
 }
 
-func TestGossipTopology(t *testing.T) {
-	wt.RunWithTimeout(t, 5*time.Second, func() {
-		implTestGossipTopology(t)
-	})
-}
-
 // Create a Peer representing the receiver router, with connections to
 // the routers supplied as arguments, carrying across all UID and
 // version information.
@@ -95,7 +87,7 @@ func checkTopology(t *testing.T, router *Router, wantedPeers ...*Peer) {
 	router.Peers.RUnlock()
 }
 
-func implTestGossipTopology(t *testing.T) {
+func TestGossipTopology(t *testing.T) {
 	// Create some peers that will talk to each other
 	r1 := NewTestRouter("01:00:00:01:00:00")
 	r2 := NewTestRouter("02:00:00:02:00:00")

--- a/nameserver/nameserver_test.go
+++ b/nameserver/nameserver_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/weaveworks/weave/mesh"
 	"github.com/weaveworks/weave/net/address"
-	wt "github.com/weaveworks/weave/testing"
 	"github.com/weaveworks/weave/testing/gossip"
 )
 
@@ -76,12 +75,6 @@ func (m mapping) Addrs() []address.Address {
 }
 
 func TestNameservers(t *testing.T) {
-	wt.RunWithTimeout(t, 2*time.Minute, func() {
-		testNameservers(t)
-	})
-}
-
-func testNameservers(t *testing.T) {
 	//common.SetLogLevel("debug")
 
 	lookupTimeout := 10 // ms

--- a/testing/util.go
+++ b/testing/util.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -34,22 +33,6 @@ func stackTrace(all bool) string {
 	buf := make([]byte, 1<<20)
 	stacklen := runtime.Stack(buf, all)
 	return string(buf[:stacklen])
-}
-
-// Borrowed from net/http tests:
-// goTimeout runs f, failing t if f takes more than d to complete.
-func RunWithTimeout(t *testing.T, d time.Duration, f func()) {
-	ch := make(chan bool, 2)
-	timer := time.AfterFunc(d, func() {
-		t.Errorf("Timeout expired after %v: stacks:\n%s", d, stackTrace(true))
-		ch <- true
-	})
-	defer timer.Stop()
-	go func() {
-		defer func() { ch <- true }()
-		f()
-	}()
-	<-ch
 }
 
 // TrimTestArgs finds the first -- in os.Args and trim all args before that


### PR DESCRIPTION
It breaks stack traces on failure.

We can just rely on running `go test -timeout ...` instead, which we already do in tools/test.