### PR TITLE
make `weave dns-args` and `weave run` work with `--no-dns`

### DIFF
--- a/test/205_dns_disabled.sh
+++ b/test/205_dns_disabled.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+
+. ./config.sh
+
+C1=10.2.0.87
+
+start_suite "Standard behaviour when weaveDNS is disabled"
+
+weave_on $HOST1 launch --no-dns
+
+assert "weave_on $HOST1 dns-args" ""
+
+C=$(start_container_with_dns $HOST1 $C1/24 --name=c1)
+
+# hostname is left untouched; equals short container id
+assert "exec_on $HOST1 c1 hostname" $(echo $C | cut -c1-12)
+
+# domainname is left empty
+assert "exec_on $HOST1 c1 dnsdomainname" ""
+
+# external name resolution works
+assert_raises "exec_on $HOST1 c1 getent hosts www.weave.works"
+
+end_suite

--- a/weave
+++ b/weave
@@ -1092,6 +1092,7 @@ peer_args() {
 # Memoized function to query the weaveDNS server for our dns domain.
 dns_domain() {
     DNS_DOMAIN=${DNS_DOMAIN:-$(call_weave GET /domain 2>/dev/null || true)}
+    [ "$DNS_DOMAIN" = "404 page not found" ] && return 1
     DNS_DOMAIN=${DNS_DOMAIN:-weave.local.}
     echo $DNS_DOMAIN
 }
@@ -1127,9 +1128,9 @@ dns_args() {
         shift
     done
     [ -n "$WITHOUT_DNS" ] && return 0
+    DOMAIN=$(dns_domain) || return 0
     DNS_ARGS="--dns $DOCKER_BRIDGE_IP"
     if [ -n "$NAME_ARG" -a -z "$HOSTNAME_SPECIFIED" ] ; then
-        DOMAIN=$(dns_domain)
         HOSTNAME="$NAME_ARG.${DOMAIN%.}"
         if [ ${#HOSTNAME} -gt 64 ] ; then
             echo "Container name too long to be used as hostname" >&2
@@ -1140,7 +1141,7 @@ dns_args() {
     fi
     if [ -z "$DNS_SEARCH_SPECIFIED" ] ; then
       if [ -z "$HOSTNAME_SPECIFIED" ] ; then
-        DNS_ARGS="$DNS_ARGS --dns-search=$(dns_domain)"
+        DNS_ARGS="$DNS_ARGS --dns-search=$DOMAIN"
       else
         DNS_ARGS="$DNS_ARGS --dns-search=."
       fi

--- a/weave
+++ b/weave
@@ -1089,16 +1089,12 @@ peer_args() {
 # weaveDNS helpers
 ######################################################################
 
-# Memoized function to query the weaveDNS server for our dns domain.
-dns_domain() {
-    DNS_DOMAIN=${DNS_DOMAIN:-$(call_weave GET /domain 2>/dev/null || true)}
-    [ "$DNS_DOMAIN" = "404 page not found" ] && return 1
-    DNS_DOMAIN=${DNS_DOMAIN:-weave.local.}
-    echo $DNS_DOMAIN
-}
-
 dns_args() {
-    DOMAIN=$(dns_domain) || return 0
+    # NB: this is memoized
+    DNS_DOMAIN=${DNS_DOMAIN:-$(call_weave GET /domain 2>/dev/null || true)}
+    [ "$DNS_DOMAIN" = "404 page not found" ] && return 0
+    DNS_DOMAIN=${DNS_DOMAIN:-weave.local.}
+
     NAME_ARG=""
     HOSTNAME_SPECIFIED=
     DNS_SEARCH_SPECIFIED=
@@ -1128,10 +1124,11 @@ dns_args() {
         shift
     done
     [ -n "$WITHOUT_DNS" ] && return 0
+
     docker_bridge_ip
     DNS_ARGS="--dns $DOCKER_BRIDGE_IP"
     if [ -n "$NAME_ARG" -a -z "$HOSTNAME_SPECIFIED" ] ; then
-        HOSTNAME="$NAME_ARG.${DOMAIN%.}"
+        HOSTNAME="$NAME_ARG.${DNS_DOMAIN%.}"
         if [ ${#HOSTNAME} -gt 64 ] ; then
             echo "Container name too long to be used as hostname" >&2
         else
@@ -1141,7 +1138,7 @@ dns_args() {
     fi
     if [ -z "$DNS_SEARCH_SPECIFIED" ] ; then
       if [ -z "$HOSTNAME_SPECIFIED" ] ; then
-        DNS_ARGS="$DNS_ARGS --dns-search=$DOMAIN"
+        DNS_ARGS="$DNS_ARGS --dns-search=$DNS_DOMAIN"
       else
         DNS_ARGS="$DNS_ARGS --dns-search=."
       fi

--- a/weave
+++ b/weave
@@ -1098,7 +1098,7 @@ dns_domain() {
 }
 
 dns_args() {
-    docker_bridge_ip
+    DOMAIN=$(dns_domain) || return 0
     NAME_ARG=""
     HOSTNAME_SPECIFIED=
     DNS_SEARCH_SPECIFIED=
@@ -1128,7 +1128,7 @@ dns_args() {
         shift
     done
     [ -n "$WITHOUT_DNS" ] && return 0
-    DOMAIN=$(dns_domain) || return 0
+    docker_bridge_ip
     DNS_ARGS="--dns $DOCKER_BRIDGE_IP"
     if [ -n "$NAME_ARG" -a -z "$HOSTNAME_SPECIFIED" ] ; then
         HOSTNAME="$NAME_ARG.${DOMAIN%.}"


### PR DESCRIPTION
...rather than exploding

i.e. the former returns nothing and the latter leaves naming related container settings untouched, just like happens in the proxy and plugin.

Fixes #2099.