### PR TITLE
Store all addresses+subnets in IPAM

### DIFF
--- a/ipam/allocate.go
+++ b/ipam/allocate.go
@@ -25,15 +25,15 @@ func (g *allocate) Try(alloc *Allocator) bool {
 		return true
 	}
 
-	if addr, found := alloc.ownedInRange(g.ident, g.r); found {
+	if addrs := alloc.ownedInRange(g.ident, g.r); len(addrs) > 0 {
 		// If we had heard that this container died, resurrect it
 		delete(alloc.dead, g.ident) // delete is no-op if key not in map
-		g.resultChan <- allocateResult{addr, nil}
+		g.resultChan <- allocateResult{addrs[0], nil}
 		return true
 	}
 
 	if !alloc.universe.Overlaps(g.r) {
-		g.resultChan <- allocateResult{0, fmt.Errorf("range %s out of bounds: %s", g.r, alloc.universe)}
+		g.resultChan <- allocateResult{err: fmt.Errorf("range %s out of bounds: %s", g.r, alloc.universe)}
 		return true
 	}
 
@@ -66,7 +66,7 @@ func (g *allocate) Try(alloc *Allocator) bool {
 }
 
 func (g *allocate) Cancel() {
-	g.resultChan <- allocateResult{0, &errorCancelled{"Allocate", g.ident}}
+	g.resultChan <- allocateResult{err: &errorCancelled{"Allocate", g.ident}}
 }
 
 func (g *allocate) ForContainer(ident string) bool {

--- a/ipam/allocate.go
+++ b/ipam/allocate.go
@@ -28,7 +28,7 @@ func (g *allocate) Try(alloc *Allocator) bool {
 	if addrs := alloc.ownedInRange(g.ident, g.r); len(addrs) > 0 {
 		// If we had heard that this container died, resurrect it
 		delete(alloc.dead, g.ident) // delete is no-op if key not in map
-		g.resultChan <- allocateResult{addrs[0], nil}
+		g.resultChan <- allocateResult{addrs[0].Addr, nil}
 		return true
 	}
 
@@ -46,7 +46,7 @@ func (g *allocate) Try(alloc *Allocator) bool {
 			g.ident = addr.String()
 		}
 		alloc.debugln("Allocated", addr, "for", g.ident, "in", g.r)
-		alloc.addOwned(g.ident, addr)
+		alloc.addOwned(g.ident, address.MakeCIDR(g.r, addr))
 		g.resultChan <- allocateResult{addr, nil}
 		return true
 	}

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -195,7 +195,7 @@ func (e *errorCancelled) Error() string {
 
 // Allocate (Sync) - get new IP address for container with given name in range
 // if there isn't any space in that range we block indefinitely
-func (alloc *Allocator) Allocate(ident string, r address.Range, hasBeenCancelled func() bool) (address.Address, error) {
+func (alloc *Allocator) Allocate(ident string, r address.CIDR, hasBeenCancelled func() bool) (address.Address, error) {
 	resultChan := make(chan allocateResult)
 	op := &allocate{resultChan: resultChan, ident: ident, r: r, hasBeenCancelled: hasBeenCancelled}
 	alloc.doOperation(op, &alloc.pendingAllocates)

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -49,6 +49,10 @@ func TestAllocFree(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testAddr2, addr2.String(), "address")
 
+	addrs, err := alloc.Lookup(container1, subnet)
+	require.NoError(t, err)
+	require.Equal(t, []address.Address{addr1, addr2}, addrs)
+
 	// Ask for another address for a different container and check it's different
 	addr1b, _ := alloc.Allocate(container2, cidr1.HostRange(), returnFalse)
 	if addr1b.String() == testAddr1 {

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -41,11 +41,11 @@ func TestAllocFree(t *testing.T) {
 	_, cidr2, _ := address.ParseCIDR(subnet2)
 
 	alloc.claimRingForTesting()
-	addr1, err := alloc.Allocate(container1, cidr1.HostRange(), returnFalse)
+	addr1, err := alloc.Allocate(container1, cidr1, returnFalse)
 	require.NoError(t, err)
 	require.Equal(t, testAddr1, addr1.String(), "address")
 
-	addr2, err := alloc.Allocate(container1, cidr2.HostRange(), returnFalse)
+	addr2, err := alloc.Allocate(container1, cidr2, returnFalse)
 	require.NoError(t, err)
 	require.Equal(t, testAddr2, addr2.String(), "address")
 
@@ -54,28 +54,28 @@ func TestAllocFree(t *testing.T) {
 	require.Equal(t, []address.Address{addr1, addr2}, addrs)
 
 	// Ask for another address for a different container and check it's different
-	addr1b, _ := alloc.Allocate(container2, cidr1.HostRange(), returnFalse)
+	addr1b, _ := alloc.Allocate(container2, cidr1, returnFalse)
 	if addr1b.String() == testAddr1 {
 		t.Fatalf("Expected different address but got %s", addr1b.String())
 	}
 
 	// Ask for the first container again and we should get the same addresses again
-	addr1a, _ := alloc.Allocate(container1, cidr1.HostRange(), returnFalse)
+	addr1a, _ := alloc.Allocate(container1, cidr1, returnFalse)
 	require.Equal(t, testAddr1, addr1a.String(), "address")
-	addr2a, _ := alloc.Allocate(container1, cidr2.HostRange(), returnFalse)
+	addr2a, _ := alloc.Allocate(container1, cidr2, returnFalse)
 	require.Equal(t, testAddr2, addr2a.String(), "address")
 
 	// Now delete the first container, and we should get its addresses back
 	require.NoError(t, alloc.Delete(container1))
-	addr3, _ := alloc.Allocate(container3, cidr1.HostRange(), returnFalse)
+	addr3, _ := alloc.Allocate(container3, cidr1, returnFalse)
 	require.Equal(t, testAddr1, addr3.String(), "address")
-	addr4, _ := alloc.Allocate(container3, cidr2.HostRange(), returnFalse)
+	addr4, _ := alloc.Allocate(container3, cidr2, returnFalse)
 	require.Equal(t, testAddr2, addr4.String(), "address")
 
 	alloc.ContainerDied(container2)
 
 	// Resurrect
-	addr1c, err := alloc.Allocate(container2, cidr1.HostRange(), returnFalse)
+	addr1c, err := alloc.Allocate(container2, cidr1, returnFalse)
 	require.NoError(t, err)
 	require.Equal(t, addr1b, addr1c, "address")
 

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -34,7 +34,8 @@ func (c *claim) sendResult(result error) {
 func (c *claim) Try(alloc *Allocator) bool {
 	if !alloc.ring.Contains(c.addr) {
 		// Address not within our universe; assume user knows what they are doing
-		alloc.infof("Ignored address %s claimed by %s - not in our universe", c.addr, c.ident)
+		alloc.infof("Address %s claimed by %s - not in our range", c.addr, c.ident)
+		alloc.addOwned(c.ident, c.addr)
 		c.sendResult(nil)
 		return true
 	}

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -29,6 +29,15 @@ func parseCIDR(w http.ResponseWriter, cidrStr string) (address.CIDR, bool) {
 	return cidr, true
 }
 
+func writeAddresses(w http.ResponseWriter, addrs []address.Address, subnet address.CIDR) {
+	for i, addr := range addrs {
+		fmt.Fprintf(w, "%s/%d", addr, subnet.PrefixLen)
+		if i < len(addrs)-1 {
+			w.Write([]byte{' '})
+		}
+	}
+}
+
 func (alloc *Allocator) handleHTTPAllocate(dockerCli *docker.Client, w http.ResponseWriter, ident string, checkAlive bool, subnet address.CIDR) {
 	closedChan := w.(http.CloseNotifier).CloseNotify()
 	addr, err := alloc.Allocate(ident, subnet.HostRange(),
@@ -80,22 +89,22 @@ func (alloc *Allocator) HandleHTTP(router *mux.Router, defaultSubnet address.CID
 	router.Methods("GET").Path("/ip/{id}/{ip}/{prefixlen}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		if subnet, ok := parseCIDR(w, vars["ip"]+"/"+vars["prefixlen"]); ok {
-			addr, err := alloc.Lookup(vars["id"], subnet.HostRange())
+			addrs, err := alloc.Lookup(vars["id"], subnet.HostRange())
 			if err != nil {
 				http.NotFound(w, r)
 				return
 			}
-			fmt.Fprintf(w, "%s/%d", addr, subnet.PrefixLen)
+			writeAddresses(w, addrs, subnet)
 		}
 	})
 
 	router.Methods("GET").Path("/ip/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		addr, err := alloc.Lookup(mux.Vars(r)["id"], defaultSubnet.HostRange())
+		addrs, err := alloc.Lookup(mux.Vars(r)["id"], defaultSubnet.HostRange())
 		if err != nil {
 			http.NotFound(w, r)
 			return
 		}
-		fmt.Fprintf(w, "%s/%d", addr, defaultSubnet.PrefixLen)
+		writeAddresses(w, addrs, defaultSubnet)
 	})
 
 	router.Methods("POST").Path("/ip/{id}/{ip}/{prefixlen}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -17,12 +17,12 @@ func badRequest(w http.ResponseWriter, err error) {
 }
 
 func parseCIDR(w http.ResponseWriter, cidrStr string, net bool) (address.CIDR, bool) {
-	subnetAddr, cidr, err := address.ParseCIDR(cidrStr)
+	cidr, err := address.ParseCIDR(cidrStr)
 	if err != nil {
 		badRequest(w, err)
 		return address.CIDR{}, false
 	}
-	if net && cidr.Addr != subnetAddr {
+	if net && !cidr.IsSubnet() {
 		badRequest(w, fmt.Errorf("Invalid subnet %s - bits after network prefix are not all zero", cidrStr))
 		return address.CIDR{}, false
 	}

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -40,7 +40,7 @@ func writeAddresses(w http.ResponseWriter, cidrs []address.CIDR) {
 
 func (alloc *Allocator) handleHTTPAllocate(dockerCli *docker.Client, w http.ResponseWriter, ident string, checkAlive bool, subnet address.CIDR) {
 	closedChan := w.(http.CloseNotifier).CloseNotify()
-	addr, err := alloc.Allocate(ident, subnet.HostRange(),
+	addr, err := alloc.Allocate(ident, subnet,
 		func() bool {
 			select {
 			case <-closedChan:

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -16,23 +16,23 @@ func badRequest(w http.ResponseWriter, err error) {
 	common.Log.Warningln("[allocator]:", err.Error())
 }
 
-func parseCIDR(w http.ResponseWriter, cidrStr string) (address.CIDR, bool) {
+func parseCIDR(w http.ResponseWriter, cidrStr string, net bool) (address.CIDR, bool) {
 	subnetAddr, cidr, err := address.ParseCIDR(cidrStr)
 	if err != nil {
 		badRequest(w, err)
 		return address.CIDR{}, false
 	}
-	if cidr.Start != subnetAddr {
+	if net && cidr.Addr != subnetAddr {
 		badRequest(w, fmt.Errorf("Invalid subnet %s - bits after network prefix are not all zero", cidrStr))
 		return address.CIDR{}, false
 	}
 	return cidr, true
 }
 
-func writeAddresses(w http.ResponseWriter, addrs []address.Address, subnet address.CIDR) {
-	for i, addr := range addrs {
-		fmt.Fprintf(w, "%s/%d", addr, subnet.PrefixLen)
-		if i < len(addrs)-1 {
+func writeAddresses(w http.ResponseWriter, cidrs []address.CIDR) {
+	for i, cidr := range cidrs {
+		fmt.Fprint(w, cidr)
+		if i < len(cidrs)-1 {
 			w.Write([]byte{' '})
 		}
 	}
@@ -70,31 +70,27 @@ func (alloc *Allocator) HandleHTTP(router *mux.Router, defaultSubnet address.CID
 		fmt.Fprintf(w, "%s", defaultSubnet)
 	})
 
-	router.Methods("PUT").Path("/ip/{id}/{ip}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	router.Methods("PUT").Path("/ip/{id}/{ip}/{prefixlen}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-		ident := vars["id"]
-		ipStr := vars["ip"]
-		noErrorOnUnknown := r.FormValue("noErrorOnUnknown") == "true"
-		if ip, err := address.ParseIP(ipStr); err != nil {
-			badRequest(w, err)
-			return
-		} else if err := alloc.Claim(ident, ip, noErrorOnUnknown); err != nil {
-			badRequest(w, fmt.Errorf("Unable to claim: %s", err))
-			return
+		if cidr, ok := parseCIDR(w, vars["ip"]+"/"+vars["prefixlen"], false); ok {
+			noErrorOnUnknown := r.FormValue("noErrorOnUnknown") == "true"
+			if err := alloc.Claim(vars["id"], cidr, noErrorOnUnknown); err != nil {
+				badRequest(w, fmt.Errorf("Unable to claim: %s", err))
+				return
+			}
+			w.WriteHeader(204)
 		}
-
-		w.WriteHeader(204)
 	})
 
 	router.Methods("GET").Path("/ip/{id}/{ip}/{prefixlen}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-		if subnet, ok := parseCIDR(w, vars["ip"]+"/"+vars["prefixlen"]); ok {
-			addrs, err := alloc.Lookup(vars["id"], subnet.HostRange())
+		if subnet, ok := parseCIDR(w, vars["ip"]+"/"+vars["prefixlen"], true); ok {
+			cidrs, err := alloc.Lookup(vars["id"], subnet.HostRange())
 			if err != nil {
 				http.NotFound(w, r)
 				return
 			}
-			writeAddresses(w, addrs, subnet)
+			writeAddresses(w, cidrs)
 		}
 	})
 
@@ -104,12 +100,12 @@ func (alloc *Allocator) HandleHTTP(router *mux.Router, defaultSubnet address.CID
 			http.NotFound(w, r)
 			return
 		}
-		writeAddresses(w, addrs, defaultSubnet)
+		writeAddresses(w, addrs)
 	})
 
 	router.Methods("POST").Path("/ip/{id}/{ip}/{prefixlen}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-		if subnet, ok := parseCIDR(w, vars["ip"]+"/"+vars["prefixlen"]); ok {
+		if subnet, ok := parseCIDR(w, vars["ip"]+"/"+vars["prefixlen"], true); ok {
 			alloc.handleHTTPAllocate(dockerCli, w, vars["id"], r.FormValue("check-alive") == "true", subnet)
 		}
 	})

--- a/ipam/http_test.go
+++ b/ipam/http_test.go
@@ -80,7 +80,7 @@ func TestHttp(t *testing.T) {
 	)
 
 	alloc, _ := makeAllocatorWithMockGossip(t, "08:00:27:01:c3:9a", universe, 1)
-	_, cidr, _ := address.ParseCIDR(universe)
+	cidr, _ := address.ParseCIDR(universe)
 	port := listenHTTP(alloc, cidr)
 	alloc.claimRingForTesting()
 
@@ -122,7 +122,7 @@ func TestBadHttp(t *testing.T) {
 
 	alloc, _ := makeAllocatorWithMockGossip(t, "08:00:27:01:c3:9a", testCIDR1, 1)
 	defer alloc.Stop()
-	_, cidr, _ := address.ParseCIDR(testCIDR1)
+	cidr, _ := address.ParseCIDR(testCIDR1)
 	port := listenHTTP(alloc, cidr)
 
 	alloc.claimRingForTesting()
@@ -153,7 +153,7 @@ func TestHTTPCancel(t *testing.T) {
 	alloc, _ := makeAllocatorWithMockGossip(t, "08:00:27:01:c3:9a", testCIDR1, 2)
 	defer alloc.Stop()
 	ExpectBroadcastMessage(alloc, nil) // trying to form consensus
-	_, cidr, _ := address.ParseCIDR(testCIDR1)
+	cidr, _ := address.ParseCIDR(testCIDR1)
 	port := listenHTTP(alloc, cidr)
 
 	// Ask the http server for a new address

--- a/ipam/status.go
+++ b/ipam/status.go
@@ -26,8 +26,8 @@ type EntryStatus struct {
 }
 
 type ClaimStatus struct {
-	Ident   string
-	Address address.Address
+	Ident string
+	CIDR  address.CIDR
 }
 
 func NewStatus(allocator *Allocator, defaultSubnet address.CIDR) *Status {
@@ -80,7 +80,7 @@ func newClaimStatusSlice(allocator *Allocator) []ClaimStatus {
 	var slice []ClaimStatus
 	for _, op := range allocator.pendingClaims {
 		claim := op.(*claim)
-		slice = append(slice, ClaimStatus{claim.ident, claim.addr})
+		slice = append(slice, ClaimStatus{claim.ident, claim.cidr})
 	}
 	return slice
 }

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -128,13 +128,13 @@ type mockDB struct{}
 func (d *mockDB) Load(_ string, _ interface{}) error { return nil }
 func (d *mockDB) Save(_ string, _ interface{}) error { return nil }
 
-func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, address.Range) {
+func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, address.CIDR) {
 	peername, err := mesh.PeerNameFromString(name)
 	if err != nil {
 		panic(err)
 	}
 
-	_, cidr, err := address.ParseCIDR(cidrStr)
+	cidr, err := address.ParseCIDR(cidrStr)
 	if err != nil {
 		panic(err)
 	}
@@ -142,10 +142,10 @@ func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, addres
 	alloc := NewAllocator(peername, mesh.PeerUID(rand.Int63()),
 		"nick-"+name, cidr.Range(), quorum, new(mockDB), func(mesh.PeerName) bool { return true })
 
-	return alloc, cidr.HostRange()
+	return alloc, cidr
 }
 
-func makeAllocatorWithMockGossip(t *testing.T, name string, universeCIDR string, quorum uint) (*Allocator, address.Range) {
+func makeAllocatorWithMockGossip(t *testing.T, name string, universeCIDR string, quorum uint) (*Allocator, address.CIDR) {
 	alloc, subnet := makeAllocator(name, universeCIDR, quorum)
 	gossip := &mockGossipComms{T: t, name: name}
 	alloc.SetInterfaces(gossip)
@@ -199,10 +199,10 @@ func AssertNothingSentErr(t *testing.T, ch <-chan error) {
 	}
 }
 
-func makeNetworkOfAllocators(size int, cidr string) ([]*Allocator, *gossip.TestRouter, address.Range) {
+func makeNetworkOfAllocators(size int, cidr string) ([]*Allocator, *gossip.TestRouter, address.CIDR) {
 	gossipRouter := gossip.NewTestRouter(0.0)
 	allocs := make([]*Allocator, size)
-	var subnet address.Range
+	var subnet address.CIDR
 
 	for i := 0; i < size; i++ {
 		var alloc *Allocator

--- a/net/address/address.go
+++ b/net/address/address.go
@@ -31,11 +31,15 @@ func (r Range) AsCIDRString() string {
 		}
 		prefixLen--
 	}
-	return CIDR{Start: r.Start, PrefixLen: prefixLen}.String()
+	return CIDR{Addr: r.Start, PrefixLen: prefixLen}.String()
+}
+
+func MakeCIDR(subnet CIDR, addr Address) CIDR {
+	return CIDR{Addr: addr, PrefixLen: subnet.PrefixLen}
 }
 
 type CIDR struct {
-	Start     Address
+	Addr      Address
 	PrefixLen int
 }
 
@@ -53,22 +57,22 @@ func ParseCIDR(s string) (Address, CIDR, error) {
 		return 0, CIDR{}, &net.ParseError{Type: "Non-IPv4 address not supported", Text: s}
 	} else {
 		prefixLen, _ := ipnet.Mask.Size()
-		return FromIP4(ip), CIDR{Start: FromIP4(ipnet.IP), PrefixLen: prefixLen}, nil
+		return FromIP4(ip), CIDR{Addr: FromIP4(ipnet.IP), PrefixLen: prefixLen}, nil
 	}
 }
 
 func (cidr CIDR) Size() Offset { return 1 << uint(32-cidr.PrefixLen) }
 
 func (cidr CIDR) Range() Range {
-	return NewRange(cidr.Start, cidr.Size())
+	return NewRange(cidr.Addr, cidr.Size())
 }
 func (cidr CIDR) HostRange() Range {
 	// Respect RFC1122 exclusions of first and last addresses
-	return NewRange(cidr.Start+1, cidr.Size()-2)
+	return NewRange(cidr.Addr+1, cidr.Size()-2)
 }
 
 func (cidr CIDR) String() string {
-	return fmt.Sprintf("%s/%d", cidr.Start.String(), cidr.PrefixLen)
+	return fmt.Sprintf("%s/%d", cidr.Addr.String(), cidr.PrefixLen)
 }
 
 // FromIP4 converts an ipv4 address to our integer address type

--- a/net/address/address.go
+++ b/net/address/address.go
@@ -50,15 +50,20 @@ func ParseIP(s string) (Address, error) {
 	return 0, &net.ParseError{Type: "IP Address", Text: s}
 }
 
-func ParseCIDR(s string) (Address, CIDR, error) {
+func ParseCIDR(s string) (CIDR, error) {
 	if ip, ipnet, err := net.ParseCIDR(s); err != nil {
-		return 0, CIDR{}, err
+		return CIDR{}, err
 	} else if ipnet.IP.To4() == nil {
-		return 0, CIDR{}, &net.ParseError{Type: "Non-IPv4 address not supported", Text: s}
+		return CIDR{}, &net.ParseError{Type: "Non-IPv4 address not supported", Text: s}
 	} else {
 		prefixLen, _ := ipnet.Mask.Size()
-		return FromIP4(ip), CIDR{Addr: FromIP4(ipnet.IP), PrefixLen: prefixLen}, nil
+		return CIDR{Addr: FromIP4(ip), PrefixLen: prefixLen}, nil
 	}
+}
+
+func (cidr CIDR) IsSubnet() bool {
+	mask := cidr.Size() - 1
+	return Offset(cidr.Addr)&mask == 0
 }
 
 func (cidr CIDR) Size() Offset { return 1 << uint(32-cidr.PrefixLen) }

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -340,9 +340,12 @@ func createOverlay(datapathName string, ifaceName string, host string, port int,
 }
 
 func parseAndCheckCIDR(cidrStr string) address.CIDR {
-	_, cidr, err := address.ParseCIDR(cidrStr)
+	cidr, err := address.ParseCIDR(cidrStr)
 	checkFatal(err)
 
+	if !cidr.IsSubnet() {
+		Log.Fatalf("Invalid allocation range %s - bits after network prefix are not all zero", cidrStr)
+	}
 	if cidr.Size() < ipam.MinSubnetSize {
 		Log.Fatalf("Allocation range smaller than minimum size %d: %s", ipam.MinSubnetSize, cidrStr)
 	}

--- a/weave
+++ b/weave
@@ -1343,7 +1343,7 @@ ipam_cidrs() {
                     echo "IP address allocation must be enabled to use 'net:'" >&2
                     return 1
                 fi
-            elif ! is_cidr "$CIDR" ; then
+            elif [ -n "$CIDR" ] && ! is_cidr "$CIDR" ; then
                 echo "$CIDR" >&2
                 return 1
             else

--- a/weave
+++ b/weave
@@ -1298,7 +1298,7 @@ check_overlap() {
 # with_container_addresses.
 ipam_reclaim() {
     for CIDR in $3 ; do
-        http_call $HTTP_ADDR PUT /ip/$1/${CIDR%/*}?noErrorOnUnknown=true
+        http_call $HTTP_ADDR PUT /ip/$1/$CIDR?noErrorOnUnknown=true
     done
 }
 
@@ -1354,7 +1354,7 @@ ipam_cidrs() {
             if [ "$METHOD" = "POST" ] ; then
                 # Assignment of a plain IP address; warn if it clashes but carry on
                 check_overlap $arg || true
-                when_weave_running http_call $HTTP_ADDR PUT /ip/$CONTAINER_ID/${arg%/*} >&2
+                when_weave_running http_call $HTTP_ADDR PUT /ip/$CONTAINER_ID/$arg >&2
             fi
             ALL_CIDRS="$ALL_CIDRS $arg"
         fi
@@ -2064,7 +2064,7 @@ EOF
         RES=$(docker restart $1)
         CONTAINER=$(container_id $1)
         for CIDR in $ALL_CIDRS ; do
-            call_weave PUT /ip/$CONTAINER/${CIDR%/*}
+            call_weave PUT /ip/$CONTAINER/$CIDR
         done
         with_container_netns_or_die $1 attach $ALL_CIDRS
         when_weave_running with_container_fqdn $1 put_dns_fqdn $ALL_CIDRS


### PR DESCRIPTION
Partial fix for #1655 

The missing piece is having the proxy recover the addresses on restart.  Currently the proxy acts via `weave attach`, so we would need a variant of that to retrieve all addresses from IPAM.