### PR TITLE
Improve handling of `claim _`

### DIFF
--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -72,14 +72,14 @@ func (c *claim) Try(alloc *Allocator) bool {
 		return false
 	}
 
+	if c.ident == "_" { // Special "I don't have a unique ID" identifier
+		c.ident = c.cidr.Addr.String()
+	}
 	// We are the owner, check we haven't given it to another container
 	switch existingIdent := alloc.findOwner(c.cidr.Addr); existingIdent {
 	case "":
 		if err := alloc.space.Claim(c.cidr.Addr); err == nil {
 			alloc.debugln("Claimed", c.cidr, "for", c.ident)
-			if c.ident == "_" { // Special "I don't have a unique ID" identifier
-				c.ident = c.cidr.String()
-			}
 			alloc.addOwned(c.ident, c.cidr, c.isContainer)
 			c.sendResult(nil)
 		} else {
@@ -89,7 +89,7 @@ func (c *claim) Try(alloc *Allocator) bool {
 		// same identifier is claiming same address; that's OK
 		alloc.debugln("Re-Claimed", c.cidr, "for", c.ident)
 		c.sendResult(nil)
-	case c.cidr.String():
+	case c.cidr.Addr.String():
 		// Address already allocated via "_" name
 		c.sendResult(fmt.Errorf("address %s already in use", c.cidr))
 	default:


### PR DESCRIPTION
This improves the error message from "address 10.32.0.1/12 is already owned by 10.32.0.1" to "address 10.32.0.1/12 already in use".  Also the code as it stands would not have removed the 'owned' entry if it was deleted from the plugin.

It does not address the basic point of #2194, which is that the situation does not deserve a diagnostic. When the re-launch does its "claim" operations, it passes in the container ID, which does not match up to the earlier allocation via the plugin.