### PR TITLE
Immediately broadcast DNS records that "re-assert a peer's authority"

### DIFF
--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -208,8 +208,8 @@ func (n *Nameserver) receiveGossip(msg []byte) (mesh.GossipData, mesh.GossipData
 		return n.isKnownPeer(e.Origin)
 	})
 
+	var overriddenEntries []Entry
 	n.Lock()
-	defer n.Unlock()
 
 	// Check entries claiming to originate from us against our current data
 	gossip.Entries.filter(func(e *Entry) bool {
@@ -221,15 +221,24 @@ func (n *Nameserver) receiveGossip(msg []byte) (mesh.GossipData, mesh.GossipData
 					nextVersion := e.Version + 1
 					*e = *ourEntry
 					e.Version = nextVersion
+					overriddenEntries = append(overriddenEntries, *e)
 				}
 			} else { // We have no entry matching the one that came in with us as Origin
-				e.tombstone()
+				if e.tombstone() {
+					overriddenEntries = append(overriddenEntries, *e)
+				}
 			}
 		}
 		return true
 	})
 
 	newEntries := n.entries.merge(gossip.Entries)
+	n.Unlock() // unlock before attempting to broadcast
+
+	// Note that all overriddenEntries have been merged into our entries, either
+	// because we forced the version higher or because they were missing before.
+	n.broadcastEntries(overriddenEntries...)
+
 	if len(newEntries) > 0 {
 		return &GossipData{Entries: newEntries, Timestamp: now()}, &gossip, nil
 	}

--- a/test/215_stale_dns_3_test.sh
+++ b/test/215_stale_dns_3_test.sh
@@ -22,10 +22,11 @@ docker_on $HOST1 rm -f c1
 
 weave_on $HOST1 launch-router --no-discovery $HOST3
 
-# Now re-enable gossip
+# Now re-enable gossip from host2 to host3
 run_on $HOST3 "sudo iptables -D INPUT -s $HOST2 -j DROP"
 
-# Currently failing due to Mesh #28
-# assert_no_dns_record $HOST3 c3 c1.weave.local
+sleep 1
+
+assert_no_dns_record $HOST3 c3 c1.weave.local
 
 end_suite


### PR DESCRIPTION
Further improvement to the issue raised at #2081 - don't wait for periodic gossip to get the data corrected on other peers.

![Authoritaah](http://i.kinja-img.com/gawker-media/image/upload/s--tty88IyF--/17xf8e3pga57ojpg.jpg)