### PR TITLE
Fix broken link

### DIFF
--- a/bin/publish-site
+++ b/bin/publish-site
@@ -36,4 +36,4 @@ esac
 
 echo ">>> Publishing $PRODUCT $VERSION site to $1"
 
-wordepress --dry-run --url "$1" --user "$2" --password "$3" --product "$PRODUCT" --version "$VERSION" publish site
+wordepress --url "$1" --user "$2" --password "$3" --product "$PRODUCT" --version "$VERSION" publish site

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -284,7 +284,7 @@ on reboot. This can be disabled via:
     weave launch --no-restart
 
 Note that the
-[Weave Net Docker API Proxy](/site/weave-docker-api/set-up-proxy.md)
+[Weave Net Docker API Proxy](/site/weave-docker-api.md)
 is responsible for reconfiguring the Weave router and re-attaching
 application containers to the Weave network at startup, so if you
 choose not to run it you must make arrangements for this


### PR DESCRIPTION
Fixes #2216.

Should be able to check at http://dev-weavewww.pantheon.io/documentation/net-2216-fix-link-troubleshooting/ once the CI build has completed.