### PR TITLE
[WIP] persist IPAM addresses

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "vendor/github.com/vishvananda/netns"]
 	path = vendor/github.com/vishvananda/netns
 	url = https://github.com/vishvananda/netns.git
+[submodule "vendor/github.com/boltdb/bolt"]
+	path = vendor/github.com/boltdb/bolt
+	url = https://github.com/boltdb/bolt

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -94,6 +94,18 @@ func (c *Client) AddObserver(ob ContainerObserver) error {
 	return nil
 }
 
+func (c *Client) AllContainerIDs() ([]string, error) {
+	all, err := c.ListContainers(docker.ListContainersOptions{All: true})
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, c := range all {
+		ids = append(ids, c.ID)
+	}
+	return ids, nil
+}
+
 // IsContainerNotRunning returns true if we have checked with Docker that the ID is not running
 func (c *Client) IsContainerNotRunning(idStr string) bool {
 	container, err := c.InspectContainer(idStr)

--- a/ipam/allocate.go
+++ b/ipam/allocate.go
@@ -25,15 +25,15 @@ func (g *allocate) Try(alloc *Allocator) bool {
 		return true
 	}
 
-	if addr, found := alloc.ownedInRange(g.ident, g.r); found {
+	if addr := alloc.ownedInRange(g.ident, g.r); len(addr) > 0 {
 		// If we had heard that this container died, resurrect it
 		delete(alloc.dead, g.ident) // delete is no-op if key not in map
-		g.resultChan <- allocateResult{addr, nil}
+		g.resultChan <- allocateResult{addr[0], nil}
 		return true
 	}
 
 	if !alloc.universe.Overlaps(g.r) {
-		g.resultChan <- allocateResult{0, fmt.Errorf("range %s out of bounds: %s", g.r, alloc.universe)}
+		g.resultChan <- allocateResult{err: fmt.Errorf("range %s out of bounds: %s", g.r, alloc.universe)}
 		return true
 	}
 
@@ -66,7 +66,7 @@ func (g *allocate) Try(alloc *Allocator) bool {
 }
 
 func (g *allocate) Cancel() {
-	g.resultChan <- allocateResult{0, &errorCancelled{"Allocate", g.ident}}
+	g.resultChan <- allocateResult{err: &errorCancelled{"Allocate", g.ident}}
 }
 
 func (g *allocate) ForContainer(ident string) bool {

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -859,6 +859,9 @@ func (alloc *Allocator) loadPersistedRing() {
 	}))
 	if alloc.ring != nil {
 		alloc.space.UpdateRanges(alloc.ring.OwnedRanges())
+		alloc.checkErr(alloc.forEachOwned(func(_ []byte, addr address.Address) error {
+			return alloc.space.Claim(addr)
+		}))
 	}
 }
 

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -35,6 +35,7 @@ var (
 	topBucket          = []byte("top")
 	nameIdent          = []byte("peername")
 	ringBucket         = []byte("ring")
+	ownedBucket        = []byte("owned")
 )
 
 // operation represents something which Allocator wants to do, but
