### PR TITLE
2089: Add info about new available versions to the `weave status` report

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ Weave Net respects the environment variable `DOCKER_HOST`, so you can run
 it locally to control a weave network on a remote host.
 
 Weave Net
-[periodically contacts Weaveworks servers for available versions](https://github.com/weaveworks/go-checkpoint)
-and announces new versions in the log. To disable this check, run:
+[periodically contacts Weaveworks servers for available versions](https://github.com/weaveworks/go-checkpoint).
+New versions are announced in the log and in
+[the status summary](http://docs.weave.works/weave/latest_release/troubleshooting.html#weave-status).
+To disable this check, run:
 
 ```
 export CHECKPOINT_DISABLE=1

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -48,7 +48,7 @@ A status summary can be obtained using `weave status`:
 ````
 $ weave status
 
-        Version: 1.1.0
+        Version: 1.1.0 (up to date; next check at 2016/04/06 12:30:00)
 
         Service: router
        Protocol: weave 1..2
@@ -80,7 +80,9 @@ $ weave status
 The terms used here are explained further at
 [How Weave Net Works](/site/router-topology.md).
 
-  * **Version** - shows the Weave Net version.
+  * **Version** - shows the Weave Net version. If checkpoint is enabled (i.e.
+`CHECKPOINT_DISABLE` is not set), information about existence of a new version
+will be shown.
 
   * **Protocol**- indicates the Weave Router inter-peer
 communication protocol name and supported versions (min..max).

--- a/test/700_status_and_report_test.sh
+++ b/test/700_status_and_report_test.sh
@@ -26,4 +26,19 @@ weave_on $HOST1 connect 10.2.2.1
 assert "weave_on $HOST1 status targets" "10.2.2.1"
 assert "weave_on $HOST1 status connections | tr -s ' ' | cut -d ' ' -f 2" "10.2.2.1:6783"
 
+assert "weave_on $HOST1 report -f '{{.VersionCheck.Enabled}}'" "false"
+assert_raises "weave_on $HOST1 status | grep 'version check update disabled'"
+
+weave_on $HOST1 reset
+
+CHECKPOINT_DISABLE="" weave_on $HOST1 launch
+assert "weave_on $HOST1 report -f '{{.VersionCheck.Enabled}}'" "true"
+
+NEW_VSN=$(weave_on $HOST1 report  -f "{{.VersionCheck.NewVersion}}")
+if [ -z "$NEW_VSN" ]; then
+    assert_raises "weave_on $HOST1 status | grep 'up to date; next check at '"
+else
+    assert_raises "weave_on $HOST1 status | grep \"version $NEW_VSN available - please upgrade!\""
+fi
+
 end_suite

--- a/test/config.sh
+++ b/test/config.sh
@@ -44,6 +44,8 @@ CHECK_ETHWE_MISSING="test ! -d /sys/class/net/ethwe"
 
 DOCKER_PORT=2375
 
+CHECKPOINT_DISABLE=true
+
 upload_executable() {
     host=$1
     file=$2
@@ -118,7 +120,7 @@ weave_on() {
     host=$1
     shift 1
     [ -z "$DEBUG" ] || greyly echo "Weave on $host:$DOCKER_PORT: $@" >&2
-    CHECKPOINT_DISABLE=true DOCKER_HOST=tcp://$host:$DOCKER_PORT $WEAVE "$@"
+    CHECKPOINT_DISABLE="$CHECKPOINT_DISABLE" DOCKER_HOST=tcp://$host:$DOCKER_PORT $WEAVE "$@"
 }
 
 stop_weave_on() {


### PR DESCRIPTION
The `AvailableVersion` field denotes the latest available version which is retrieved via go-checkpoint.
If checkpoint is disabled, the field will contain the `<checkpoint disabled>` value.

E.g.:
```bash
ubuntu@host:~$ weave status

         Version: git-b7d49cdeb7db
AvailableVersion: 1.4.4
<..>
```
Fixes #2089 
