### PR TITLE
Doc fixes required by updated WP markdown plugin

### DIFF
--- a/site/fastdp/fastdp-how-it-works.md
+++ b/site/fastdp/fastdp-how-it-works.md
@@ -6,16 +6,16 @@ layout: default
 
 Weave Net implements an overlay network between Docker hosts. Without fast datapath enabled, each packet is encapsulated in a tunnel protocol header and sent to the destination host, where the header is removed.  The Weave router is a user space process, which means that the packet follows a winding path in and out of the Linux kernel:
 
-![Weave Net Encapsulation](/images/weave-net-encap1-1024x459.png)
+![Weave Net Encapsulation](/site/images/weave-net-encap1-1024x459.png)
 
 
 The fast datapath in Weave Net uses the Linux kernel's [Open vSwitch datapath module](https://www.kernel.org/doc/Documentation/networking/openvswitch.txt). This module enables the Weave Net router to tell the kernel how to process packets:
 
-![Weave Net Encapsulation](/images/weave-net-fdp1-1024x454.png)
+![Weave Net Encapsulation](/site/images/weave-net-fdp1-1024x454.png)
 
 Because Weave Net issues instructions directly to the kernel, context switches are decreased, and so by using `fast datapath` CPU overhead and latency is reduced. The packet goes straight from your application to the kernel, where the Virtual Extensible Lan (VXLAN) header is added (the NIC does this if it offers VXLAN acceleration). VXLAN is an IETF standard UDP-based tunneling protocol that enable you to use common networking tools like [Wireshark](https://www.wireshark.org/) to inspect the tunneled packets.
 
-![Weave Net Encapsulation](/images/weave-frame-encapsulation-178x300.png)
+![Weave Net Encapsulation](/site/images/weave-frame-encapsulation-178x300.png)
 
 Prior to version 1.2, Weave Net used a custom encapsulation format. Fast data path uses VXLAN, and like Weave Net's custom encapsulation format, VXLAN is UDP-based, and therefore needs no special configuration with network infrastructure. 
 

--- a/site/features.md
+++ b/site/features.md
@@ -87,7 +87,7 @@ named `weave` is created by `weave launch`, which is used as follows:
 
     $ docker run --net=weave -ti ubuntu 
 
-Using the Weave plugin enables you to take advantage of [Docker's network functionality]( https://docs.docker.com/engine/extend/plugins_network/)
+Using the Weave plugin enables you to take advantage of [Docker's network functionality](https://docs.docker.com/engine/extend/plugins_network/)
 
 Also, Weave’s Docker Network plugin doesn't require an external cluster store and you can start and stop containers even 
 when there are network connectivity problems.

--- a/site/introducing-weave.md
+++ b/site/introducing-weave.md
@@ -15,7 +15,7 @@ Services provided by application containers on the weave network can be exposed 
 
 Weave Net simplifies setting up a container network. Because containers on a Weave network use standard port numbers, (for example MySQL’s default is port 3306), managing microservices is straightforward. Every container can find the IP of any other container using a simple DNS query on the container's name, and it can also communicate directly without NAT, without using port mappings or complicated ambassador linking.  And best of all deploying a Weave container network requires zero changes to your application’s code. 
 
-![Weave Net Encapsulation](/images/weave-net-overview.png)
+![Weave Net Encapsulation](/site/images/weave-net-overview.png)
 
 ###Service Discovery
 

--- a/site/introducing-weave.md
+++ b/site/introducing-weave.md
@@ -36,7 +36,7 @@ Weave Net can forward traffic between nodes, and it works even if the mesh netwo
 
 Weave Net automatically chooses the fastest path between two hosts, offering near native throughput and latency, all without your intervention.  
 
-See [How Fast Datapath Works](site/fastdp/using-fastdp.md) for more information.
+See [How Fast Datapath Works](/site/fastdp/using-fastdp.md) for more information.
 
 ###Network Operations Friendly
 

--- a/site/router-topology/overview.md
+++ b/site/router-topology/overview.md
@@ -43,7 +43,7 @@ changing topology. For example, in this network, peer 1 is connected
 directly to 2 and 3, but if 1 needs to send a packet to 4 or 5 it must
 first send it to peer 3:
 
-![A Partially Connected Weave Network](images/top-diag1.png "Partially connected Weave Network")
+![A Partially Connected Weave Network](/site/images/top-diag1.png "Partially connected Weave Network")
 
 **See Also**
 

--- a/site/using-weave/deploying-applications.md
+++ b/site/using-weave/deploying-applications.md
@@ -13,7 +13,7 @@ This section contains the following topics:
 
 ###<a name="launching"></a>Launching Weave Net
 
-Before launching Weave Net and deploying your apps, ensure that Docker is [installed]( https://docs.docker.com/engine/installation/) on both hosts. 
+Before launching Weave Net and deploying your apps, ensure that Docker is [installed](https://docs.docker.com/engine/installation/) on both hosts. 
 
 On `$HOST1` run:
 
@@ -25,7 +25,7 @@ Where,
 
  * The first line runs Weave Net. 
  * The second line configures the Weave Net environment, so that containers launched via the Docker command line are automatically attached to the Weave network, and, 
- * The third line runs the application container using [Docker commands]( https://docs.Docker.com/engine/reference/commandline/daemon/). 
+ * The third line runs the application container using [Docker commands](https://docs.Docker.com/engine/reference/commandline/daemon/). 
 
 >>**Note:** If the first command results in an error like
  `http:///var/run/Docker.sock/v1.19/containers/create: dial unix

--- a/site/using-weave/host-network-integration.md
+++ b/site/using-weave/host-network-integration.md
@@ -5,7 +5,7 @@ layout: default
 
 Weave application networks can be integrated with an external host network, establishing connectivity between the host and with application containers running anywhere.
 
-For example, returning to the [netcat example]( /site/using-weave/intro-example.md), you’ve now decided that you need to have the application containers that are running on `$HOST2` accessible by other hosts and containers. 
+For example, returning to the [netcat example](/site/using-weave/intro-example.md), you’ve now decided that you need to have the application containers that are running on `$HOST2` accessible by other hosts and containers. 
 
 On `$HOST2` run:
 

--- a/site/using-weave/security-untrusted-networks.md
+++ b/site/using-weave/security-untrusted-networks.md
@@ -34,7 +34,7 @@ password at `weave launch` the router falls back to a slower
 
 If some of your peers are co-located in a trusted network (for example within the boundary of your own datacenter) you can use the `--trusted-subnets` argument to `weave launch` to selectively disable data plane encryption as an optimization. 
 
->>**Note:** Both peers must consider the other to be in a trusted subnet for this to take place - if they do not agree, Weave Net [falls back to a slower method]( /site/fastdp/using-fastdp.md) for transporting data between peers, since fast datapath does not support encryption.
+>>**Note:** Both peers must consider the other to be in a trusted subnet for this to take place - if they do not agree, Weave Net [falls back to a slower method](/site/fastdp/using-fastdp.md) for transporting data between peers, since fast datapath does not support encryption.
 
 Be aware that:
 

--- a/site/using-weave/service-export.md
+++ b/site/using-weave/service-export.md
@@ -8,7 +8,7 @@ accessible to the outside world (and, more generally, to other networks)
 from any Weave Net host, irrespective of where the service containers are
 located.
 
-Returning to the netcat example service, described in [Deploying Applications]( /site/using-weave/deploying-applications.md), 
+Returning to the netcat example service, described in [Deploying Applications](/site/using-weave/deploying-applications.md), 
 you can expose the netcat service running on `HOST1` and make it accessible to the outside world via `$HOST2`. 
 
 First, expose the application network to `$HOST2`, as explained in [Integrating a Host Network with a Weave Net](/site/using-weave/host-network-integration.md):


### PR DESCRIPTION
Required by (the now misnamed) weaveworks/weave-guide-sync#1