### PR TITLE
Don't remove weave network on plugin shutdown because it bricks Docker 1.10

### DIFF
--- a/prog/plugin/main.go
+++ b/prog/plugin/main.go
@@ -106,9 +106,6 @@ func run(dockerClient *docker.Client, address, meshAddress, meshNetworkName, nam
 	select {
 	case sig := <-sigChan:
 		Log.Debugf("Caught signal %s; shutting down", sig)
-		if meshNetworkName != "" {
-			return dockerClient.Client.RemoveNetwork(meshNetworkName)
-		}
 		return nil
 	case err := <-endChan:
 		return err


### PR DESCRIPTION
Fixes #1959.

This code was originally added because leaving the weave network in-situ while Docker restarted would cause errors and delay Docker startup.  Unfortunately, somewhere along the line to Docker 1.10 the opposite situation came into effect, only it's now much worse.

The weave script already tries to remove the `weave` network on `stop` or `reset`, so this extra call should be unnecessary - we start the plugin with `--restart=always` so it should come up after Docker restart.