### PR TITLE
Try all pending allocations

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -140,29 +140,23 @@ func (alloc *Allocator) cancelOpsFor(ops *[]operation, ident string) bool {
 	return found
 }
 
-// Try all pending operations
-func (alloc *Allocator) tryPendingOps() {
-	// The slightly different semantics requires us to operate on 'claims' and
-	// 'allocates' separately:
-	// Claims must be tried before Allocates
-	for i := 0; i < len(alloc.pendingClaims); {
-		op := alloc.pendingClaims[i]
+// Try all operations in a queue
+func (alloc *Allocator) tryOps(ops *[]operation) {
+	for i := 0; i < len(*ops); {
+		op := (*ops)[i]
 		if !op.Try(alloc) {
 			i++
 			continue
 		}
-		alloc.pendingClaims = append(alloc.pendingClaims[:i], alloc.pendingClaims[i+1:]...)
+		*ops = append((*ops)[:i], (*ops)[i+1:]...)
 	}
+}
 
-	// When the first Allocate fails, bail - no need to
-	// send too many begs for space.
-	for i := 0; i < len(alloc.pendingAllocates); {
-		op := alloc.pendingAllocates[i]
-		if !op.Try(alloc) {
-			break
-		}
-		alloc.pendingAllocates = append(alloc.pendingAllocates[:i], alloc.pendingAllocates[i+1:]...)
-	}
+// Try all pending operations
+func (alloc *Allocator) tryPendingOps() {
+	// Process existing claims before servicing new allocations
+	alloc.tryOps(&alloc.pendingClaims)
+	alloc.tryOps(&alloc.pendingAllocates)
 }
 
 func (alloc *Allocator) spaceRequestDenied(sender mesh.PeerName, r address.Range) {


### PR DESCRIPTION
We can have outstanding allocations for different ranges owned by different peers, so we should not short circuit after the first space request.

Fixes #1996.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/weaveworks/weave/2001)
<!-- Reviewable:end -->
