### PR TITLE
Update weaveworks/mesh to send gossip to restarted peer

### DIFF
--- a/common/logging.go
+++ b/common/logging.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -63,4 +64,24 @@ func CheckWarn(e error) {
 	if e != nil {
 		Log.Warnln(e)
 	}
+}
+
+// Adaptor type to go from Logrus to something expecting a standard library log.Logger
+type logLogger struct {
+	logger *logrus.Logger
+}
+
+// io.Writer interface
+func (l logLogger) Write(p []byte) (n int, err error) {
+	ln := len(p)
+	// Strip a trailing newline, because logrus formatter adds one
+	if ln > 0 && p[ln-1] == '\n' {
+		p = p[:ln-1]
+	}
+	l.logger.Info(string(p))
+	return ln, nil
+}
+
+func LogLogger() *log.Logger {
+	return log.New(logLogger{Log}, "", 0)
 }

--- a/router/network_router.go
+++ b/router/network_router.go
@@ -57,7 +57,7 @@ func NewNetworkRouter(config mesh.Config, networkConfig NetworkConfig, name mesh
 		networkConfig.Bridge = NullBridge{}
 	}
 
-	router := &NetworkRouter{Router: mesh.NewRouter(config, name, nickName, overlay), NetworkConfig: networkConfig, db: db}
+	router := &NetworkRouter{Router: mesh.NewRouter(config, name, nickName, overlay, common.LogLogger()), NetworkConfig: networkConfig, db: db}
 	router.Peers.OnInvalidateShortIDs(overlay.InvalidateShortIDs)
 	router.Routes.OnChange(overlay.InvalidateRoutes)
 	router.Macs = NewMacCache(macMaxAge,


### PR DESCRIPTION
Particularly to bring in https://github.com/weaveworks/mesh/pull/29

Note the test now has a `sleep 32` in it, to take us past a periodic gossip interval.  This is a bit nasty, arising from the fact that we don't immediately broadcast corrections to DNS gossip information received.

Fixes #2085