### PR TITLE
Don't delete targets that seem invalid if they are 'direct' targets

### DIFF
--- a/mesh/status.go
+++ b/mesh/status.go
@@ -181,6 +181,7 @@ func NewLocalConnectionStatusSlice(cm *ConnectionMaker) []LocalConnectionStatus 
 					add("retrying", target.lastError.Error())
 				}
 			case TargetConnected:
+			case TargetSuspended:
 			}
 		}
 		resultChan <- slice


### PR DESCRIPTION
Fixes #2087 

We were removing the `cm.targets` entry because we had an incoming connection from that IP address, but that means we remove all knowledge of previous attempts so we will reconnect very quickly.

Leaving all "direct" targets in the `targets` set is a better approach: it is bounded (by the size of the direct peer list), and innocuous unless the connection is repeatedly failing.