### PR TITLE
Return an error when weave isn't running, on RequestPool

### DIFF
--- a/plugin/ipam/driver.go
+++ b/plugin/ipam/driver.go
@@ -33,6 +33,9 @@ func (i *ipam) RequestPool(addressSpace, pool, subPool string, options map[strin
 	Log.Debugln("RequestPool", addressSpace, pool, subPool, options)
 	cidr, err := i.weave.DefaultSubnet()
 	Log.Debugln("RequestPool returning ", cidr, err)
+	if err != nil {
+		return "", nil, nil, err
+	}
 	// Pass back a fake "gateway address"; we don't actually use it,
 	// so just give the network address.
 	data := map[string]string{netlabel.Gateway: cidr.String()}

--- a/plugin/ipam/driver.go
+++ b/plugin/ipam/driver.go
@@ -1,10 +1,12 @@
 package ipamplugin
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/netlabel"
+	godocker "github.com/fsouza/go-dockerclient"
 	"github.com/weaveworks/weave/api"
 	. "github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/common/docker"
@@ -20,7 +22,13 @@ type ipam struct {
 }
 
 func NewIpam(client *docker.Client, version string) (ipamapi.Ipam, error) {
-	resolver := func() (string, error) { return client.GetContainerIP(WeaveContainer) }
+	resolver := func() (string, error) {
+		addr, err := client.GetContainerIP(WeaveContainer)
+		if _, ok := err.(*godocker.NoSuchContainer); ok {
+			return "", fmt.Errorf("%s container is not present. Have you launched it?", WeaveContainer)
+		}
+		return addr, err
+	}
 	return &ipam{client: client, weave: api.NewClientWithResolver(resolver)}, nil
 }
 

--- a/plugin/skel/listener.go
+++ b/plugin/skel/listener.go
@@ -265,6 +265,7 @@ func sendError(w http.ResponseWriter, msg string, code int) {
 }
 
 func errorResponse(w http.ResponseWriter, fmtString string, item ...interface{}) {
+	w.WriteHeader(http.StatusInternalServerError)
 	json.NewEncoder(w).Encode(map[string]string{
 		"Err": fmt.Sprintf(fmtString, item...),
 	})


### PR DESCRIPTION
Fixes #1906.

When I did just the simple fix, I got "invalid CIDR address" back from Docker, which suggested the error wasn't being propagated correctly, hence the other two commits.