### PR TITLE
make `eval $(weave env)` idempotent

### DIFF
--- a/weave
+++ b/weave
@@ -1880,7 +1880,8 @@ EOF
     env|proxy-env)
         [ "$COMMAND" = "env" ] || deprecation_warning "$COMMAND" "'weave env'"
         if PROXY_ADDR=$(proxy_addr) ; then
-            echo "export DOCKER_HOST=$PROXY_ADDR ORIG_DOCKER_HOST=$DOCKER_CLIENT_HOST"
+            [ "$PROXY_ADDR" = "$DOCKER_CLIENT_HOST" ] || RESTORE="ORIG_DOCKER_HOST=$DOCKER_CLIENT_HOST"
+            echo "export DOCKER_HOST=$PROXY_ADDR $RESTORE"
         fi
         ;;
     config|proxy-config)


### PR DESCRIPTION
so that `weave $(env --restore)` does the right thing regardless of how many times `eval $(weave env)` was invoked previously.

Fixes #1824.