@@ -57,15 +58,14 @@ type Allocator struct {
 	actionChan       chan<- func()
 	db               *bolt.DB
 	ourName          mesh.PeerName
-	universe         address.Range                // superset of all ranges
-	ring             *ring.Ring                   // information on ranges owned by all peers
-	space            space.Space                  // more detail on ranges owned by us
-	owned            map[string][]address.Address // who owns what addresses, indexed by container-ID
-	nicknames        map[mesh.PeerName]string     // so we can map nicknames for rmpeer
-	pendingAllocates []operation                  // held until we get some free space
-	pendingClaims    []operation                  // held until we know who owns the space
-	dead             map[string]time.Time         // containers we heard were dead, and when
-	gossip           mesh.Gossip                  // our link to the outside world for sending messages
+	universe         address.Range            // superset of all ranges
+	ring             *ring.Ring               // information on ranges owned by all peers
+	space            space.Space              // more detail on ranges owned by us
+	nicknames        map[mesh.PeerName]string // so we can map nicknames for rmpeer
+	pendingAllocates []operation              // held until we get some free space
+	pendingClaims    []operation              // held until we know who owns the space
+	dead             map[string]time.Time     // containers we heard were dead, and when
+	gossip           mesh.Gossip              // our link to the outside world for sending messages
 	paxos            *paxos.Node
 	paxosActive      bool
 	ticker           *time.Ticker
@@ -85,7 +85,6 @@ func NewAllocator(ourName mesh.PeerName, ourUID mesh.PeerUID, ourNickname string
 		ourName:     ourName,
 		universe:    universe,
 		ring:        ring.New(universe.Start, universe.End, ourName),
-		owned:       make(map[string][]address.Address),
 		paxos:       paxos.NewNode(ourName, ourUID, quorum),
 		nicknames:   map[mesh.PeerName]string{ourName: ourNickname},
 		isKnownPeer: isKnownPeer,
@@ -119,11 +118,16 @@ func openDB(ourName mesh.PeerName, dbPrefix string) (*bolt.DB, error) {
 			if checkPeerName := top.Get(nameIdent); !bytes.Equal(checkPeerName, nameVal) {
 				common.Log.Infof("[allocator] Deleting persisted data for peername %s", checkPeerName)
 				tx.DeleteBucket(ringBucket)
+				tx.DeleteBucket(ownedBucket)
 				top.Put(nameIdent, nameVal)
 			}
 		}
 		// Create all the buckets we are going to need
 		_, err := tx.CreateBucketIfNotExists(ringBucket)
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists(ownedBucket)
 		return err
 	})
 	return db, err
@@ -849,59 +853,120 @@ func (alloc *Allocator) loadPersistedRing() {
 
 // Owned addresses
 
-func (alloc *Allocator) allOwned(ident string) []address.Address {
-	return alloc.owned[ident]
-}
+/* The structure inside BoltDB is: one top-level bucket for all
+/* 'owned' data; inside that is a bucket per ID (container), and
+/* inside that is a tree-map of all addresses.
+*/
 
-func (alloc *Allocator) hasOwned(ident string) bool {
-	_, b := alloc.owned[ident]
-	return b
+func (alloc *Allocator) hasOwned(ident string) (found bool) {
+	alloc.checkErr(alloc.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(ownedBucket)
+		v := b.Bucket([]byte(ident))
+		found = (v != nil)
+		return nil
+	}))
+	return
 }
 
 // NB: addr must not be owned by ident already
 func (alloc *Allocator) addOwned(ident string, addr address.Address) {
-	alloc.owned[ident] = append(alloc.owned[ident], addr)
+	alloc.checkErr(alloc.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(ownedBucket)
+		v, err := b.CreateBucketIfNotExists([]byte(ident))
+		if err != nil {
+			return err
+		}
+		return v.Put(addr.IP4(), []byte{})
+	}))
 }
 
 func (alloc *Allocator) removeAllOwned(ident string) []address.Address {
-	a := alloc.owned[ident]
-	delete(alloc.owned, ident)
+	var a []address.Address
+	alloc.checkErr(alloc.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(ownedBucket)
+		v := b.Bucket([]byte(ident))
+		if v == nil {
+			return nil
+		}
+		v.ForEach(func(k, _ []byte) error {
+			a = append(a, address.FromIP4(k))
+			return nil
+		})
+		return b.DeleteBucket([]byte(ident))
+	}))
 	return a
 }
 
