### PR TITLE
Remove unnecessary netns change in attach_router

### DIFF
--- a/weave
+++ b/weave
@@ -1644,7 +1644,7 @@ launch_router() {
         "$@"
     setup_router_iface_$BRIDGE_TYPE
     wait_for_status $CONTAINER_NAME http_call $HTTP_ADDR
-    [ -n "$ALREADY_RUNNING_CONTAINER" ] || attach_router
+    [ -n "$ALREADY_RUNNING_CONTAINER" ] || populate_router
 }
 
 # Recreate the parameter values that are set when the router is first launched
@@ -1654,7 +1654,7 @@ fetch_router_args() {
     NO_DNS_OPT=$(echo $CONTAINER_ARGS | grep -o -e '--no-dns') || true
 }
 
-attach_router() {
+populate_router() {
     if [ -n "$IPRANGE" ] ; then
         # Tell the newly-started weave IP allocator about existing weave IPs
         with_container_addresses ipam_reclaim weave:expose $(docker ps -q --no-trunc)
@@ -1893,9 +1893,9 @@ EOF
         enforce_docker_bridge_addr_assign_type
         create_bridge
         fetch_router_args
-        with_container_netns $CONTAINER_NAME setup_router_iface_$BRIDGE_TYPE
+        setup_router_iface_$BRIDGE_TYPE
         wait_for_status $CONTAINER_NAME http_call $HTTP_ADDR
-        attach_router
+        populate_router
         ;;
     launch-proxy)
         deprecation_warnings "$@"


### PR DESCRIPTION
This was missed from #1930.

Also rename function `attach_router` to `populate_router`, which describes the behaviour better.