### PR TITLE
[WIP] Hack up the Weave Proxy to talk CNI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "vendor/github.com/weaveworks/mesh"]
 	path = vendor/github.com/weaveworks/mesh
 	url = https://github.com/weaveworks/mesh
+[submodule "vendor/github.com/appc/cni"]
+	path = vendor/github.com/appc/cni
+	url = https://github.com/appc/cni

--- a/prog/weaveexec/Dockerfile
+++ b/prog/weaveexec/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine
+#FROM alpine
+FROM jeanblanchard/alpine-glibc
 
 MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system

--- a/proxy/cni.go
+++ b/proxy/cni.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/appc/cni/libcni"
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/weaveworks/weave/common"
+)
+
+var (
+	cniScript     = "./cni.sh"
+	cniNetwork    = "cni.network"
+	cniConfPath   = "/etc/cni/net.d"
+	cniPluginPath = []string{"/home/weave", "/usr/bin", "/"}
+	cniIfName     = "ethwe" // /w/w is waiting for an interface of this name
+)
+
+func useCNI(container *docker.Container) bool {
+	_, ok := container.Labels[cniNetwork]
+	return ok
+}
+
+func (proxy *Proxy) attachCNI(container *docker.Container, orDie bool) {
+	network := container.Labels[cniNetwork]
+
+	// read the json config to find the plugin exe
+	conf, err := libcni.LoadConf(cniConfPath, network)
+	if err != nil {
+		Log.Warningf("Attaching container %s using CNI plugin failed: %s", container.ID, string(stderr))
+		return errors.New(string(stderr))
+	}
+
+	// tell plugin to attach container
+	c := RuntimeConf.CNIConfig{Path: cniPluginPath}
+	_, err := c.AddNetwork(conf, libcni.RuntimeConf{
+		ContainerID: container.ID,
+		NetNS:       fmt.Printf("/proc/net/%s/ns", container.Status.PID),
+		IfName:      cniIfName,
+	})
+
+	if err != nil {
+		Log.Warningf("Attaching container %s using CNI plugin failed: %s", container.ID, string(stderr))
+		return errors.New(string(stderr))
+	}
+	return nil
+}

--- a/proxy/cni.go
+++ b/proxy/cni.go
@@ -20,7 +20,7 @@ func useCNI(container *docker.Container) bool {
 	return ok
 }
 
-func (proxy *Proxy) attachCNI(container *docker.Container, orDie bool) error {
+func (proxy *Proxy) attachCNI(container *docker.Container, orDie bool) (err error) {
 	network := container.Config.Labels[cniNetwork]
 
 	// read the json config to find the plugin exe
@@ -38,7 +38,7 @@ func (proxy *Proxy) attachCNI(container *docker.Container, orDie bool) error {
 		IfName:      cniIfName,
 	}
 
-	if _, err := c.AddNetwork(conf, r); err != nil  {
+	if _, err := c.AddNetwork(conf, r); err != nil {
 		Log.Warningf("Attaching container %s using CNI plugin failed: %s", container.ID, err)
 		return err
 	}

--- a/proxy/cni.go
+++ b/proxy/cni.go
@@ -12,7 +12,7 @@ var (
 	cniScript     = "./cni.sh"
 	cniNetwork    = "cni.network"
 	cniConfPath   = "/etc/cni/net.d"
-	cniPluginPath = []string{"/home/weave", "/usr/bin", "/"}
+	cniPluginPath = []string{"/etc/cni/plugins"}
 	cniIfName     = "ethwe" // /w/w is waiting for an interface of this name
 )
 
@@ -35,7 +35,7 @@ func (proxy *Proxy) attachCNI(container *docker.Container, orDie bool) error {
 	c := libcni.CNIConfig{Path: cniPluginPath}
 	r := &libcni.RuntimeConf{
 		ContainerID: container.ID,
-		NetNS:       fmt.Sprintf("/proc/net/%s/ns", container.State.Pid),
+		NetNS:       fmt.Sprintf("/hostproc/%d/ns/net", container.State.Pid),
 		IfName:      cniIfName,
 	}
 

--- a/proxy/cni.go
+++ b/proxy/cni.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	cniScript     = "./cni.sh"
 	cniNetwork    = "cni.network"
 	cniConfPath   = "/etc/cni/net.d"
 	cniPluginPath = []string{"/etc/cni/plugins"}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -478,6 +478,10 @@ func (proxy *Proxy) attach(containerID string, orDie bool) error {
 		return nil
 	}
 
+	if useCNI(container) {
+		return proxy.attachCNI(container, orDie)
+	}
+
 	cidrs, err := proxy.weaveCIDRs(container.HostConfig.NetworkMode, container.Config.Env)
 	if err != nil {
 		Log.Infof("Leaving container %s alone because %s", containerID, err)

--- a/weave
+++ b/weave
@@ -1674,6 +1674,8 @@ launch_proxy() {
         $PROXY_VOLUMES \
         $(docker_sock_options) \
         -v /var/run/weave:/var/run/weave \
+        -v /etc/cni/net.d:/etc/cni/net.d \
+        -v /etc/cni/plugins:/etc/cni/plugins \
         -v /proc:/hostproc \
         -e PROCFS=/hostproc \
         -e DOCKER_BRIDGE \


### PR DESCRIPTION
This was an idea in the pub, we could make the weave proxy talk to CNI plugins so they could work nicer with Docker.

And it works!  This is POC code, but feedback is welcome:

```
$ # setup your CNI network*
$ ./weave launch-proxy --without-dns --no-multicast-route
$ docker run -ti -l cni.network=net1 alpine /bin/sh
/ # ifconfig
...
ethwe     Link encap:Ethernet  HWaddr 86:5C:46:0F:F8:A0  
          inet addr:192.168.0.6  Bcast:0.0.0.0  Mask:255.255.255.255
          inet6 addr: fe80::845c:46ff:fe0f:f8a0%32623/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:7 errors:0 dropped:0 overruns:0 frame:0
          TX packets:6 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:738 (738.0 B)  TX bytes:508 (508.0 B)
...
```

Details:
- This uses @squaremo's libcni
- We're telling the CNI plugin to make an `ethwe` so that the /w/w script works.
- We have to be careful about volume mounting in the CNI configs and plugins into the proxy container; running the proxy not in a container would be a big help with @awh 
- We haven't wired up delete yet.
- `--no-multicast-route` was needed as we hit #1932

Thanks to @tomdee for his help with this.
- How to setup a calico CNI network:

```
$ mkdir -P /etc/cni/net.d
$ cat >/etc/cni/net.d/10-calico-net1.conf <<EOF
{
    "name": "net1",
    "type": "calico",
    "ipam": {
        "type": "calico-ipam"
    }
}
EOF
$ wget -O /etc/cni/plugins/calico https://github.com/projectcalico/calico-cni/releases/download/v1.0.0/calico
$ chmod +x /etc/cni/plugins/calico
$ wget https://github.com/projectcalico/calico-containers/releases/download/v0.15.0/calicoctl
$ chmod +x calicoctl
$ docker run --detach \
    --net=host \
   --name calico-etcd quay.io/coreos/etcd:v2.0.11 \
    --advertise-client-urls "http://127.0.0.1:2379" \
    --listen-client-urls "http://127.0.0.1:2379"
sudo ./calicoctl node
```
