### PR TITLE
Tweak titles under "Using Weave Net"

### DIFF
--- a/site/features.md
+++ b/site/features.md
@@ -186,7 +186,7 @@ For information on how to secure your Docker network connections, see [Securing 
 Weave Net application networks can be integrated with a host's network, and establish connectivity between the host and 
 application containers anywhere.
 
-See [Integrating a Host Network with Weave](/site/using-weave/host-network-integration.md).
+See [Integrating with the Host Network](/site/using-weave/host-network-integration.md).
 
 ###<a name="services"></a>Managing Services: Exporting, Importing, Binding and Routing
  
@@ -195,7 +195,7 @@ See [Integrating a Host Network with Weave](/site/using-weave/host-network-integ
  * **Binding Services** - A container can be bound to a particular IP and port without having to change your application code, while at the same time will maintain its original endpoint. 
  * **Routing Services** - By combining the importing and exporting features, you can connect to disjointed networks, even when separated by firewalls and where there may be overlapping IP addresses.  
 
-See [Managing Services in Weave: Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md) for instructions on how to manage services on a Weave container network. 
+See [Managing Services - Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md) for instructions on how to manage services on a Weave container network. 
 
 ###<a name="multi-cloud-networking"></a>Multi-Cloud Networking
 
@@ -232,7 +232,7 @@ reconfiguration or, in many cases, restarts of other containers.
 All that is required is for the migrated container to be started 
 with the same IP address as it was given originally.
 
-See [Managing Services in Weave: Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md), in particular, Routing Services for more information on container mobility. 
+See [Managing Services - Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md), in particular, Routing Services for more information on container mobility. 
 
 
 ###<a name="fault-tolerance"></a>Fault Tolerance

--- a/site/how-it-works/ip-addresses.md
+++ b/site/how-it-works/ip-addresses.md
@@ -63,4 +63,4 @@ find a match, so uses the default rule.
 
 **See Also**
 
- * [Configuring Weave to Explicitly Use an IP Range](/site/ip-addresses/configuring-weave.md) 
+ * [Allocating IPs in a Specific Range](/site/ip-addresses/configuring-weave.md) 

--- a/site/using-weave/application-isolation.md
+++ b/site/using-weave/application-isolation.md
@@ -66,4 +66,4 @@ isolation between application containers, that feature needs to be disabled by [
 **See Also** 
 
  * [Automatic Allocation Across Multiple Subnets](/site/ipam/allocation-multi-ipam.md)
- * [Managing Services in Weave Net: Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md)
+ * [Managing Services - Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md)

--- a/site/using-weave/configuring-weave.md
+++ b/site/using-weave/configuring-weave.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring Weave to Explicitly Use an IP Range
+title: Allocating IPs in a Specific Range
 menu_order: 15
 ---
 

--- a/site/using-weave/host-network-integration.md
+++ b/site/using-weave/host-network-integration.md
@@ -1,5 +1,5 @@
 ---
-title: Integrating a Host Network with Weave Net
+title: Integrating with the Host Network
 menu_order: 60
 ---
 
@@ -42,4 +42,4 @@ Exposed addresses can also be added to weaveDNS by supplying fully qualified dom
 **See Also**
 
  * [Using Weave Net](/site/using-weave.md)
- * [Managing Services in Weave: Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md)
+ * [Managing Services - Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md)

--- a/site/using-weave/manual-ip-address.md
+++ b/site/using-weave/manual-ip-address.md
@@ -51,7 +51,7 @@ Individual IP addresses given to containers must, of course, be unique. If you p
 
 **See Also**
 
- * [Managing Services: Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md)
- * [Configuring Weave to Explicitly Use an IP Range](/site/using-weave/configuring-weave.md) 
+ * [Managing Services - Exporting, Importing, Binding and Routing](/site/using-weave/service-management.md)
+ * [Allocating IPs in a Specific Range](/site/using-weave/configuring-weave.md) 
  * [Automatic IP Address Management](/site/ipam.md)   
 

--- a/site/using-weave/service-management.md
+++ b/site/using-weave/service-management.md
@@ -1,5 +1,5 @@
 ---
-title: Managing Services in Weave Net - Exporting, Importing, Binding and Routing
+title: Managing Services - Exporting, Importing, Binding and Routing
 menu_order: 70
 ---
 
@@ -23,7 +23,7 @@ located.
 Returning to the [netcat example service](/site/using-weave.md), 
 you can expose the netcat service running on `HOST1` and make it accessible to the outside world via `$HOST2`. 
 
-First, expose the application network to `$HOST2`, as explained in [Integrating a Host Network with a Weave Net](/site/using-weave/host-network-integration.md):
+First, expose the application network to `$HOST2`, as explained in [Integrating with the Host Network](/site/using-weave/host-network-integration.md):
 
     host2$ weave expose
     10.2.1.132


### PR DESCRIPTION
- strip "Weave" and "Weave Net"
- "Integrating a Host Network with Weave" -> "Integrating with the
  Host Network"
- "Configuring Weave to Explicitly Use an IP Range" -> "Allocating IPs
  in a Specific Range"

@abuehrle 