### PR TITLE
don't set the interface 'up' before it is fully configured

### DIFF
--- a/weave
+++ b/weave
@@ -763,11 +763,11 @@ connect_container_to_bridge() {
     # veth pair in the 'up' or 'down' state.  Furthermore, moving one
     # end into a netns normally sets them to 'down'.  But, moving an
     # end into the default netns is a null operation, so they stay up,
-    # which leads to errors later on.  So to get a consistent result,
-    # we have to be explicit in setting them 'up' or 'down' as
-    # necessary.
+    # which leads to errors in 'set name' since that requires the
+    # interface to be down. So to get a consistent result, we set the
+    # interface 'down' to begin with.
     if ! netnsenter ip link set $GUEST_IFNAME down ||
-       ! netnsenter ip link set $GUEST_IFNAME name $1 up ||
+       ! netnsenter ip link set $GUEST_IFNAME name $1 ||
        ! ip link set $LOCAL_IFNAME up ||
        ! add_iface_$BRIDGE_TYPE $LOCAL_IFNAME ||
        ! configure_arp_cache $1 "netnsenter" ; then


### PR DESCRIPTION
This was causing container entrypoints to execute too early, e.g. before the interface had been given an IP address. But only when running with `--no-multicast-route`, since otherwise weavewait is
waiting for the multicast route to appear.

Fixes #1942.