### PR TITLE
Don't try to form IPAM ring with a bogus quorum size

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -86,7 +86,7 @@ func NewAllocator(config Config) *Allocator {
 	if config.IsObserver {
 		participant = paxos.NewObserver()
 	} else {
-		participant = paxos.NewNode(config.OurName, config.OurUID, 1)
+		participant = paxos.NewNode(config.OurName, config.OurUID, 0)
 	}
 	return &Allocator{
 		ourName:     config.OurName,

--- a/ipam/paxos/paxos.go
+++ b/ipam/paxos/paxos.go
@@ -241,6 +241,9 @@ func (node *Node) pickValue() Value {
 
 // Has a consensus been reached, based on the known claims of other nodes?
 func (node *Node) Consensus() (bool, AcceptedValue) {
+	if node.quorum == 0 {
+		return false, AcceptedValue{}
+	}
 	counts := map[ProposalID]uint{}
 
 	for _, claims := range node.knows {


### PR DESCRIPTION
Following #2070 we defer computing the quorum size until we need it.  This PR ensures that we do not have a bogus value of 1 lying around in the case where we never tried to compute a better value.

Also fix up `TestBootstrap()` which attempts to simulate and check the messages exchanged at startup.  This test is really operating at the wrong level.

Fixes #2139.