### PR TITLE
2057: Add allocator.PeerGone

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -452,6 +452,7 @@ func createAllocator(router *weave.NetworkRouter, config ipamConfig, db db.DB, i
 
 	allocator.SetInterfaces(router.NewGossip("IPallocation", allocator))
 	allocator.Start()
+	router.Peers.OnGC(func(peer *mesh.Peer) { allocator.PeerGone(peer.Name) })
 
 	return allocator, defaultSubnet
 }


### PR DESCRIPTION
The function is registered within the mesh GC and it is responsible
for removing gone nicknames.

Fixes #2057 