-func (alloc *Allocator) removeOwned(ident string, addrToFree address.Address) bool {
-	addrs, _ := alloc.owned[ident]
-	for i, ownedAddr := range addrs {
-		if ownedAddr == addrToFree {
-			if len(addrs) == 1 {
-				delete(alloc.owned, ident)
-			} else {
-				alloc.owned[ident] = append(addrs[:i], addrs[i+1:]...)
-			}
-			return true
-		}
-	}
-	return false
+var (
+	errBreakLoop = fmt.Errorf("break out of Bolt loop") // not really an error
+)
+
+// helper function to detect if a Bucket is empty or not
+func empty(b *bolt.Bucket) bool {
+	return b.ForEach(func(_, _ []byte) error {
+		return errBreakLoop
+	}) == errBreakLoop
 }
 
-func (alloc *Allocator) ownedInRange(ident string, r address.Range) (address.Address, bool) {
-	for _, addr := range alloc.owned[ident] {
-		if r.Contains(addr) {
-			return addr, true
+func (alloc *Allocator) removeOwned(ident string, addrToFree address.Address) (found bool) {
+	alloc.checkErr(alloc.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(ownedBucket)
+		v := b.Bucket([]byte(ident))
+		if v == nil {
+			return nil
 		}
-	}
-	return 0, false
+		err := v.Delete(addrToFree.IP4())
+		if err == nil {
+			found = true
+			if empty(v) {
+				if err := b.DeleteBucket([]byte(ident)); err != nil {
+					return err
+				}
+			}
+		} else if err == bolt.ErrBucketNotFound {
+			return nil
+		}
+		return err
+	}))
+	return
 }
 
-func (alloc *Allocator) findOwner(addr address.Address) string {
-	for ident, addrs := range alloc.owned {
-		for _, candidate := range addrs {
-			if candidate == addr {
-				return ident
-			}
+func (alloc *Allocator) ownedInRange(ident string, r address.Range) (a address.Address, found bool) {
+	alloc.checkErr(alloc.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(ownedBucket)
+		v := b.Bucket([]byte(ident))
+		if v == nil {
+			return nil
 		}
-	}
-	return ""
+		return v.ForEach(func(k, _ []byte) error {
+			addr := address.FromIP4(k)
+			if r.Contains(addr) {
+				a = addr
+				found = true
+				return errBreakLoop
+			}
+			return nil
+		})
+	}))
+	return
+}
+
+func (alloc *Allocator) findOwner(addr address.Address) (owner string) {
+	alloc.checkErr(alloc.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(ownedBucket)
+		return b.ForEach(func(name, _ []byte) error {
+			v := b.Bucket(name)
+			return v.ForEach(func(k, _ []byte) error {
+				candidate := address.FromIP4(k)
+				if candidate == addr {
+					owner = string(name)
+					return errBreakLoop
+				}
+				return nil
+			})
+		})
+	}))
+	return owner
 }
 
 // Logging
