### PR TITLE
move plugin network creation/removal into weaveutil

### DIFF
--- a/prog/plugin/main.go
+++ b/prog/plugin/main.go
@@ -27,7 +27,6 @@ func main() {
 		logLevel         string
 		meshNetworkName  string
 		noMulticastRoute bool
-		removeNetwork    bool
 	)
 
 	flag.BoolVar(&justVersion, "version", false, "print version and exit")
@@ -37,7 +36,6 @@ func main() {
 	flag.StringVar(&meshAddress, "meshsocket", "/run/docker/plugins/weavemesh.sock", "socket on which to listen in mesh mode")
 	flag.StringVar(&meshNetworkName, "mesh-network-name", "weave", "network name to create in mesh mode")
 	flag.BoolVar(&noMulticastRoute, "no-multicast-route", false, "do not add a multicast route to network endpoints")
-	flag.BoolVar(&removeNetwork, "remove-network", false, "remove mesh network and exit")
 
 	flag.Parse()
 
@@ -52,16 +50,6 @@ func main() {
 	dockerClient, err := docker.NewVersionedClientFromEnv("1.21")
 	if err != nil {
 		Log.Fatalf("unable to connect to docker: %s", err)
-	}
-
-	if removeNetwork {
-		if _, err = dockerClient.Client.NetworkInfo(meshNetworkName); err == nil {
-			err = dockerClient.Client.RemoveNetwork(meshNetworkName)
-			if err != nil {
-				Log.Fatalf("unable to remove network: %s", err)
-			}
-		}
-		os.Exit(0)
 	}
 
 	Log.Println("Weave plugin", version, "Command line options:", os.Args[1:])

--- a/prog/weaveutil/main.go
+++ b/prog/weaveutil/main.go
@@ -16,6 +16,7 @@ func init() {
 		"create-datapath":        createDatapath,
 		"delete-datapath":        deleteDatapath,
 		"add-datapath-interface": addDatapathInterface,
+		"create-plugin-network":  createPluginNetwork,
 		"remove-plugin-network":  removePluginNetwork,
 	}
 }

--- a/prog/weaveutil/main.go
+++ b/prog/weaveutil/main.go
@@ -16,6 +16,7 @@ func init() {
 		"create-datapath":        createDatapath,
 		"delete-datapath":        deleteDatapath,
 		"add-datapath-interface": addDatapathInterface,
+		"remove-plugin-network":  removePluginNetwork,
 	}
 }
 

--- a/prog/weaveutil/plugin_network.go
+++ b/prog/weaveutil/plugin_network.go
@@ -1,0 +1,43 @@
+/* various weave docker network plugin operations */
+package main
+
+import (
+	"fmt"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+func removePluginNetwork(args []string) error {
+	if len(args) != 1 {
+		cmdUsage("remove-plugin-network", "<network-name>")
+	}
+	networkName := args[0]
+	d, err := newDockerClient()
+	if err != nil {
+		return err
+	}
+	_, err = d.NetworkInfo(networkName)
+	if err != nil {
+		// network probably doesn't exist; TODO check this better
+		return nil
+	}
+	err = d.RemoveNetwork(networkName)
+	if err != nil {
+		return fmt.Errorf("unable to remove network: %s", err)
+	}
+	return nil
+}
+
+func newDockerClient() (*docker.Client, error) {
+	// API 1.21 is the first version that supports docker network
+	// commands
+	c, err := docker.NewVersionedClientFromEnv("1.21")
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to docker: %s", err)
+	}
+	_, err = c.Version()
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to docker: %s", err)
+	}
+	return c, nil
+}

--- a/site/plugin.md
+++ b/site/plugin.md
@@ -73,8 +73,6 @@ The plugin command-line arguments are:
 
  * `--log-level=debug|info|warning|error`, which tells the plugin
    how much information to emit for debugging.
- * `--mesh-network-name=<name>`: set it to blank to disable creation
-   of a default network, or a name of your own choice.
  * `--no-multicast-route`: stop weave adding a static IP route for
    multicast traffic on its interface
 

--- a/weave
+++ b/weave
@@ -1683,12 +1683,15 @@ launch_plugin_if_not_running() {
     # Any other kind of error code from check_not_running is a failure.
     [ $retval -gt 0 ] && return $retval
 
-    PLUGIN_CONTAINER=$(docker run --privileged -d --name=$PLUGIN_CONTAINER_NAME \
+    if ! PLUGIN_CONTAINER=$(docker run --privileged -d --name=$PLUGIN_CONTAINER_NAME \
         --restart=always \
         --net=host \
         $(docker_sock_options) \
         -v /run/docker/plugins:/run/docker/plugins \
-        $PLUGIN_IMAGE "$@")
+        $PLUGIN_IMAGE "$@") ; then
+        return 1
+    fi
+    util_op create-plugin-network weave weavemesh
 }
 
 plugin_disabled() {

--- a/weave
+++ b/weave
@@ -448,7 +448,8 @@ util_op() {
     if command_exists weaveutil ; then
         weaveutil "$@"
     else
-        docker run --rm --privileged --net=host -v /proc:/hostproc -e PROCFS=/hostproc \
+        docker run --rm --privileged --net=host $(docker_sock_options) \
+            -v /proc:/hostproc -e PROCFS=/hostproc \
             --entrypoint=/usr/bin/weaveutil $EXEC_IMAGE "$@"
     fi
 }
@@ -1694,14 +1695,8 @@ plugin_disabled() {
     [ -n "$WEAVE_NO_PLUGIN" ] || ! check_docker_server_api_version 1.21
 }
 
-remove_plugin_network() {
-    docker run --rm --net=host \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        $PLUGIN_IMAGE --remove-network
-}
-
 stop_plugin() {
-    remove_plugin_network
+    util_op remove-plugin-network weave
     stop $PLUGIN_CONTAINER_NAME "Plugin"
 }
 
@@ -2137,7 +2132,7 @@ EOF
         ;;
     reset)
         [ $# -eq 0 ] || usage
-        plugin_disabled || remove_plugin_network || \
+        plugin_disabled || util_op remove-plugin-network weave || \
             echo "WARNING: docker may hang in this state; re-launch weave and remove attached containers before shutting down" >&2
         warn_if_stopping_proxy_in_env
         call_weave DELETE /peer >/dev/null 2>&1 || true


### PR DESCRIPTION
The main gotcha is that we lose the ability to specify a different mesh network name, or disable it altogether. That was always poorly supported and IMO is not worth losing sleep over until we / our users have a real need for it.

Closes #1897.