### PR TITLE
Update Vagrant to use Wily 15.10

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,8 +18,8 @@ pkgs = %w(
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/ubuntu-15.04-amd64"
-  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/vivid/current/vivid-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "ubuntu/ubuntu-15.10-amd64"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/wily/current/wily-server-cloudimg-amd64-vagrant-disk1.box"
 
   config.vm.network "private_network", ip: vm_ip
   config.vm.provider :virtualbox do |vb|

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -14,8 +14,8 @@ require '../vagrant-common.rb'
 def configure_docker(host, hostname, ip)
   pkgs = %w(docker-engine ethtool)
 
-  host.vm.box = "ubuntu/ubuntu-15.04-amd64"
-  host.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/vivid/current/vivid-server-cloudimg-amd64-vagrant-disk1.box"
+  host.vm.box = "ubuntu/ubuntu-15.10-amd64"
+  host.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/wily/current/wily-server-cloudimg-amd64-vagrant-disk1.box"
 
   host.vm.provision :shell, :inline => "hostnamectl set-hostname "+hostname
   host.vm.network "private_network", ip: ip
@@ -23,7 +23,7 @@ def configure_docker(host, hostname, ip)
   host.vm.synced_folder ".", "/vagrant", disabled: true
 
   host.vm.provision :shell, :inline => "sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"
-  host.vm.provision :shell, :inline => "echo deb https://apt.dockerproject.org/repo ubuntu-vivid main > /etc/apt/sources.list.d/docker.list"
+  host.vm.provision :shell, :inline => "echo deb https://apt.dockerproject.org/repo ubuntu-wily main > /etc/apt/sources.list.d/docker.list"
 
   install_packages host.vm, pkgs
   tweak_docker_daemon host.vm

--- a/vagrant-common.rb
+++ b/vagrant-common.rb
@@ -15,7 +15,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-key adv \
   --keyserver hkp://p80.pool.sks-keyservers.net:80 \
   --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-echo 'deb https://apt.dockerproject.org/repo ubuntu-vivid main' \
+echo 'deb https://apt.dockerproject.org/repo ubuntu-wily main' \
   > /etc/apt/sources.list.d/docker.list
 SCRIPT
   install_packages(vm, pkgs)


### PR DESCRIPTION
Vivid is EOL on the 4/2/2016 and [there will be no Docker 1.10 packages for it](https://github.com/docker/docker/issues/19451).