### PR TITLE
Store 'checkAlive' flag in IPAM, so we don't delete non-container IDs

### DIFF
--- a/ipam/allocate.go
+++ b/ipam/allocate.go
@@ -15,6 +15,7 @@ type allocate struct {
 	resultChan       chan<- allocateResult
 	ident            string
 	r                address.CIDR // Subnet we are trying to allocate within
+	isContainer      bool
 	hasBeenCancelled func() bool
 }
 
@@ -46,7 +47,7 @@ func (g *allocate) Try(alloc *Allocator) bool {
 			g.ident = addr.String()
 		}
 		alloc.debugln("Allocated", addr, "for", g.ident, "in", g.r)
-		alloc.addOwned(g.ident, address.MakeCIDR(g.r, addr))
+		alloc.addOwned(g.ident, address.MakeCIDR(g.r, addr), g.isContainer)
 		g.resultChan <- allocateResult{addr, nil}
 		return true
 	}

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -971,6 +971,7 @@ func (alloc *Allocator) syncOwned(ids map[string]struct{}) {
 			for _, cidr := range cidrs {
 				alloc.space.Free(cidr.Addr)
 			}
+			alloc.debugf("Deleting old entry %s: %v", ident, cidrs)
 			delete(alloc.owned, ident)
 			changed = true
 		}

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -239,9 +239,15 @@ func (alloc *Allocator) Prime() {
 
 // Allocate (Sync) - get new IP address for container with given name in range
 // if there isn't any space in that range we block indefinitely
-func (alloc *Allocator) Allocate(ident string, r address.CIDR, hasBeenCancelled func() bool) (address.Address, error) {
+func (alloc *Allocator) Allocate(ident string, r address.CIDR, isContainer bool, hasBeenCancelled func() bool) (address.Address, error) {
 	resultChan := make(chan allocateResult)
-	op := &allocate{resultChan: resultChan, ident: ident, r: r, hasBeenCancelled: hasBeenCancelled}
+	op := &allocate{
+		resultChan:       resultChan,
+		ident:            ident,
+		r:                r,
+		isContainer:      isContainer,
+		hasBeenCancelled: hasBeenCancelled,
+	}
 	alloc.doOperation(op, &alloc.pendingAllocates)
 	result := <-resultChan
 	return result.addr, result.err
@@ -920,8 +926,9 @@ func (alloc *Allocator) hasOwned(ident string) bool {
 }
 
 // NB: addr must not be owned by ident already
-func (alloc *Allocator) addOwned(ident string, cidr address.CIDR) {
+func (alloc *Allocator) addOwned(ident string, cidr address.CIDR, isContainer bool) {
 	d := alloc.owned[ident]
+	d.IsContainer = isContainer
 	d.Cidrs = append(d.Cidrs, cidr)
 	alloc.owned[ident] = d
 	alloc.persistOwned()

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -263,9 +263,15 @@ func (alloc *Allocator) Lookup(ident string, r address.Range) ([]address.CIDR, e
 }
 
 // Claim an address that we think we should own (Sync)
-func (alloc *Allocator) Claim(ident string, cidr address.CIDR, noErrorOnUnknown bool) error {
+func (alloc *Allocator) Claim(ident string, cidr address.CIDR, isContainer, noErrorOnUnknown bool) error {
 	resultChan := make(chan error)
-	op := &claim{resultChan: resultChan, ident: ident, cidr: cidr, noErrorOnUnknown: noErrorOnUnknown}
+	op := &claim{
+		resultChan:       resultChan,
+		ident:            ident,
+		cidr:             cidr,
+		isContainer:      isContainer,
+		noErrorOnUnknown: noErrorOnUnknown,
+	}
 	alloc.doOperation(op, &alloc.pendingClaims)
 	return <-resultChan
 }

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -170,7 +170,7 @@ func TestAllocatorClaim(t *testing.T) {
 	addr1, _ := address.ParseCIDR(testAddr1)
 
 	// First claim should trigger "dunno, I'm going to wait"
-	err := alloc.Claim(container3, addr1, true)
+	err := alloc.Claim(container3, addr1, true, true)
 	require.NoError(t, err)
 
 	alloc.Prime()
@@ -178,23 +178,23 @@ func TestAllocatorClaim(t *testing.T) {
 	addrx, err := allocs[0].Allocate(container1, subnet, true, returnFalse)
 
 	// Now try the claim again
-	err = alloc.Claim(container3, addr1, true)
+	err = alloc.Claim(container3, addr1, true, true)
 	require.NoError(t, err)
 	// Check we get this address back if we try an allocate
 	addr3, _ := alloc.Allocate(container3, subnet, true, returnFalse)
 	require.Equal(t, testAddr1, address.MakeCIDR(subnet, addr3).String(), "address")
 	// one more claim should still work
-	err = alloc.Claim(container3, addr1, true)
+	err = alloc.Claim(container3, addr1, true, true)
 	require.NoError(t, err)
 	// claim for a different container should fail
-	err = alloc.Claim(container1, addr1, true)
+	err = alloc.Claim(container1, addr1, true, true)
 	require.Error(t, err)
 	// claiming the address allocated on the other peer should fail
-	err = alloc.Claim(container1, address.MakeCIDR(subnet, addrx), true)
+	err = alloc.Claim(container1, address.MakeCIDR(subnet, addrx), true, true)
 	require.Error(t, err, "claiming address allocated on other peer should fail")
 	// Check an address outside of our universe
 	addr2, _ := address.ParseCIDR(testAddr2)
-	err = alloc.Claim(container1, addr2, true)
+	err = alloc.Claim(container1, addr2, true, true)
 	require.NoError(t, err)
 }
 
@@ -530,7 +530,7 @@ func TestAllocatorFuzz(t *testing.T) {
 		addressIndex := rand.Int31n(int32(subnet.Size()))
 		alloc := allocs[allocIndex]
 		addr := address.Add(subnet.Addr, address.Offset(addressIndex))
-		err := alloc.Claim(name, address.MakeCIDR(subnet, addr), true)
+		err := alloc.Claim(name, address.MakeCIDR(subnet, addr), true, true)
 		if err == nil {
 			noteAllocation(allocIndex, name, addr)
 		}

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -13,6 +13,7 @@ type claim struct {
 	resultChan       chan<- error
 	ident            string
 	cidr             address.CIDR
+	isContainer      bool
 	noErrorOnUnknown bool
 }
 
@@ -35,7 +36,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 	if !alloc.ring.Contains(c.cidr.Addr) {
 		// Address not within our universe; assume user knows what they are doing
 		alloc.infof("Address %s claimed by %s - not in our range", c.cidr, c.ident)
-		alloc.addOwned(c.ident, c.cidr)
+		alloc.addOwned(c.ident, c.cidr, c.isContainer)
 		c.sendResult(nil)
 		return true
 	}
@@ -79,7 +80,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 			if c.ident == "_" { // Special "I don't have a unique ID" identifier
 				c.ident = c.cidr.String()
 			}
-			alloc.addOwned(c.ident, c.cidr)
+			alloc.addOwned(c.ident, c.cidr, c.isContainer)
 			c.sendResult(nil)
 		} else {
 			c.sendResult(err)

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -74,7 +74,8 @@ func (alloc *Allocator) HandleHTTP(router *mux.Router, defaultSubnet address.CID
 		vars := mux.Vars(r)
 		if cidr, ok := parseCIDR(w, vars["ip"]+"/"+vars["prefixlen"], false); ok {
 			noErrorOnUnknown := r.FormValue("noErrorOnUnknown") == "true"
-			if err := alloc.Claim(vars["id"], cidr, noErrorOnUnknown); err != nil {
+			checkAlive := r.FormValue("check-alive") == "true"
+			if err := alloc.Claim(vars["id"], cidr, checkAlive, noErrorOnUnknown); err != nil {
 				badRequest(w, fmt.Errorf("Unable to claim: %s", err))
 				return
 			}

--- a/ipam/http.go
+++ b/ipam/http.go
@@ -40,7 +40,7 @@ func writeAddresses(w http.ResponseWriter, cidrs []address.CIDR) {
 
 func (alloc *Allocator) handleHTTPAllocate(dockerCli *docker.Client, w http.ResponseWriter, ident string, checkAlive bool, subnet address.CIDR) {
 	closedChan := w.(http.CloseNotifier).CloseNotify()
-	addr, err := alloc.Allocate(ident, subnet,
+	addr, err := alloc.Allocate(ident, subnet, checkAlive,
 		func() bool {
 			select {
 			case <-closedChan:

--- a/test/370_persist_ipam_2_test.sh
+++ b/test/370_persist_ipam_2_test.sh
@@ -13,22 +13,36 @@ launch_router_with_db() {
 launch_router_with_db $HOST1 $HOST2
 launch_router_with_db $HOST2 $HOST1
 
+EXPOSE=$(weave_on $HOST1 expose)
 start_container $HOST1 --name=c1
 C1=$(container_ip $HOST1 c1)
 start_container $HOST2 --name=c2
 assert_raises "exec_on $HOST2 c2 $PING $C1"
+start_container $HOST2 --name=c3a
+C3a=$(container_ip $HOST2 c3a)
 
 stop_weave_on $HOST1
 stop_weave_on $HOST2
+
+# Stop one container while weave is down; the address should be freed on launch
+docker_on $HOST2 rm -f c3a
 
 # Start just HOST2; if nothing persisted it would form its own ring
 launch_router_with_db $HOST2
 start_container $HOST2 --name=c3
 C3=$(container_ip $HOST2 c3)
 assert_raises "[ $C3 != $C1 ]"
+assert_raises "[ $C3 = $C3a ]"
 
 # Restart HOST1 and see if it remembers to connect to HOST2
 launch_router_with_db $HOST1
 assert_raises "exec_on $HOST2 c2 $PING $C1"
+
+# Restart the router without going through the reclaim procedure on launch
+docker_on $HOST1 restart weave
+# Check that weave:expose address hasn't been lost
+start_container $HOST1 --name=c4
+C4=$(container_ip $HOST1 c4)
+assert_raises "[ $C4 != $EXPOSE ]"
 
 end_suite

--- a/weave
+++ b/weave
@@ -1380,6 +1380,12 @@ check_overlap() {
 # with_container_addresses.
 ipam_reclaim() {
     for CIDR in $3 ; do
+        http_call $HTTP_ADDR PUT "/ip/$1/$CIDR?noErrorOnUnknown=true&?check-alive=true" || true
+    done
+}
+
+ipam_reclaim_no_check_alive() {
+    for CIDR in $3 ; do
         http_call $HTTP_ADDR PUT /ip/$1/$CIDR?noErrorOnUnknown=true || true
     done
 }
@@ -1433,7 +1439,7 @@ ipam_cidrs() {
                 # Assignment of a plain IP address; warn if it clashes but carry on
                 check_overlap $arg || true
                 # Abort on failure, but not 4 (=404), which means IPAM is disabled
-                when_weave_running http_call $HTTP_ADDR PUT /ip/$CONTAINER_ID/$arg || [ $? -eq 4 ] || return 1
+                when_weave_running http_call $HTTP_ADDR PUT /ip/$CONTAINER_ID/$arg$CHECK_ALIVE || [ $? -eq 4 ] || return 1
             fi
             ALL_CIDRS="$ALL_CIDRS $arg"
         fi
@@ -1740,7 +1746,8 @@ fetch_router_args() {
 populate_router() {
     if [ -n "$IPRANGE" ] ; then
         # Tell the newly-started weave IP allocator about existing weave IPs
-        with_container_addresses ipam_reclaim weave:expose $(docker ps -q --no-trunc)
+        with_container_addresses ipam_reclaim_no_check_alive weave:expose
+        with_container_addresses ipam_reclaim $(docker ps -q --no-trunc)
     fi
     if [ -z "$NO_DNS_OPT" ] ; then
         # Tell the newly-started weaveDNS about existing weave IPs
@@ -2170,7 +2177,7 @@ EOF
         RES=$(docker restart $1)
         CONTAINER=$(container_id $1)
         for CIDR in $ALL_CIDRS ; do
-            call_weave PUT /ip/$CONTAINER/$CIDR
+            call_weave PUT /ip/$CONTAINER/$CIDR?check-alive=true
         done
         with_container_netns_or_die $1 attach $ALL_CIDRS
         when_weave_running with_container_fqdn $1 put_dns_fqdn $ALL_CIDRS


### PR DESCRIPTION
Fixes #2164 

Note the `owned` map changes type so breaks compatibility with earlier persistence files