### PR TITLE
Add equals sign to --dns arg, for consistency

### DIFF
--- a/weave
+++ b/weave
@@ -1211,7 +1211,7 @@ dns_args() {
     [ -n "$WITHOUT_DNS" ] && return 0
 
     docker_bridge_ip
-    DNS_ARGS="--dns $DOCKER_BRIDGE_IP"
+    DNS_ARGS="--dns=$DOCKER_BRIDGE_IP"
     if [ -n "$NAME_ARG" -a -z "$HOSTNAME_SPECIFIED" ] ; then
         HOSTNAME="$NAME_ARG.${DNS_DOMAIN%.}"
         if [ ${#HOSTNAME} -gt 64 ] ; then


### PR DESCRIPTION
Fixes #2197 

As discussed there, I don't think it really matters, but it's odd that we have one arg without equals and the others with.