### PR TITLE
make `weave rmpeer` accept a list of peers

### DIFF
--- a/site/ipam/stop-remove-peers-ipam.md
+++ b/site/ipam/stop-remove-peers-ipam.md
@@ -14,12 +14,13 @@ network so if Weave Net is run again on that node it will start from
 scratch.
 
 For failed peers, the `weave rmpeer` command can be invoked to
-permanently remove the ranges allocated to said peer.  This allows
+permanently remove the ranges allocated to said peers.  This allows
 other peers to allocate IPs in the ranges previously owned by the
-removed peer, and as such should be used with extreme caution - if the
-removed peer had transferred some range of IP addresses to another
-peer but this is not known to the whole network, or if it later
-rejoins the Weave network, the same IP address may be allocated twice.
+removed peers, and as such should be used with extreme caution: if the
+removed peers had transferred some range of IP addresses to other
+peers but this is not known to the whole network, or if some of them
+later rejoin the Weave network, the same IP address may be allocated
+twice.
 
 Assume you had started the three peers in the example earlier, and
 then host3 caught fire, you can go to one of the other hosts and run:

--- a/weave
+++ b/weave
@@ -86,13 +86,14 @@ weave stop
       stop-plugin
 
 weave reset
-      rmpeer        <nickname> | <weave internal peer ID>
+      rmpeer        <peer_id> ...
 
 
 where <peer>     = <ip_address_or_fqdn>[:<port>]
       <cidr>     = <ip_address>/<routing_prefix_length>
       <addr>     = [ip:]<cidr> | net:<cidr> | net:default
       <endpoint> = [tcp://][<ip_address>]:<port> | [unix://]/path/to/socket
+      <peer_id>  = <nickname> | <weave internal peer ID>
 EOF
 }
 
@@ -2190,9 +2191,12 @@ EOF
         done
         ;;
     rmpeer)
-        [ $# -eq 1 ] || usage
-        PEER=$1
-        call_weave DELETE /peer/$PEER
+        [ $# -gt 0 ] || usage
+        res=0
+        for PEER in "$@" ; do
+            call_weave DELETE /peer/$PEER || res=1
+        done
+        [ $res -eq 0 ]
         ;;
     launch-dns)
         echo "The 'launch-dns' command has been removed; DNS is launched as part of 'launch' and 'launch-router'." >&2


### PR DESCRIPTION
This isn't as efficient as it could be. In particular we end up broadcasting the ipam state for every peer listed. To avoid that we'd have to change the HTTP API, and would no longer be able to use 'DELETE'. That is just not worth it.

Closes #2044.