### PR TITLE
cope with errors during route traversal

### DIFF
--- a/net/if.go
+++ b/net/if.go
@@ -57,8 +57,7 @@ func EnsureInterfaceAndMcastRoute(ifaceName string) (*net.Interface, error) {
 		return iface, err
 	}
 	for update := range ch {
-		link, _ := netlink.LinkByIndex(update.Route.LinkIndex)
-		if link.Attrs().Name == ifaceName && update.Route.Dst.IP.Equal(dest) {
+		if update.Route.LinkIndex == iface.Index && update.Route.Dst.IP.Equal(dest) {
 			break
 		}
 	}

--- a/net/route.go
+++ b/net/route.go
@@ -54,14 +54,3 @@ func forEachRoute(ignoreIfaceNames map[string]struct{}, check func(name string, 
 	}
 	return nil
 }
-
-func CheckRouteExists(ifaceName string, dest net.IP) bool {
-	found := false
-	forEachRoute(map[string]struct{}{}, func(name string, route netlink.Route) error {
-		if name == ifaceName && route.Dst.IP.Equal(dest) {
-			found = true
-		}
-		return nil
-	})
-	return found
-}

--- a/net/route.go
+++ b/net/route.go
@@ -41,12 +41,14 @@ func forEachRoute(ignoreIfaceNames map[string]struct{}, check func(name string, 
 	}
 	for _, route := range routes {
 		link, err := netlink.LinkByIndex(route.LinkIndex)
-		if err == nil {
-			if _, found := ignoreIfaceNames[link.Attrs().Name]; found {
-				continue
-			}
+		if err != nil {
+			continue
 		}
-		if err := check(link.Attrs().Name, route); err != nil {
+		ifaceName := link.Attrs().Name
+		if _, found := ignoreIfaceNames[ifaceName]; found {
+			continue
+		}
+		if err := check(ifaceName, route); err != nil {
 			return err
 		}
 	}

--- a/net/route.go
+++ b/net/route.go
@@ -10,7 +10,7 @@ import (
 // A network is considered free if it does not overlap any existing
 // routes on this host. This is the same approach taken by Docker.
 func CheckNetworkFree(subnet *net.IPNet, ignoreIfaceNames map[string]struct{}) error {
-	return forEachRoute(ignoreIfaceNames, func(name string, route netlink.Route) error {
+	return forEachRoute(ignoreIfaceNames, func(route netlink.Route) error {
 		if route.Dst != nil && overlaps(route.Dst, subnet) {
 			return fmt.Errorf("Network %s overlaps with existing route %s on host.", subnet, route.Dst)
 		}
@@ -26,7 +26,7 @@ func overlaps(n1, n2 *net.IPNet) bool {
 // For a specific address, we only care if it is actually *inside* an
 // existing route, because weave-local traffic never hits IP routing.
 func CheckAddressOverlap(addr net.IP, ignoreIfaceNames map[string]struct{}) error {
-	return forEachRoute(ignoreIfaceNames, func(name string, route netlink.Route) error {
+	return forEachRoute(ignoreIfaceNames, func(route netlink.Route) error {
 		if route.Dst != nil && route.Dst.Contains(addr) {
 			return fmt.Errorf("Address %s overlaps with existing route %s on host.", addr, route.Dst)
 		}
@@ -34,21 +34,22 @@ func CheckAddressOverlap(addr net.IP, ignoreIfaceNames map[string]struct{}) erro
 	})
 }
 
-func forEachRoute(ignoreIfaceNames map[string]struct{}, check func(name string, r netlink.Route) error) error {
+func forEachRoute(ignoreIfaceNames map[string]struct{}, check func(r netlink.Route) error) error {
+	ignoreIfaceIndices := make(map[int]struct{})
+	for ifaceName := range ignoreIfaceNames {
+		if iface, err := net.InterfaceByName(ifaceName); err == nil {
+			ignoreIfaceIndices[iface.Index] = struct{}{}
+		}
+	}
 	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
 		return err
 	}
 	for _, route := range routes {
-		link, err := netlink.LinkByIndex(route.LinkIndex)
-		if err != nil {
+		if _, found := ignoreIfaceIndices[route.LinkIndex]; found {
 			continue
 		}
-		ifaceName := link.Attrs().Name
-		if _, found := ignoreIfaceNames[ifaceName]; found {
-			continue
-		}
-		if err := check(ifaceName, route); err != nil {
+		if err := check(route); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
...and bypass `netlink.LinkByIndex`.

Fixes #1909.