### PR TITLE
Allow an existing plugin to keep running on `weave launch` if it has the right arguments

### DIFF
--- a/weave
+++ b/weave
@@ -1701,11 +1701,15 @@ stop_proxy() {
 }
 
 launch_plugin() {
+    # Set WEAVEPLUGIN_DOCKER_ARGS in the environment in order to supply
+    # additional parameters, such as resource limits, to docker
+    # when launching the weaveplugin container.
     PLUGIN_CONTAINER=$(docker run --privileged -d --name=$PLUGIN_CONTAINER_NAME \
         --restart=always \
         --net=host \
         $(docker_sock_options) \
         -v /run/docker/plugins:/run/docker/plugins \
+        $WEAVEPLUGIN_DOCKER_ARGS \
         $PLUGIN_IMAGE "$@")
 }
 

--- a/weave
+++ b/weave
@@ -904,6 +904,7 @@ container_weave_addrs() {
 ######################################################################
 
 # Check that a container for component $1 named $2 with image $3 is not running
+# or is a plugin running with identical arguments to $4...
 check_not_running() {
     RUN_STATUS=$(docker inspect --format='{{.State.Running}} {{.State.Status}} {{.Config.Image}}' $2 2>/dev/null) || true
     case ${RUN_STATUS%:*} in
@@ -912,8 +913,18 @@ check_not_running() {
             exit 1
             ;;
         "true "*" $3")
-            echo "$2 is already running; you can stop it with 'weave stop-$1'." >&2
-            exit 1
+            if [ "$1" = "plugin" ] ; then
+                ARGS=$(docker inspect --format='{{.Args}}' $2)
+                shift 3
+                if [ "$ARGS" != "[$@]" ] ; then
+                    echo "$PLUGIN_CONTAINER_NAME is already running with arguments $ARGS; you can stop it with 'weave stop-plugin'." >&2
+                    exit 1
+                fi
+                PLUGIN_CONTAINER=$(container_id $PLUGIN_CONTAINER_NAME)
+            else
+                echo "$2 is already running; you can stop it with 'weave stop-$1'." >&2
+                exit 1
+            fi
             ;;
         "false "*" $3")
             docker rm $2 >/dev/null
@@ -1846,11 +1857,11 @@ EOF
         deprecation_warnings "$@"
         check_not_running router $CONTAINER_NAME        $BASE_IMAGE
         check_not_running proxy  $PROXY_CONTAINER_NAME  $BASE_EXEC_IMAGE
-        check_not_running plugin $PLUGIN_CONTAINER_NAME $BASE_PLUGIN_IMAGE
         COMMON_ARGS=$(common_launch_args "$@")
+        check_not_running plugin $PLUGIN_CONTAINER_NAME $BASE_PLUGIN_IMAGE $COMMON_ARGS
         launch_router "$@"
         launch_proxy  $COMMON_ARGS
-        plugin_disabled || launch_plugin $COMMON_ARGS
+        plugin_disabled || [ -n "$PLUGIN_CONTAINER" ] || launch_plugin $COMMON_ARGS
         ;;
     launch-router)
         deprecation_warnings "$@"
@@ -1873,8 +1884,8 @@ EOF
         echo $PROXY_CONTAINER
         ;;
     launch-plugin)
-        check_not_running plugin $PLUGIN_CONTAINER_NAME $BASE_PLUGIN_IMAGE
-        launch_plugin "$@"
+        check_not_running plugin $PLUGIN_CONTAINER_NAME $BASE_PLUGIN_IMAGE "$@"
+        [ -n "$PLUGIN_CONTAINER" ] || launch_plugin "$@"
         echo $PLUGIN_CONTAINER
         ;;
     env|proxy-env)


### PR DESCRIPTION
Fixes #1869 

This is heavily special-cased for the plugin; much more mechanism needed to generalise it to all components, but we don't start them with a retry policy so the drive isn't there.

I also added `WEAVEPLUGIN_DOCKER_ARGS`, which came up in the discussion.