### PR TITLE
tweak 'Using Weave Net' section order

### DIFF
--- a/site/using-weave/finding-adding-hosts-dynamically.md
+++ b/site/using-weave/finding-adding-hosts-dynamically.md
@@ -1,6 +1,6 @@
 ---
 title: Adding and Removing Hosts Dynamically
-menu_order: 50
+menu_order: 90
 ---
 
 

--- a/site/using-weave/service-management.md
+++ b/site/using-weave/service-management.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Services in Weave Net - Exporting, Importing, Binding and Routing
-menu_order: 90
+menu_order: 70
 ---
 
 This section contains the following topics: 


### PR DESCRIPTION
- move "Managing Services in Weave Net" up so it comes after
  "Integrating a Host Network with Weave Net", to which it is deeply
  related
- move "Adding and Removing Hosts Dynamically" down so it is adjacent
  to the other sections which talk about peer connectivity

@abuehrle 