### PR TITLE
Prefix interface names with 'veth' so NetworkManager ignores them

### DIFF
--- a/weave
+++ b/weave
@@ -319,8 +319,8 @@ CONTAINER_NAME=${WEAVE_CONTAINER_NAME:-weave}
 BRIDGE=weave
 # This value is overridden when the datapath is used unbridged
 DATAPATH=datapath
-BRIDGE_IFNAME=link-${BRIDGE}
-DATAPATH_IFNAME=${DATAPATH}-link
+BRIDGE_IFNAME=vethwe-bridge
+DATAPATH_IFNAME=vethwe-datapath
 CONTAINER_IFNAME=ethwe
 PORT=${WEAVE_PORT:-6783}
 HTTP_PORT=6784


### PR DESCRIPTION
Fixes #1783