### PR TITLE
refactor overlay creation

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -133,6 +133,21 @@ func main() {
 	overlay, bridge := createOverlay(datapathName, ifaceName, config.Port, bufSzMB)
 	networkConfig.Bridge = bridge
 
+	if routerName == "" {
+		iface := bridge.Interface()
+		if iface == nil {
+			Log.Fatal("Either an interface must be specified with --datapath or --iface, or a name with --name")
+		}
+		routerName = iface.HardwareAddr.String()
+	}
+	name, err := mesh.PeerNameFromUserInput(routerName)
+	checkFatal(err)
+
+	if nickName == "" {
+		nickName, err = os.Hostname()
+		checkFatal(err)
+	}
+
 	if password == "" {
 		password = os.Getenv("WEAVE_PASSWORD")
 	}
@@ -141,22 +156,6 @@ func main() {
 	} else {
 		config.Password = []byte(password)
 		Log.Println("Communication between peers via untrusted networks is encrypted.")
-	}
-
-	if routerName == "" {
-		iface := networkConfig.Bridge.Interface()
-		if iface == nil {
-			Log.Fatal("Either an interface must be specified with --datapath or --iface, or a name with --name")
-		}
-		routerName = iface.HardwareAddr.String()
-	}
-
-	name, err := mesh.PeerNameFromUserInput(routerName)
-	checkFatal(err)
-
-	if nickName == "" {
-		nickName, err = os.Hostname()
-		checkFatal(err)
 	}
 
 	if prof != "" {

--- a/router/bridge.go
+++ b/router/bridge.go
@@ -1,5 +1,9 @@
 package router
 
+import (
+	"net"
+)
+
 // Interface to packet handling on the local virtual bridge
 type Bridge interface {
 	// Inject a packet to be delivered locally
@@ -9,6 +13,7 @@ type Bridge interface {
 	// should not be included.
 	StartConsumingPackets(BridgeConsumer) error
 
+	Interface() *net.Interface
 	String() string
 	Stats() map[string]int
 }
@@ -23,6 +28,10 @@ func (NullBridge) InjectPacket(PacketKey) FlowOp {
 }
 
 func (NullBridge) StartConsumingPackets(BridgeConsumer) error {
+	return nil
+}
+
+func (NullBridge) Interface() *net.Interface {
 	return nil
 }
 

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -204,6 +204,10 @@ func (fastdp *FastDatapath) Bridge() Bridge {
 	return fastDatapathBridge{fastdp}
 }
 
+func (fastdp fastDatapathBridge) Interface() *net.Interface {
+	return fastdp.iface
+}
+
 func (fastdp fastDatapathBridge) String() string {
 	return fmt.Sprint(fastdp.dpname, " (via ODP)")
 }

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -32,7 +32,7 @@ type FastDatapath struct {
 	lock             sync.Mutex // guards state and synchronises use of dpif
 	dpif             *odp.Dpif
 	dp               odp.DatapathHandle
-	mtu              int // [1]
+	iface            *net.Interface
 	deleteFlowsCount uint64
 	missCount        uint64
 	missHandlers     map[odp.VportID]missHandler
@@ -59,10 +59,6 @@ type FastDatapath struct {
 
 	// forwarders by remote peer
 	forwarders map[mesh.PeerName]*fastDatapathForwarder
-
-	// [1] The mtu from the datapath netdev (which should match the
-	// mtus on all the veths hooked up to the datapath).  We validate
-	// that we are able to support that mtu.
 }
 
 func NewFastDatapath(dpName string, port int) (*FastDatapath, error) {
@@ -92,7 +88,7 @@ func NewFastDatapath(dpName string, port int) (*FastDatapath, error) {
 		dpname:        dpName,
 		dpif:          dpif,
 		dp:            dp,
-		mtu:           iface.MTU,
+		iface:         iface,
 		missHandlers:  make(map[odp.VportID]missHandler),
 		sendToPort:    nil,
 		sendToMAC:     make(map[MAC]bridgeSender),
@@ -665,7 +661,7 @@ func (fwd *fastDatapathForwarder) sendHeartbeat() {
 
 	// the heartbeat payload consists of the 64-bit connection uid
 	// followed by the 16-bit packet size.
-	buf := make([]byte, EthernetOverhead+fwd.fastdp.mtu)
+	buf := make([]byte, EthernetOverhead+fwd.fastdp.iface.MTU)
 	binary.BigEndian.PutUint64(buf[EthernetOverhead:], fwd.connUID)
 	binary.BigEndian.PutUint16(buf[EthernetOverhead+8:], uint16(len(buf)))
 

--- a/router/pcap.go
+++ b/router/pcap.go
@@ -104,6 +104,10 @@ func newPcapHandle(ifName string, promisc bool, snaplen int, bufSz int) (handle 
 	return
 }
 
+func (p *Pcap) Interface() *net.Interface {
+	return p.iface
+}
+
 func (p *Pcap) String() string {
 	return fmt.Sprint(p.iface.Name, " (via pcap)")
 }


### PR DESCRIPTION
There is one behavioural change in this: the routerName, if not specified with --name, is now derived from the datapath network interface MAC (for --datapath) or the pcap interface MAC (for --iface). Previously it was only derived from the latter. So this removes an awkward asymmetry.

This doesn't actually make any difference to weave usage, since the script always supplies a --name.