### PR TITLE
Use current target list to compute quorum

### DIFF
--- a/ipam/paxos/participant.go
+++ b/ipam/paxos/participant.go
@@ -1,25 +1,19 @@
 package paxos
 
-import "github.com/weaveworks/mesh"
-
 type Participant interface {
 	GossipState() GossipState
 	Update(from GossipState) bool
+	SetQuorum(uint)
 	Propose()
 	Think() bool
 	Consensus() (bool, AcceptedValue)
 }
 
-func NewParticipant(name mesh.PeerName, uid mesh.PeerUID, quorum uint) Participant {
-	switch quorum {
-	case 0:
-		return &Observer{}
-	default:
-		return NewNode(name, uid, quorum)
-	}
+type Observer struct {
 }
 
-type Observer struct {
+func NewObserver() Participant {
+	return &Observer{}
 }
 
 func (observer *Observer) GossipState() GossipState {
@@ -31,6 +25,9 @@ func (observer *Observer) Update(from GossipState) bool {
 }
 
 func (observer *Observer) Propose() {
+}
+
+func (observer *Observer) SetQuorum(uint) {
 }
 
 func (observer *Observer) Think() bool {

--- a/ipam/paxos/paxos.go
+++ b/ipam/paxos/paxos.go
@@ -80,6 +80,10 @@ func NewNode(name mesh.PeerName, uid mesh.PeerUID, quorum uint) *Node {
 	}
 }
 
+func (node *Node) SetQuorum(quorum uint) {
+	node.quorum = quorum
+}
+
 func (node *Node) GossipState() GossipState {
 	return node.knows
 }

--- a/ipam/paxos/paxos.go
+++ b/ipam/paxos/paxos.go
@@ -128,6 +128,9 @@ func max(a uint, b uint) uint {
 // simply a matter of gossipping a new proposal that supersedes all
 // others.
 func (node *Node) Propose() {
+	if node.quorum == 0 {
+		panic("Paxos node.Propose() called with no quorum set")
+	}
 	// Find the highest round number around
 	round := uint(0)
 

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -144,7 +144,8 @@ func makeAllocator(name string, cidrStr string, quorum uint) (*Allocator, addres
 		OurUID:      mesh.PeerUID(rand.Int63()),
 		OurNickname: "nick-" + name,
 		Universe:    cidr.Range(),
-		Quorum:      quorum,
+		IsObserver:  quorum == 0,
+		Quorum:      func() uint { return quorum },
 		Db:          new(mockDB),
 		IsKnownPeer: func(mesh.PeerName) bool { return true },
 	}), cidr

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -433,7 +433,7 @@ func determineQuorum(initPeerCountFlag int, router *weave.NetworkRouter) uint {
 		return uint(initPeerCountFlag/2 + 1)
 	}
 
-	peers := router.ConnectionMaker.Targets()
+	peers := router.ConnectionMaker.Targets(true)
 
 	// Guess a suitable quorum size based on the list of peer
 	// addresses.  The peer list might or might not contain an

--- a/test/700_status_and_report_test.sh
+++ b/test/700_status_and_report_test.sh
@@ -19,11 +19,11 @@ check "DefaultSubnet" "{{.IPAM.DefaultSubnet}}"                $UNIVERSE
 check "Domain"        "{{.DNS.Domain}}"                        "weave.local."
 
 assert_raises "weave_on $HOST1 status peers | grep nicknamington"
-weave_on $HOST1 connect 10.2.2.1
-assert "weave_on $HOST1 status targets" "10.2.2.1"
-assert "weave_on $HOST1 status connections | tr -s ' ' | cut -d ' ' -f 2" "10.2.2.1:6783"
 start_container $HOST1 --name test
 assert "weave_on $HOST1 status dns         | tr -s ' ' | cut -d ' ' -f 1" "test"
 assert_raises "weave_on $HOST1 report | grep nicknamington"
+weave_on $HOST1 connect 10.2.2.1
+assert "weave_on $HOST1 status targets" "10.2.2.1"
+assert "weave_on $HOST1 status connections | tr -s ' ' | cut -d ' ' -f 2" "10.2.2.1:6783"
 
 end_suite


### PR DESCRIPTION
Do it by calling out into a function which has access to the list, rather than pushing updates in as suggested in #1721.

Fixes #1721 and #1881

The fix for #1881 is racy - if we decide to go for consensus before hearing back that the address refers to ourselves then we will still count ourself.