### PR TITLE
Warn user if weave network is in use on stop or reset of plugin

### DIFF
--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -2,9 +2,10 @@ package docker
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 
 	. "github.com/weaveworks/weave/common"
 )
@@ -57,12 +58,16 @@ func NewVersionedClientFromEnv(apiVersionString string) (*Client, error) {
 }
 
 func (c *Client) checkWorking() error {
-	env, err := c.Version()
-	if err != nil {
-		return err
+	_, err := c.Version()
+	return err
+}
+
+func (c *Client) Info() string {
+	if env, err := c.Version(); err != nil {
+		return fmt.Sprintf("Docker API error: %s", err)
+	} else {
+		return fmt.Sprintf("Docker API on %s: %v", c.Endpoint(), env)
 	}
-	Log.Infof("[docker] Using Docker API on %s: %v", c.Endpoint(), env)
-	return nil
 }
 
 // AddObserver adds an observer for docker events

--- a/prog/plugin/main.go
+++ b/prog/plugin/main.go
@@ -29,6 +29,7 @@ func main() {
 		logLevel         string
 		meshNetworkName  string
 		noMulticastRoute bool
+		removeNetwork    bool
 	)
 
 	flag.BoolVar(&justVersion, "version", false, "print version and exit")
@@ -38,6 +39,7 @@ func main() {
 	flag.StringVar(&meshAddress, "meshsocket", "/run/docker/plugins/weavemesh.sock", "socket on which to listen in mesh mode")
 	flag.StringVar(&meshNetworkName, "mesh-network-name", "weave", "network name to create in mesh mode")
 	flag.BoolVar(&noMulticastRoute, "no-multicast-route", false, "do not add a multicast route to network endpoints")
+	flag.BoolVar(&removeNetwork, "remove-network", false, "remove mesh network and exit")
 
 	flag.Parse()
 
@@ -48,15 +50,24 @@ func main() {
 
 	SetLogLevel(logLevel)
 
-	Log.Println("Weave plugin", version, "Command line options:", os.Args[1:])
-
 	// API 1.21 is the first version that supports docker network commands
 	dockerClient, err := docker.NewVersionedClientFromEnv("1.21")
 	if err != nil {
 		Log.Fatalf("unable to connect to docker: %s", err)
-	} else {
-		Log.Info(dockerClient.Info())
 	}
+
+	if removeNetwork {
+		if _, err = dockerClient.Client.NetworkInfo(meshNetworkName); err == nil {
+			err = dockerClient.Client.RemoveNetwork(meshNetworkName)
+			if err != nil {
+				Log.Fatalf("unable to remove network: %s", err)
+			}
+		}
+		os.Exit(0)
+	}
+
+	Log.Println("Weave plugin", version, "Command line options:", os.Args[1:])
+	Log.Info(dockerClient.Info())
 
 	var globalListener, meshListener net.Listener
 	endChan := make(chan error, 1)

--- a/prog/plugin/main.go
+++ b/prog/plugin/main.go
@@ -54,6 +54,8 @@ func main() {
 	dockerClient, err := docker.NewVersionedClientFromEnv("1.21")
 	if err != nil {
 		Log.Fatalf("unable to connect to docker: %s", err)
+	} else {
+		Log.Info(dockerClient.Info())
 	}
 
 	var globalListener, meshListener net.Listener

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -255,6 +255,8 @@ func main() {
 		dc, err := docker.NewClient(dockerAPI)
 		if err != nil {
 			Log.Fatal("Unable to start docker client: ", err)
+		} else {
+			Log.Info(dc.Info())
 		}
 		dockerCli = dc
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -94,6 +94,8 @@ func NewProxy(c Config) (*Proxy, error) {
 	client, err := weavedocker.NewVersionedClient(c.DockerHost, "1.18")
 	if err != nil {
 		return nil, err
+	} else {
+		Log.Info(client.Info())
 	}
 	p.client = client.Client
 

--- a/site/plugin.md
+++ b/site/plugin.md
@@ -12,6 +12,12 @@ The Weave Net plugin runs automatically when you `weave launch`.  You
 must still tell the weave peers to connect to one another, either via
 `weave launch` or `weave connect`.
 
+Note that the plugin container (`weaveplugin`) is run with
+`--restart=always`, so that it is there after a restart or reboot. If
+you remove this container (e.g. using `weave reset`) before removing
+all endpoints created using `--net=weave`, Docker can
+[hang](https://github.com/docker/libnetwork/issues/813).
+
 ## Starting a container:
 
     $ docker run --net=weave -ti ubuntu

--- a/weave
+++ b/weave
@@ -1712,7 +1712,14 @@ launch_plugin() {
         $PLUGIN_IMAGE "$@")
 }
 
+remove_plugin_network() {
+    docker run --rm --net=host \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        $PLUGIN_IMAGE --remove-network
+}
+
 stop_plugin() {
+    remove_plugin_network
     stop $PLUGIN_CONTAINER_NAME "Plugin"
 }
 
@@ -2146,6 +2153,7 @@ EOF
         ;;
     reset)
         [ $# -eq 0 ] || usage
+        remove_plugin_network || echo "WARNING: docker may hang in this state; re-launch weave and remove attached containers before shutting down" >&2
         warn_if_stopping_proxy_in_env
         call_weave DELETE /peer >/dev/null 2>&1 || true
         for NAME in $PLUGIN_CONTAINER_NAME $CONTAINER_NAME $PROXY_CONTAINER_NAME ; do


### PR DESCRIPTION
If Docker perceives "active endpoints" on a network, it will attempt to contact the driver about them, and if you've shut down the plugin then this will time out.  So if you get into this state the best thing to do is restart the plugin.

This is particularly bad on a restart of Docker (e.g. on host reboot), when Docker may never get going, hence leave you unable to start the plugin.