@@ -917,7 +982,7 @@ func (alloc *Allocator) debugf(fmt string, args ...interface{}) {
 }
 
 func (alloc *Allocator) checkErr(err error) {
-	if err != nil {
+	if err != nil && err != errBreakLoop {
 		panic(err)
 	}
 }

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -49,6 +49,10 @@ func TestAllocFree(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testAddr2, addr2.String(), "address")
 
+	addrs, err := alloc.Lookup(container1, subnet)
+	require.NoError(t, err)
+	require.Equal(t, []address.Address{addr1, addr2}, addrs)
+
 	// Ask for another address for a different container and check it's different
 	addr1b, _ := alloc.Allocate(container2, cidr1.HostRange(), returnFalse)
 	if addr1b.String() == testAddr1 {

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -68,6 +68,13 @@ func TestAllocFree(t *testing.T) {
 	addr4, _ := alloc.Allocate(container3, cidr2.HostRange(), returnFalse)
 	require.Equal(t, testAddr2, addr4.String(), "address")
 
+	// Check that the one we deleted isn't still lurking
+	addr1d, _ := alloc.Allocate(container1, cidr1.HostRange(), returnFalse)
+	if addr1d.String() == testAddr1 {
+		t.Fatalf("Expected different address but got %s", addr1d.String())
+	}
+	require.NoError(t, alloc.Delete(container1))
+
 	alloc.ContainerDied(container2)
 
 	// Resurrect

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -3,7 +3,9 @@ package ipam
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -134,8 +136,18 @@ func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, addres
 		panic(err)
 	}
 
-	alloc := NewAllocator(peername, mesh.PeerUID(rand.Int63()),
-		"nick-"+name, cidr.Range(), quorum, func(mesh.PeerName) bool { return true })
+	err = os.Remove("/tmp/" + name + "ipam.db")
+	if err != nil {
+		if e := err.(*os.PathError); e.Err != syscall.ENOENT {
+			panic(e.Err)
+		}
+	}
+
+	alloc, err := NewAllocator(peername, mesh.PeerUID(rand.Int63()),
+		"nick-"+name, cidr.Range(), quorum, "/tmp/"+name, func(mesh.PeerName) bool { return true })
+	if err != nil {
+		panic(err)
+	}
 
 	return alloc, cidr.HostRange()
 }

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -192,6 +192,9 @@ func main() {
 	if iprangeCIDR != "" {
 		allocator, defaultSubnet = createAllocator(router.Router, iprangeCIDR, ipsubnetCIDR, determineQuorum(peerCount, peers), dbPrefix, isKnownPeer)
 		observeContainers(allocator)
+		ids, err := dockerCli.AllContainerIDs()
+		checkFatal(err)
+		allocator.AllContainerIDs(ids)
 	} else if peerCount > 0 {
 		Log.Fatal("--init-peer-count flag specified without --ipalloc-range")
 	}

--- a/test/162_persist_ipam_2_test.sh
+++ b/test/162_persist_ipam_2_test.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Checking persistence of IPAM"
+
+launch_router_with_db() {
+    host=$1
+    shift
+    WEAVE_DOCKER_ARGS="-v /tmp:/db" weave_on $host launch-router --db-prefix=/db/test162- "$@"
+}
+
+# Remove any persisted data from previous runs
+run_on $HOST1 "sudo rm -f /tmp/test162-*"
+run_on $HOST2 "sudo rm -f /tmp/test162-*"
+
+launch_router_with_db $HOST1
+launch_router_with_db $HOST2 $HOST1
+
+start_container $HOST1 --name=c1
+C1=$(container_ip $HOST1 c1)
+start_container $HOST2 --name=c2
+assert_raises "exec_on $HOST2 c2 $PING $C1"
+
+stop_router_on $HOST1
+stop_router_on $HOST2
+
+# Start just HOST2; if nothing persisted it would form its own ring
+launch_router_with_db $HOST2
+start_container $HOST2 --name=c3
+C3=$(container_ip $HOST2 c3)
+assert_raises "[ $C3 != $C1 ]"
+
+stop_router_on $HOST2
+
+# Now start HOST1 with HOST2 down and see if it hangs when we launch a container
+launch_router_with_db $HOST1 $HOST2
+start_container $HOST1 --name=c4
+C4=$(container_ip $HOST1 c4)
+assert_raises "[ $C4 != $C1 ]"
+assert_raises "[ $C4 != $C3 ]"
+
+end_suite

--- a/test/163_docker_restart_test.sh
+++ b/test/163_docker_restart_test.sh
@@ -36,14 +36,22 @@ C2=$(container_ip $HOST1 c2)
 assert_raises "[ -n $C2 ]"
 check_attached c2
 
+# Another container, that we attach after creation
+docker_on $HOST1 run -di --name=c3 --restart=always -dt --entrypoint="/home/weave/sigproxy" weaveworks/weaveexec sleep 600
+weave_on $HOST1 attach c3
+C3=$(container_ip $HOST1 c3)
+assert_raises "[ -n $C3 ]"
+check_attached c3
+
 docker_on $HOST1 rm -f c1
 
 # Restart docker daemon, using different commands for systemd- and upstart-managed.
 run_on $HOST1 sh -c "command -v systemctl >/dev/null && sudo systemctl restart docker || sudo service docker restart"
 wait_for_proxy $HOST1
 sleep 3 # allow for re-tries of attach
-check_attached c2
+check_attached c2 c3
 # Check same IP address was retained
 assert "container_ip $HOST1 c2" "$C2"
+assert "container_ip $HOST1 c3" "$C3"
 
 end_suite

--- a/test/163_docker_restart_test.sh
+++ b/test/163_docker_restart_test.sh
@@ -1,0 +1,49 @@
+#! /bin/bash
+
+. ./config.sh
+
+check_attached() {
+    for c in $@; do
+        assert_raises "exec_on $HOST1 $c $CHECK_ETHWE_UP"
+    done
+}
+
+wait_for_proxy() {
+    for i in $(seq 1 120); do
+        echo "Waiting for proxy to start"
+        if proxy docker_on $1 info > /dev/null 2>&1 ; then
+            return
+        fi
+        sleep 1
+    done
+    echo "Timed out waiting for proxy to start" >&2
+    exit 1
+}
+
+start_suite "Containers get same IP address on restart"
+
+# Remove any persisted data from previous runs
+run_on $HOST1 "sudo rm -f /tmp/test645-*"
+
+WEAVE_DOCKER_ARGS="-v /tmp:/db --restart=always" weave_on $HOST1 launch-router --db-prefix=/db/test645-
+WEAVEPROXY_DOCKER_ARGS=--restart=always weave_on $HOST1 launch-proxy
+
+# Use up first address with throwaway container
+start_container $HOST1 --name=c1
+# Use sigproxy+sleep to create a container that will die when Docker asks it to.
+proxy docker_on $HOST1 run -di --name=c2 --restart=always -dt --entrypoint="/home/weave/sigproxy" weaveworks/weaveexec sleep 600
+C2=$(container_ip $HOST1 c2)
+assert_raises "[ -n $C2 ]"
+check_attached c2
+
+docker_on $HOST1 rm -f c1
+
+# Restart docker daemon, using different commands for systemd- and upstart-managed.
+run_on $HOST1 sh -c "command -v systemctl >/dev/null && sudo systemctl restart docker || sudo service docker restart"
+wait_for_proxy $HOST1
+sleep 3 # allow for re-tries of attach
+check_attached c2
+# Check same IP address was retained
+assert "container_ip $HOST1 c2" "$C2"
+
+end_suite


### PR DESCRIPTION
Following on from #1928, persist the `owned` addresses. `space` can be derived from a combination of `owned` and `ring`.

Note the first 4 commits on this PR are from #1928; they will be rebased out when #1928 is merged.

`owned` is implemented directly in BoltDB's tree-map structure, while we use Gob to store the ring.  This results in a lot more code for the 'owned' operations, but less work at run-time as we allocate and free addresses.

Status prior to this PR:

item | `weave restart` | `docker restart` | `docker stop` followed by `docker start` a good while later | policy restart after reboot
------|----------------------|----------------------|------------------------------------------------------------------------------|------
IPAM addresses specified with `WEAVE_CIDR`        | retained | retained | re-allocated; may change | re-allocated; may change 
non-IPAM addresses specified with `WEAVE_CIDR` | retained | retained | retained | retained
IPAM addresses specified in `weave attach`               | retained | leaked | leaked | lost
non-IPAM addresses specified in `weave attach`        | retained | lost | lost | lost

The default if you don't ask for anything special is "IPAM address specified in `weave attach`"

Status after this PR (at time of writing):

item | `weave restart` | `docker restart` | `docker stop` followed by `docker start` a good while later | policy restart after reboot
------|----------------------|----------------------|------------------------------------------------------------------------------|------
IPAM addresses specified with `WEAVE_CIDR`        | retained | retained | re-allocated; may change | retained 
non-IPAM addresses specified with `WEAVE_CIDR` | retained | retained | retained | retained
IPAM addresses specified in `weave attach`               | retained | lost | lost | lost
non-IPAM addresses specified in `weave attach`        | retained | lost | lost | lost

Final target of this PR:

item | `weave restart` | `docker restart` | `docker stop` followed by `docker start` a good while later | policy restart after reboot
------|----------------------|----------------------|------------------------------------------------------------------------------|------
IPAM addresses specified with `WEAVE_CIDR`        | retained | retained | retained | retained 
non-IPAM addresses specified with `WEAVE_CIDR` | retained | retained | retained | retained
IPAM addresses specified in `weave attach`               | retained | retained | retained | retained
non-IPAM addresses specified in `weave attach`        | retained | retained | retained | retained
