### PR TITLE
Improve IPAM Ring unit testing, and streamline ring.ClaimForPeers

### DIFF
--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -356,12 +356,7 @@ func (r *Ring) ClaimForPeers(peers []mesh.PeerName) {
 			}
 		}
 
-		if e, found := r.Entries.get(pos); found {
-			e.update(peer, share)
-		} else {
-			r.Entries.insert(entry{Token: pos, Peer: peer, Free: share})
-		}
-
+		r.Entries.insert(entry{Token: pos, Peer: peer, Free: share})
 		pos += address.Address(share)
 	}
 

--- a/ipam/ring/ring_test.go
+++ b/ipam/ring/ring_test.go
@@ -60,13 +60,19 @@ func TestInsert(t *testing.T) {
 
 	ring.Entries.entry(0).Free = 0
 	ring.Entries.insert(entry{Token: dot245, Peer: peer1name})
-	ring2 := New(start, end, peer1name)
-	ring2.Entries = []*entry{{Token: start, Peer: peer1name, Free: 0}, {Token: dot245, Peer: peer1name}}
-	require.Equal(t, ring2, ring)
+	check := []RangeInfo{
+		{Peer: peer1name, Range: address.Range{Start: start, End: dot245}},
+		{Peer: peer1name, Range: address.Range{Start: dot245, End: end}},
+	}
+	require.Equal(t, check, ring.AllRangeInfo())
 
 	ring.Entries.insert(entry{Token: dot10, Peer: peer1name})
-	ring2.Entries = []*entry{{Token: start, Peer: peer1name, Free: 0}, {Token: dot10, Peer: peer1name}, {Token: dot245, Peer: peer1name}}
-	require.Equal(t, ring2, ring)
+	check2 := []RangeInfo{
+		{Peer: peer1name, Range: address.Range{Start: start, End: dot10}},
+		{Peer: peer1name, Range: address.Range{Start: dot10, End: dot245}},
+		{Peer: peer1name, Range: address.Range{Start: dot245, End: end}},
+	}
+	require.Equal(t, check2, ring.AllRangeInfo())
 }
 
 func TestBetween(t *testing.T) {


### PR DESCRIPTION
Begun while investigating #1946; wasn't actually related but contributed here to improve code coverage.

The test for `ring.ClaimForPeers` doesn't do any special checks, relying on `checkInvariants` which is called via `defer`