### PR TITLE
Remove WITH_DNS variable from weave script

### DIFF
--- a/test/280_with_or_without_dns_test.sh
+++ b/test/280_with_or_without_dns_test.sh
@@ -27,6 +27,5 @@ start_container $HOST1 $TARGET_IP/24 --name c2 -h $TARGET
 
 check_dns assert_no_dns_record --without-dns
 check_dns assert_dns_record
-check_dns assert_dns_record --with-dns
 
 end_suite

--- a/test/config.sh
+++ b/test/config.sh
@@ -151,7 +151,7 @@ start_container() {
 start_container_with_dns() {
     host=$1
     shift 1
-    weave_on $host run --with-dns "$@" -t $DNS_IMAGE /bin/sh
+    weave_on $host run "$@" -t $DNS_IMAGE /bin/sh
 }
 
 start_container_local_plugin() {

--- a/weave
+++ b/weave
@@ -62,8 +62,7 @@ weave connect       [--replace] [<peer> ...]
 weave forget        <peer> ...
 weave status        [targets | connections | peers | dns]
 weave report        [-f <format>]
-weave run           [--with-dns | --without-dns]
-                    [--no-rewrite-hosts] [--no-multicast-route]
+weave run           [--without-dns] [--no-rewrite-hosts] [--no-multicast-route]
                       [<addr> ...] <docker run args> ...
 weave start         [<addr> ...] <container_id>
 weave attach        [<addr> ...] <container_id>
@@ -1094,12 +1093,11 @@ dns_args() {
     NAME_ARG=""
     HOSTNAME_SPECIFIED=
     DNS_SEARCH_SPECIFIED=
-    WITH_DNS=
     WITHOUT_DNS=
     while [ $# -gt 0 ] ; do
         case "$1" in
             --with-dns)
-                WITH_DNS=1
+                echo "Warning: $1 is deprecated; it is on by default" >&2
                 ;;
             --without-dns)
                 WITHOUT_DNS=1


### PR DESCRIPTION
Also deprecate --with-dns option to 'weave run'; since we were documenting this option until recently it seemed fairer to deprecate it than to take it out completely.

Doc change is in 1d9ef76080116194c904420b4a4adf639d2ca9cc on latest_release_doc_updates

Fixes #1748