### PR TITLE
Persist IPAM ring, take 2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "vendor/github.com/vishvananda/netns"]
 	path = vendor/github.com/vishvananda/netns
 	url = https://github.com/vishvananda/netns.git
+[submodule "vendor/github.com/boltdb/bolt"]
+	path = vendor/github.com/boltdb/bolt
+	url = https://github.com/boltdb/bolt

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ testrunner: $(RUNNER_EXE) $(TEST_TLS_EXE)
 
 $(EXES): $(BUILD_UPTODATE)
 $(WEAVER_EXE) $(WEAVEPROXY_EXE) $(WEAVEUTIL_EXE): common/*.go common/*/*.go net/*.go net/*/*.go
-$(WEAVER_EXE): router/*.go ipam/*.go ipam/*/*.go nameserver/*.go prog/weaver/*.go
+$(WEAVER_EXE): router/*.go ipam/*.go ipam/*/*.go db/*.go nameserver/*.go prog/weaver/*.go
 $(WEAVEPROXY_EXE): proxy/*.go prog/weaveproxy/*.go
 $(WEAVEUTIL_EXE): prog/weaveutil/*.go
 $(SIGPROXY_EXE): prog/sigproxy/*.go

--- a/db/boltdb.go
+++ b/db/boltdb.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+
+	"github.com/boltdb/bolt"
+)
+
+type DB interface {
+	Load(string, interface{}) error
+	Save(string, interface{}) error
+}
+
+type BoltDB struct {
+	db *bolt.DB
+}
+
+var (
+	versionIdent       = []byte("version")
+	persistenceVersion = []byte{1, 0} // major.minor
+	topBucket          = []byte("top")
+)
+
+func NewBoltDB(dbPathname string) (*BoltDB, error) {
+	db, err := bolt.Open(dbPathname, 0660, nil)
+	if err != nil {
+		return nil, fmt.Errorf("[boltDB] Unable to open %s: %s", dbPathname, err)
+	}
+	// check the persistence version
+	err = db.Update(func(tx *bolt.Tx) error {
+		if top := tx.Bucket(topBucket); top == nil {
+			top, err := tx.CreateBucket(topBucket)
+			if err != nil {
+				return err
+			}
+			if err := top.Put(versionIdent, persistenceVersion); err != nil {
+				return err
+			}
+		} else {
+			if checkVersion := top.Get(versionIdent); checkVersion != nil {
+				if checkVersion[0] != persistenceVersion[0] {
+					return fmt.Errorf("[boltDB] Cannot use persistence file %s - version %x", dbPathname, checkVersion)
+				}
+			}
+		}
+		return nil
+	})
+	return &BoltDB{db: db}, err
+}
+
+func (d *BoltDB) Load(ident string, data interface{}) error {
+	return d.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(topBucket)
+		v := b.Get([]byte(ident))
+		if v == nil {
+			return nil
+		}
+		reader := bytes.NewReader(v)
+		decoder := gob.NewDecoder(reader)
+		err := decoder.Decode(data)
+		return err
+	})
+}
+
+func (d *BoltDB) Save(ident string, data interface{}) error {
+	return d.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(topBucket)
+		buf := new(bytes.Buffer)
+		enc := gob.NewEncoder(buf)
+		if err := enc.Encode(data); err != nil {
+			return err
+		}
+		return b.Put([]byte(ident), buf.Bytes())
+	})
+}
+
+func (d *BoltDB) Close() error {
+	return d.db.Close()
+}

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -774,18 +774,18 @@ const (
 func (alloc *Allocator) persistRing() {
 	// It would be better if these two Save operations happened in the same transaction
 	if err := alloc.db.Save(nameIdent, alloc.ourName); err != nil {
-		common.Log.Errorf("Error persisting ring data: %s", err)
+		alloc.fatalf("Error persisting ring data: %s", err)
 		return
 	}
 	if err := alloc.db.Save(ringIdent, alloc.ring); err != nil {
-		common.Log.Errorf("Error persisting ring data: %s", err)
+		alloc.fatalf("Error persisting ring data: %s", err)
 	}
 }
 
 func (alloc *Allocator) loadPersistedRing() {
 	var checkPeerName mesh.PeerName
 	if err := alloc.db.Load(nameIdent, &checkPeerName); err != nil {
-		common.Log.Errorf("Error loading persisted peer name: %s", err)
+		alloc.fatalf("Error loading persisted peer name: %s", err)
 		return
 	}
 	if checkPeerName != alloc.ourName {
@@ -794,7 +794,7 @@ func (alloc *Allocator) loadPersistedRing() {
 		return
 	}
 	if err := alloc.db.Load(ringIdent, &alloc.ring); err != nil {
-		common.Log.Errorf("Error loading persisted ring data: %s", err)
+		alloc.fatalf("Error loading persisted ring data: %s", err)
 	}
 	if alloc.ring != nil {
 		alloc.space.UpdateRanges(alloc.ring.OwnedRanges())
@@ -860,6 +860,9 @@ func (alloc *Allocator) findOwner(addr address.Address) string {
 
 // Logging
 
+func (alloc *Allocator) fatalf(fmt string, args ...interface{}) {
+	common.Log.Fatalf("[allocator %s] "+fmt, append([]interface{}{alloc.ourName}, args...)...)
+}
 func (alloc *Allocator) infof(fmt string, args ...interface{}) {
 	common.Log.Infof("[allocator %s] "+fmt, append([]interface{}{alloc.ourName}, args...)...)
 }

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -123,6 +123,11 @@ func CheckAllExpectedMessagesSent(allocs ...*Allocator) {
 	}
 }
 
+type mockDB struct{}
+
+func (d *mockDB) Load(_ string, _ interface{}) error { return nil }
+func (d *mockDB) Save(_ string, _ interface{}) error { return nil }
+
 func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, address.Range) {
 	peername, err := mesh.PeerNameFromString(name)
 	if err != nil {
@@ -135,7 +140,7 @@ func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, addres
 	}
 
 	alloc := NewAllocator(peername, mesh.PeerUID(rand.Int63()),
-		"nick-"+name, cidr.Range(), quorum, func(mesh.PeerName) bool { return true })
+		"nick-"+name, cidr.Range(), quorum, new(mockDB), func(mesh.PeerName) bool { return true })
 
 	return alloc, cidr.HostRange()
 }

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -195,7 +195,7 @@ func main() {
 		defaultSubnet address.CIDR
 	)
 	if iprangeCIDR != "" {
-		allocator, defaultSubnet = createAllocator(router.Router, iprangeCIDR, ipsubnetCIDR, determineQuorum(peerCount, peers), isKnownPeer)
+		allocator, defaultSubnet = createAllocator(router.Router, iprangeCIDR, ipsubnetCIDR, determineQuorum(peerCount, peers), db, isKnownPeer)
 		observeContainers(allocator)
 	} else if peerCount > 0 {
 		Log.Fatal("--init-peer-count flag specified without --ipalloc-range")
@@ -315,7 +315,7 @@ func parseAndCheckCIDR(cidrStr string) address.CIDR {
 	return cidr
 }
 
-func createAllocator(router *mesh.Router, ipRangeStr string, defaultSubnetStr string, quorum uint, isKnownPeer func(mesh.PeerName) bool) (*ipam.Allocator, address.CIDR) {
+func createAllocator(router *mesh.Router, ipRangeStr string, defaultSubnetStr string, quorum uint, db db.DB, isKnownPeer func(mesh.PeerName) bool) (*ipam.Allocator, address.CIDR) {
 	ipRange := parseAndCheckCIDR(ipRangeStr)
 	defaultSubnet := ipRange
 	if defaultSubnetStr != "" {
@@ -324,7 +324,7 @@ func createAllocator(router *mesh.Router, ipRangeStr string, defaultSubnetStr st
 			Log.Fatalf("IP address allocation default subnet %s does not overlap with allocation range %s", defaultSubnet, ipRange)
 		}
 	}
-	allocator := ipam.NewAllocator(router.Ourself.Peer.Name, router.Ourself.Peer.UID, router.Ourself.Peer.NickName, ipRange.Range(), quorum, isKnownPeer)
+	allocator := ipam.NewAllocator(router.Ourself.Peer.Name, router.Ourself.Peer.UID, router.Ourself.Peer.NickName, ipRange.Range(), quorum, db, isKnownPeer)
 
 	allocator.SetInterfaces(router.NewGossip("IPallocation", allocator))
 	allocator.Start()

--- a/test/162_persist_ipam_2_test.sh
+++ b/test/162_persist_ipam_2_test.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Checking persistence of IPAM"
+
+launch_router_with_db() {
+    host=$1
+    shift
+    WEAVE_DOCKER_ARGS="-v /tmp:/db" weave_on $host launch-router --db-prefix=/db/test162- "$@"
+}
+
+# Remove any persisted data from previous runs
+run_on $HOST1 "sudo rm -f /tmp/test162-*"
+run_on $HOST2 "sudo rm -f /tmp/test162-*"
+
+launch_router_with_db $HOST1
+launch_router_with_db $HOST2 $HOST1
+
+start_container $HOST1 --name=c1
+C1=$(container_ip $HOST1 c1)
+start_container $HOST2 --name=c2
+assert_raises "exec_on $HOST2 c2 $PING $C1"
+
+stop_router_on $HOST1
+stop_router_on $HOST2
+
+# Start just HOST2; if nothing persisted it would form its own ring
+launch_router_with_db $HOST2
+start_container $HOST2 --name=c3
+C3=$(container_ip $HOST2 c3)
+assert_raises "[ $C3 != $C1 ]"
+
+stop_router_on $HOST2
+
+# Now start HOST1 with HOST2 down and see if it hangs when we launch a container
+launch_router_with_db $HOST1 $HOST2
+start_container $HOST1 --name=c4
+C4=$(container_ip $HOST1 c4)
+assert_raises "[ $C4 != $C1 ]"
+assert_raises "[ $C4 != $C3 ]"
+
+end_suite


### PR DESCRIPTION
Revised version of #1928, with BoltDB specifics pulled out to a separate package.

We have a very simple persistence interface, just `Load` and `Save` an `interface{}`, with serialization (Gob) hidden behind the abstraction.

Partial fix of #678