### PR TITLE
Disable persistence of peer lists

### DIFF
--- a/router/network_router.go
+++ b/router/network_router.go
@@ -211,10 +211,11 @@ func (router *NetworkRouter) relayBroadcast(srcPeer *mesh.Peer, key PacketKey) F
 const peersIdent = "directPeers"
 
 func (router *NetworkRouter) persistPeers() {
-	if err := router.db.Save(peersIdent, router.ConnectionMaker.Targets(false)); err != nil {
+	// Persistence disabled pending rationalisation of the expected behaviour
+	/*if err := router.db.Save(peersIdent, router.ConnectionMaker.Targets(false)); err != nil {
 		log.Errorf("Error persisting peers: %s", err)
 		return
-	}
+	}*/
 }
 
 func (router *NetworkRouter) InitiateConnections(peers []string, replace bool) []error {
@@ -230,9 +231,10 @@ func (router *NetworkRouter) ForgetConnections(peers []string) {
 
 func (router *NetworkRouter) InitialPeers(peers []string) ([]string, error) {
 	var storedPeers []string
-	if _, err := router.db.Load(peersIdent, &storedPeers); err != nil {
+	// Persistence disabled pending rationalisation of the expected behaviour
+	/*if _, err := router.db.Load(peersIdent, &storedPeers); err != nil {
 		return nil, err
-	}
+	}*/
 
 	if storedPeers != nil && !equal(peers, storedPeers) {
 		log.Println("Overriding initial peer list with stored list:", storedPeers)

--- a/test/370_persist_ipam_2_test.sh
+++ b/test/370_persist_ipam_2_test.sh
@@ -28,7 +28,10 @@ C3=$(container_ip $HOST2 c3)
 assert_raises "[ $C3 != $C1 ]"
 
 # Restart HOST1 and see if it remembers to connect to HOST2
-launch_router_with_db $HOST1
-assert_raises "exec_on $HOST2 c2 $PING $C1"
+#
+# disabled pending rationalisation of the expected behaviour
+#
+# launch_router_with_db $HOST1
+# assert_raises "exec_on $HOST2 c2 $PING $C1"
 
 end_suite


### PR DESCRIPTION
Persistence of peer lists gives you a difference in behaviour compared with 1.4 that may lead to unexpected side-effects.  This PR disables the feature until we can think it through some more.