### PR TITLE
Refactor plugin to create veths in CreateEndpoint

### DIFF
--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -79,7 +79,7 @@ func (driver *driver) CreateEndpoint(create *api.CreateEndpointRequest) (*api.Cr
 	if create.Interface == nil {
 		return nil, fmt.Errorf("Not supported: creating an interface from within CreateEndpoint")
 	}
-	// create veths. note we assume endpoint IDs are unique in the first 5 chars
+	// create veths. note we assume endpoint IDs are unique in the first 8 chars
 	local := vethPair(endID)
 	if err := netlink.LinkAdd(local); err != nil {
 		return nil, errorf("could not create veth pair: %s", err)
@@ -205,7 +205,7 @@ func (driver *driver) DiscoverDelete(disco *api.DiscoveryNotification) error {
 // ===
 
 func vethPair(endpointID string) *netlink.Veth {
-	suffix := endpointID[:5]
+	suffix := endpointID[:8]
 	return &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: "vethwl" + suffix},
 		PeerName:  "vethwg" + suffix,


### PR DESCRIPTION
Fixes #1803.

By moving endpoint creation into `CreateEndpoint` we can return the MAC address at the time Docker expects.  We find the endpoint later simply by looking it up with the same name, derived from the endpoint ID.

The third commit changes from using 5 chars from the endpoint-ID to using 8, to reduce the chance of collision from ~1/1000 to ~1/64K.  This is not backwards-compatible, e.g. if you stop/upgrade/start the plugin it will log a warning and leak the veth when asked to remove an endpoint, but it is believed the impact on users at this point will be minimal.