### PR TITLE
Union command-line peers with persisted peers

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -129,6 +129,7 @@ func main() {
 		datapathName       string
 		trustedSubnetStr   string
 		dbPrefix           string
+		peerListReplaces   bool
 
 		defaultDockerHost = "unix:///var/run/docker.sock"
 	)
@@ -167,6 +168,7 @@ func main() {
 	mflag.StringVar(&datapathName, []string{"-datapath"}, "", "ODP datapath name")
 	mflag.StringVar(&trustedSubnetStr, []string{"-trusted-subnets"}, "", "comma-separated list of trusted subnets in CIDR notation")
 	mflag.StringVar(&dbPrefix, []string{"-db-prefix"}, "weave", "pathname/prefix of filename to store data")
+	mflag.BoolVar(&peerListReplaces, []string{"-replace"}, false, "peer list replaces any stored list")
 
 	// crude way of detecting that we probably have been started in a
 	// container, with `weave launch` --> suppress misleading paths in
@@ -231,8 +233,10 @@ func main() {
 	router := weave.NewNetworkRouter(config, networkConfig, name, nickName, overlay, db)
 	Log.Println("Our name is", router.Ourself)
 
-	if peers, err = router.InitialPeers(peers); err != nil {
-		Log.Fatal("Unable to get initial peer set: ", err)
+	if !peerListReplaces {
+		if peers, err = router.InitialPeers(peers); err != nil {
+			Log.Fatal("Unable to get initial peer set: ", err)
+		}
 	}
 	Log.Println("Initial set of peers:", peers)
 

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -234,6 +234,7 @@ func main() {
 	if peers, err = router.InitialPeers(peers); err != nil {
 		Log.Fatal("Unable to get initial peer set: ", err)
 	}
+	Log.Println("Initial set of peers:", peers)
 
 	var dockerCli *docker.Client
 	if dockerAPI != "" {

--- a/router/network_router.go
+++ b/router/network_router.go
@@ -228,29 +228,26 @@ func (router *NetworkRouter) ForgetConnections(peers []string) {
 	router.persistPeers()
 }
 
+// Load the peers stored from last time, and union with the set passed in
 func (router *NetworkRouter) InitialPeers(peers []string) ([]string, error) {
 	var storedPeers []string
 	if _, err := router.db.Load(peersIdent, &storedPeers); err != nil {
 		return nil, err
 	}
 
-	if storedPeers != nil && !equal(peers, storedPeers) {
-		log.Println("Overriding initial peer list with stored list:", storedPeers)
-		peers = storedPeers
-	} else {
-		log.Println("Initial set of peers:", peers)
+	for _, peer := range storedPeers {
+		if !contains(peers, peer) {
+			peers = append(peers, peer)
+		}
 	}
 	return peers, nil
 }
 
-func equal(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
+func contains(a []string, s string) bool {
+	for _, v := range a {
+		if s == v {
+			return true
 		}
 	}
-	return true
+	return false
 }

--- a/test/370_persist_ipam_2_test.sh
+++ b/test/370_persist_ipam_2_test.sh
@@ -35,4 +35,11 @@ assert_raises "[ $C3 != $C1 ]"
 launch_router_with_db $HOST1
 assert_raises "exec_on $HOST2 c2 $PING $C1"
 
+# See if persistence overrides the command-line
+weave_on $HOST1 forget $HOST2
+weave_on $HOST2 forget $HOST1
+stop_weave_on $HOST1
+launch_router_with_db $HOST1 $HOST2
+assert_raises "exec_on $HOST2 c2 $PING $C1"
+
 end_suite

--- a/test/370_persist_ipam_2_test.sh
+++ b/test/370_persist_ipam_2_test.sh
@@ -42,4 +42,9 @@ stop_weave_on $HOST1
 launch_router_with_db $HOST1 $HOST2
 assert_raises "exec_on $HOST2 c2 $PING $C1"
 
+# Check we can replace the stored list
+stop_weave_on $HOST1
+launch_router_with_db $HOST1 --replace
+assert_raises "exec_on $HOST2 c2 sh -c '! $PING $C1'"
+
 end_suite

--- a/weave
+++ b/weave
@@ -43,7 +43,7 @@ weave launch        <same arguments as 'weave launch-router'>
                       [--ipam-seed <mac>,...] [--observer]
                       [--ipalloc-range <cidr> [--ipalloc-default-subnet <cidr>]]
                       [--init-peer-count <count>] [--no-discovery] [--no-dns]
-                      [--trusted-subnets <cidr>,...] <peer> ...
+                      [--trusted-subnets <cidr>,...] [--replace] <peer> ...
       launch-proxy  [-H <endpoint>] [--without-dns] [--no-multicast-route]
                       [--no-rewrite-hosts] [--no-default-ipalloc]
                       [--hostname-from-label <labelkey>]


### PR DESCRIPTION
If #2135 is merged, we will have the paradoxical situation that the command-line peer list is ignored in favour of a persisted one.  This PR changes the default behaviour to take the union of the persisted list and the command-line list, with a `--replace` option to state you want exactly that new list.