### PR TITLE
Bump template name so it will fetch latest Docker

### DIFF
--- a/test/gce.sh
+++ b/test/gce.sh
@@ -11,7 +11,7 @@ set -e
 : ${SSH_KEY_FILE:=$HOME/.ssh/gce_ssh_key}
 : ${PROJECT:=positive-cocoa-90213}
 : ${IMAGE:=ubuntu-14-04}
-: ${TEMPLATE_NAME:=test-template-9}
+: ${TEMPLATE_NAME:=test-template-10}
 : ${ZONE:=us-central1-a}
 : ${NUM_HOSTS:=5}
 SUFFIX=""


### PR DESCRIPTION
At the time of writing, this gives us Docker 1.10.3.