### PR TITLE
Do not fail during teardown of test suites if $COVERAGE is not set

### DIFF
--- a/test/120_discovery_3_test.sh
+++ b/test/120_discovery_3_test.sh
@@ -19,11 +19,11 @@ start_container $HOST1 $C1/24 --name=c1
 start_container $HOST3 $C3/24 --name=c3
 
 assert_raises "exec_on $HOST1 c1 $PING $C3"
-stop_router_on $HOST2
+stop_weave_on $HOST2
 assert_raises "exec_on $HOST1 c1 $PING $C3"
 
-stop_router_on $HOST1
-stop_router_on $HOST3
+stop_weave_on $HOST1
+stop_weave_on $HOST3
 
 launch_all --no-discovery
 
@@ -36,7 +36,7 @@ assert_raises "start_container $HOST1" # triggers IPAM initialisation
 # longer than the gossip interval (30s) before giving up.
 assert_raises "timeout 40 cat <( start_container $HOST3 )"
 
-stop_router_on $HOST2
+stop_weave_on $HOST2
 assert_raises "exec_on $HOST1 c1 sh -c '! $PING $C3'"
 
 end_suite

--- a/test/150_connect_forget_2_test.sh
+++ b/test/150_connect_forget_2_test.sh
@@ -34,7 +34,7 @@ assert_raises "exec_on $HOST1 c1 $PING $C2"
 
 # Forget everyone and disconnect
 assert_raises "weave_on $HOST2 forget $HOST1 $HOST2"
-assert_raises "stop_router_on $HOST1"
+assert_raises "stop_weave_on $HOST1"
 assert_raises "weave_on $HOST1 launch-router"
 assert_peers $HOST2 ""
 assert_raises "exec_on $HOST1 c1 sh -c '! $PING $C2'"

--- a/test/320_claim_3_test_disabled.sh
+++ b/test/320_claim_3_test_disabled.sh
@@ -12,8 +12,8 @@ start_container $HOST2 --name=c2
 C1=$(container_ip $HOST1 c1)
 assert_raises "exec_on $HOST2 c2 $PING $C1"
 
-stop_router_on $HOST1
-stop_router_on $HOST2
+stop_weave_on $HOST1
+stop_weave_on $HOST2
 
 # Start hosts in reverse order so c1's address has to be claimed from host2
 weave_on $HOST2 launch-router
@@ -28,15 +28,15 @@ assert_raises "[ $C3 != $C1 ]"
 sleep 1 # give routers some time to fully establish connectivity
 assert_raises "exec_on $HOST1 c1 $PING $C3"
 
-stop_router_on $HOST1
-stop_router_on $HOST2
+stop_weave_on $HOST1
+stop_weave_on $HOST2
 
 # Now make host1 attempt to claim from host2, when host2 is stopped
 # the point being to check whether host1 will hang trying to talk to host2
 weave_on $HOST2 launch-router
 # Introduce host3 to remember the IPAM CRDT when we stop host2
 weave_on $HOST3 launch-router $HOST2
-stop_router_on $HOST2
+stop_weave_on $HOST2
 weave_on $HOST1 launch-router $HOST3
 
 end_suite

--- a/test/370_persist_ipam_2_test.sh
+++ b/test/370_persist_ipam_2_test.sh
@@ -22,8 +22,8 @@ C1=$(container_ip $HOST1 c1)
 start_container $HOST2 --name=c2
 assert_raises "exec_on $HOST2 c2 $PING $C1"
 
-stop_router_on $HOST1
-stop_router_on $HOST2
+stop_weave_on $HOST1
+stop_weave_on $HOST2
 
 # Start just HOST2; if nothing persisted it would form its own ring
 launch_router_with_db $HOST2

--- a/test/config.sh
+++ b/test/config.sh
@@ -121,16 +121,14 @@ weave_on() {
     CHECKPOINT_DISABLE=true DOCKER_HOST=tcp://$host:$DOCKER_PORT $WEAVE "$@"
 }
 
-stop_router_on() {
+stop_weave_on() {
     host=$1
-    shift 1
-    # we don't invoke `weave stop-router` here because that removes
-    # the weave container, which means we a) can't grab coverage
-    # stats, and b) can't inspect the logs when tests fail.
-    for C in weaveplugin weaveproxy weave ; do
-        docker_on $host stop $C 1>/dev/null 2>&1 || true
-        [ -n "$COVERAGE" ] && collect_coverage $host $C
-    done
+    weave_on $host stop || true
+    if [ -n "$COVERAGE" ]; then
+        for C in weaveplugin weaveproxy weave ; do
+            collect_coverage $host $C
+        done
+    fi
 }
 
 exec_on() {
@@ -238,7 +236,7 @@ start_suite() {
 end_suite() {
     whitely assert_end
     for host in $HOSTS; do
-        stop_router_on $host
+        stop_weave_on $host
     done
 }
 


### PR DESCRIPTION
Also, stop weave in `end_suite` by using `weave stop` which does not remove the weave container (#1939).