### PR TITLE
fail plugin operation on bridge attachment error

### DIFF
--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -135,11 +135,15 @@ func (driver *driver) JoinEndpoint(j *api.JoinRequest) (*api.JoinResponse, error
 			Log.Errorf("device %s is %+v", WeaveBridge, maybeBridge)
 			return nil, errorf(`device "%s" is of type "%s"`, WeaveBridge, maybeBridge.Type())
 		}
-		odp.AddDatapathInterface(WeaveBridge, local.Name)
+		if err := odp.AddDatapathInterface(WeaveBridge, local.Name); err != nil {
+			return nil, errorf(`failed to attach "%s" to device "%s": %s`, local.Name, WeaveBridge, err)
+		}
 	case *netlink.Device:
 		Log.Warnf("kernel does not report what kind of device %s is, just %+v", WeaveBridge, maybeBridge)
 		// Assume it's our openvswitch device, and the kernel has not been updated to report the kind.
-		odp.AddDatapathInterface(WeaveBridge, local.Name)
+		if err := odp.AddDatapathInterface(WeaveBridge, local.Name); err != nil {
+			return nil, errorf(`failed to attach "%s" to device "%s": %s`, local.Name, WeaveBridge, err)
+		}
 	default:
 		Log.Errorf("device %s is %+v", WeaveBridge, maybeBridge)
 		return nil, errorf(`device "%s" not a bridge`, WeaveBridge)


### PR DESCRIPTION
Fixes #2097.

The error gets reported to the user like this:
```
$ docker run --net=weave --hostname=foo.weave.local -dti alpine /bin/sh
eb4c86806973513625b7e269a1711012896958ee3d46c21b129dde6a26db050c
docker: Error response from daemon: NetworkDriver.Join: failed to attach "vethwl73264" to device "weave": netlink error response: no such device.
```
Same in plugin logs.