### PR TITLE
Wait for multicast route on any interface

### DIFF
--- a/net/if.go
+++ b/net/if.go
@@ -53,7 +53,7 @@ func EnsureInterfaceAndMcastRoute(ifaceName string) (*net.Interface, error) {
 	}
 	dest := net.IPv4(224, 0, 0, 0)
 	check := func(route netlink.Route) bool {
-		return route.LinkIndex == iface.Index && route.Dst != nil && route.Dst.IP.Equal(dest)
+		return route.Dst != nil && route.Dst.IP.Equal(dest)
 	}
 	// check for currently-existing route after subscribing, to avoid race
 	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)


### PR DESCRIPTION
Wait for multicast route on any interface, to match the weave script which only adds a route if there isn't one already.

Fixes #1956 
