### PR TITLE
wait for datapath device to be ready

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -348,6 +348,8 @@ func createOverlay(datapathName string, ifaceName string, host string, port int,
 	case datapathName != "" && ifaceName != "":
 		Log.Fatal("At most one of --datapath and --iface must be specified.")
 	case datapathName != "":
+		_, err := weavenet.EnsureInterface(datapathName)
+		checkFatal(err)
 		fastdp, err := weave.NewFastDatapath(datapathName, port)
 		checkFatal(err)
 		bridge = fastdp.Bridge()

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -348,9 +348,9 @@ func createOverlay(datapathName string, ifaceName string, host string, port int,
 	case datapathName != "" && ifaceName != "":
 		Log.Fatal("At most one of --datapath and --iface must be specified.")
 	case datapathName != "":
-		_, err := weavenet.EnsureInterface(datapathName)
+		iface, err := weavenet.EnsureInterface(datapathName)
 		checkFatal(err)
-		fastdp, err := weave.NewFastDatapath(datapathName, port)
+		fastdp, err := weave.NewFastDatapath(iface, port)
 		checkFatal(err)
 		bridge = fastdp.Bridge()
 		overlay.Add("fastdp", fastdp.Overlay())

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -28,7 +28,6 @@ type bridgeSender func(key PacketKey, lock *fastDatapathLock) FlowOp
 type missHandler func(fks odp.FlowKeys, lock *fastDatapathLock) FlowOp
 
 type FastDatapath struct {
-	dpname           string
 	lock             sync.Mutex // guards state and synchronises use of dpif
 	dpif             *odp.Dpif
 	dp               odp.DatapathHandle
@@ -80,7 +79,6 @@ func NewFastDatapath(iface *net.Interface, port int) (*FastDatapath, error) {
 	}
 
 	fastdp := &FastDatapath{
-		dpname:        iface.Name,
 		dpif:          dpif,
 		dp:            dp,
 		iface:         iface,
@@ -204,7 +202,7 @@ func (fastdp fastDatapathBridge) Interface() *net.Interface {
 }
 
 func (fastdp fastDatapathBridge) String() string {
-	return fmt.Sprint(fastdp.dpname, " (via ODP)")
+	return fmt.Sprint(fastdp.iface.Name, " (via ODP)")
 }
 
 func (fastdp fastDatapathBridge) Stats() map[string]int {

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -29,9 +29,9 @@ type missHandler func(fks odp.FlowKeys, lock *fastDatapathLock) FlowOp
 
 type FastDatapath struct {
 	lock             sync.Mutex // guards state and synchronises use of dpif
+	iface            *net.Interface
 	dpif             *odp.Dpif
 	dp               odp.DatapathHandle
-	iface            *net.Interface
 	deleteFlowsCount uint64
 	missCount        uint64
 	missHandlers     map[odp.VportID]missHandler
@@ -79,9 +79,9 @@ func NewFastDatapath(iface *net.Interface, port int) (*FastDatapath, error) {
 	}
 
 	fastdp := &FastDatapath{
+		iface:         iface,
 		dpif:          dpif,
 		dp:            dp,
-		iface:         iface,
 		missHandlers:  make(map[odp.VportID]missHandler),
 		sendToPort:    nil,
 		sendToMAC:     make(map[MAC]bridgeSender),

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -61,7 +61,7 @@ type FastDatapath struct {
 	forwarders map[mesh.PeerName]*fastDatapathForwarder
 }
 
-func NewFastDatapath(dpName string, port int) (*FastDatapath, error) {
+func NewFastDatapath(iface *net.Interface, port int) (*FastDatapath, error) {
 	dpif, err := odp.NewDpif()
 	if err != nil {
 		return nil, err
@@ -74,18 +74,13 @@ func NewFastDatapath(dpName string, port int) (*FastDatapath, error) {
 		}
 	}()
 
-	dp, err := dpif.LookupDatapath(dpName)
-	if err != nil {
-		return nil, err
-	}
-
-	iface, err := net.InterfaceByName(dpName)
+	dp, err := dpif.LookupDatapath(iface.Name)
 	if err != nil {
 		return nil, err
 	}
 
 	fastdp := &FastDatapath{
-		dpname:        dpName,
+		dpname:        iface.Name,
 		dpif:          dpif,
 		dp:            dp,
 		iface:         iface,


### PR DESCRIPTION
so that when the router container restarts after a reboot it waits for the proxy to create the datapath device, rather than dying.

Fixes #2113.