### PR TITLE
Persist the IPAM ring on `weave reset` and `weave rmpeer`

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -650,8 +650,8 @@ func (alloc *Allocator) establishRing() {
 func (alloc *Allocator) createRing(peers []mesh.PeerName) {
 	alloc.debugln("Paxos consensus:", peers)
 	alloc.ring.ClaimForPeers(normalizeConsensus(peers))
-	alloc.gossip.GossipBroadcast(alloc.Gossip())
 	alloc.ringUpdated()
+	alloc.gossip.GossipBroadcast(alloc.Gossip())
 }
 
 func (alloc *Allocator) ringUpdated() {

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -402,6 +402,7 @@ func (alloc *Allocator) Shutdown() {
 		alloc.cancelOps(&alloc.pendingPrimes)
 		if heir := alloc.pickPeerForTransfer(); heir != mesh.UnknownPeerName {
 			alloc.ring.Transfer(alloc.ourName, heir)
+			alloc.persistRing()
 			alloc.space.Clear()
 			alloc.gossip.GossipBroadcast(alloc.Gossip())
 			time.Sleep(100 * time.Millisecond)
@@ -439,7 +440,7 @@ func (alloc *Allocator) AdminTakeoverRanges(peerNameOrNickname string) address.C
 		}
 
 		before := alloc.space.NumFreeAddresses()
-		alloc.space.AddRanges(newRanges)
+		alloc.ringUpdated()
 		after := alloc.space.NumFreeAddresses()
 
 		alloc.gossip.GossipBroadcast(alloc.Gossip())

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -614,11 +614,13 @@ func (alloc *Allocator) actorLoop(actionChan <-chan func(), stopChan <-chan stru
 		case <-stopChan:
 			return
 		case <-alloc.ticker.C:
+			// Retry things in case messages got lost between here and recipients
 			if alloc.awaitingConsensus {
 				alloc.propose()
+			} else {
+				alloc.tryPendingOps()
 			}
 			alloc.removeDeadContainers()
-			alloc.tryPendingOps()
 		}
 
 		alloc.assertInvariants()

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -176,6 +176,7 @@ func TestAllocatorClaim(t *testing.T) {
 	alloc.Prime()
 	// Do an allocate on the other peer, which we will try to claim later
 	addrx, err := allocs[0].Allocate(container1, subnet, true, returnFalse)
+	router.Flush()
 
 	// Now try the claim again
 	err = alloc.Claim(container3, addr1, true, true)


### PR DESCRIPTION
These cases were missed earlier.
Note this change also makes `AdminTakeoverRanges()` cause pending ops to be retried, which seems appropriate - e.g. we may have taken over a range which covers a pending claim.

Calling `ringUpdated()` instead of `AddRanges()` is less efficient, because we will compute what space has been added instead of using what we already know in `newRanges`, but this is ok as `rmpeer` should not be called rapidly.