### PR TITLE
Abstract out logging function from weave api package

### DIFF
--- a/prog/plugin/main.go
+++ b/prog/plugin/main.go
@@ -51,7 +51,7 @@ func main() {
 		Log.Fatalf("unable to connect to docker: %s", err)
 	}
 
-	weave := weaveapi.NewClient(os.Getenv("WEAVE_HTTP_ADDR"))
+	weave := weaveapi.NewClient(os.Getenv("WEAVE_HTTP_ADDR"), Log)
 
 	Log.Println("Weave plugin", version, "Command line options:", os.Args[1:])
 	Log.Info(dockerClient.Info())

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -558,7 +558,7 @@ func (proxy *Proxy) getDNSDomain() string {
 	if proxy.WithoutDNS {
 		return ""
 	}
-	weave := weaveapi.NewClient(os.Getenv("WEAVE_HTTP_ADDR"))
+	weave := weaveapi.NewClient(os.Getenv("WEAVE_HTTP_ADDR"), Log)
 	domain, _ := weave.DNSDomain()
 	return domain
 }


### PR DESCRIPTION
To reduce dependencies for other projects who decide to use the Weave Net API.  With this change, you have to pass in the logger you want to use when you create the `Client` object.

The `Logger` interface here is a bit arbitrary; the only function we are actually using is `Debugf`, but it seemed a bit weird to just have that one line.