### PR TITLE
Fix smoke tests for docker 1.10

### DIFF
--- a/test/690_proxy_config_test.sh
+++ b/test/690_proxy_config_test.sh
@@ -34,8 +34,8 @@ assert_raises "proxy docker_on $HOST1 ps"
 weave_on $HOST1 stop-proxy
 
 # Booting it over tls errors
-assert_raises "DOCKER_CLIENT_ARGS='--tls' weave_on $HOST1 launch-proxy" 1
-assert_raises "DOCKER_CERT_PATH='./tls' DOCKER_TLS_VERIFY=1 weave_on $HOST1 launch-proxy" 1
+assert_raises "! DOCKER_CLIENT_ARGS='--tls' weave_on $HOST1 launch-proxy"
+assert_raises "! DOCKER_CERT_PATH='./tls' DOCKER_TLS_VERIFY=1 weave_on $HOST1 launch-proxy"
 
 # Booting it with a specific -H overrides defaults
 weave_on $HOST1 launch-proxy -H tcp://0.0.0.0:12345

--- a/test/695_proxy_failure_modes_test.sh
+++ b/test/695_proxy_failure_modes_test.sh
@@ -6,7 +6,7 @@ start_suite "Proxy failure modes"
 
 # docker run should fail when weave router is not running
 weave_on $HOST1 launch-proxy
-assert_raises "proxy docker_on $HOST1 run --rm $SMALL_IMAGE true" 1
+assert_raises "! proxy docker_on $HOST1 run --rm $SMALL_IMAGE true"
 assert_raises "proxy docker_on $HOST1 run --rm $SMALL_IMAGE true 2>&1 1>/dev/null | grep 'Error response from daemon: weave container is not present. Have you launched it?'"
 
 end_suite


### PR DESCRIPTION
docker/docker#14012 changed the exit codes returned by the docker client under certain circumstances; update the tests to accomodate.

NB don't merge until the CI infrastructure is switched over to 1.10.