### PR TITLE
Stop leaking 'w' files

### DIFF
--- a/prog/weaveexec/Dockerfile
+++ b/prog/weaveexec/Dockerfile
@@ -4,9 +4,6 @@ MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 
 WORKDIR /home/weave
-VOLUME /w
-VOLUME /w-noop
-VOLUME /w-nomcast
 ENTRYPOINT ["/home/weave/sigproxy", "/home/weave/weave"]
 
 RUN apk add --update \

--- a/test/config.sh
+++ b/test/config.sh
@@ -176,7 +176,7 @@ proxy_start_container_with_dns() {
 rm_containers() {
     host=$1
     shift
-    [ $# -eq 0 ] || docker_on $host rm -f "$@" >/dev/null
+    [ $# -eq 0 ] || docker_on $host rm -f -v "$@" >/dev/null
 }
 
 container_ip() {

--- a/weave
+++ b/weave
@@ -1671,7 +1671,10 @@ launch_proxy() {
     docker_client_args $DOCKER_CLIENT_ARGS
     proxy_args "$@"
     mkdir -p /var/run/weave
-    docker create -v /w -v /w-noop -v /w-nomcast --name=$VOLUMES_CONTAINER_NAME $EXEC_IMAGE >/dev/null 2>&1 || true
+    # Create a data-only container to mount the weavewait files from
+    if ! docker inspect -f ' ' $VOLUMES_CONTAINER_NAME > /dev/null 2>&1 ; then
+       docker create -v /w -v /w-noop -v /w-nomcast --name=$VOLUMES_CONTAINER_NAME --entrypoint=/bin/false $EXEC_IMAGE >/dev/null
+    fi
     PROXY_CONTAINER=$(docker run --privileged -d --name=$PROXY_CONTAINER_NAME --net=host \
         $PROXY_VOLUMES \
         --volumes-from $VOLUMES_CONTAINER_NAME \

--- a/weave
+++ b/weave
@@ -339,6 +339,7 @@ IMAGE=$BASE_IMAGE:$IMAGE_VERSION
 BASE_PLUGIN_IMAGE=$DOCKERHUB_USER/plugin
 PLUGIN_IMAGE=$BASE_PLUGIN_IMAGE:$IMAGE_VERSION
 PLUGIN_CONTAINER_NAME=weaveplugin
+VOLUMES_CONTAINER_NAME=weavevolumes
 
 PROCFS=${PROCFS:-/proc}
 DOCKER_BRIDGE=${DOCKER_BRIDGE:-docker0}
@@ -1670,8 +1671,10 @@ launch_proxy() {
     docker_client_args $DOCKER_CLIENT_ARGS
     proxy_args "$@"
     mkdir -p /var/run/weave
+    docker create -v /w -v /w-noop -v /w-nomcast --name=$VOLUMES_CONTAINER_NAME $EXEC_IMAGE >/dev/null 2>&1 || true
     PROXY_CONTAINER=$(docker run --privileged -d --name=$PROXY_CONTAINER_NAME --net=host \
         $PROXY_VOLUMES \
+        --volumes-from $VOLUMES_CONTAINER_NAME \
         $(docker_sock_options) \
         -v /var/run/weave:/var/run/weave \
         -v /proc:/hostproc \
@@ -2161,6 +2164,7 @@ EOF
             docker stop  $NAME >/dev/null 2>&1 || true
             docker rm -f $NAME >/dev/null 2>&1 || true
         done
+        docker rm -v $VOLUMES_CONTAINER_NAME >/dev/null 2>&1 || true
         conntrack -D -p udp --dport $PORT >/dev/null 2>&1 || true
         destroy_bridge
         for LOCAL_IFNAME in $(ip link show | grep v${CONTAINER_IFNAME}pl | cut -d ' ' -f 2 | tr -d ':') ; do


### PR DESCRIPTION
As noted in #1757, we left some copies of `weavewait`, copied as `w`, lying around.

This PR creates an auxilliary container `weavevolumes` to hold the `/w/w` files, so the proxy maps into that instead of creating new volumes every time.

Replaces #1768