### PR TITLE
Better deleting of persisted IPAM data 

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -876,11 +876,13 @@ func (alloc *Allocator) loadPersistedData() {
 	if err != nil {
 		alloc.fatalf("Error loading persisted peer name: %s", err)
 	}
-	ringFound, err := alloc.db.Load(ringIdent, &alloc.ring)
+	var persistedRing *ring.Ring
+	ringFound, err := alloc.db.Load(ringIdent, &persistedRing)
 	if err != nil {
 		alloc.fatalf("Error loading persisted IPAM data: %s", err)
 	}
-	ownedFound, err := alloc.db.Load(ownedIdent, &alloc.owned)
+	var persistedOwned map[string]ownedData
+	ownedFound, err := alloc.db.Load(ownedIdent, &persistedOwned)
 	if err != nil {
 		alloc.fatalf("Error loading persisted address data: %s", err)
 	}
@@ -891,9 +893,11 @@ func (alloc *Allocator) loadPersistedData() {
 				if len(alloc.seed) != 0 {
 					alloc.infof("Found persisted IPAM data, ignoring supplied IPAM seed")
 				}
+				alloc.ring = persistedRing
 				alloc.space.UpdateRanges(alloc.ring.OwnedRanges())
 			}
 			if ownedFound {
+				alloc.owned = persistedOwned
 				for _, d := range alloc.owned {
 					for _, cidr := range d.Cidrs {
 						alloc.space.Claim(cidr.Addr)

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -917,6 +917,11 @@ func (alloc *Allocator) loadPersistedData() bool {
 		return false
 	}
 
+	if persistedRing.Range() != alloc.universe {
+		overwritePersisted("Deleting persisted data for IPAM range %s; our range is %s", persistedRing.Range(), alloc.universe)
+		return false
+	}
+
 	alloc.ring = persistedRing
 	alloc.space.UpdateRanges(alloc.ring.OwnedRanges())
 

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -901,28 +901,34 @@ func (alloc *Allocator) loadPersistedData() bool {
 		alloc.fatalf("Error loading persisted address data: %s", err)
 	}
 
-	if nameFound {
-		if checkPeerName == alloc.ourName {
-			if ringFound {
-				alloc.ring = persistedRing
-				alloc.space.UpdateRanges(alloc.ring.OwnedRanges())
-			}
-			if ownedFound {
-				alloc.owned = persistedOwned
-				for _, d := range alloc.owned {
-					for _, cidr := range d.Cidrs {
-						alloc.space.Claim(cidr.Addr)
-					}
-				}
-			}
-			return true
-		}
-		alloc.infof("Deleting persisted data for peername %s", checkPeerName)
+	overwritePersisted := func(fmt string, args ...interface{}) {
+		alloc.infof(fmt, args...)
 		alloc.persistRing()
 		alloc.persistOwned()
 	}
 
-	return false
+	if !nameFound || !ringFound {
+		overwritePersisted("No valid persisted data")
+		return false
+	}
+
+	if checkPeerName != alloc.ourName {
+		overwritePersisted("Deleting persisted data for peername %s", checkPeerName)
+		return false
+	}
+
+	alloc.ring = persistedRing
+	alloc.space.UpdateRanges(alloc.ring.OwnedRanges())
+
+	if ownedFound {
+		alloc.owned = persistedOwned
+		for _, d := range alloc.owned {
+			for _, cidr := range d.Cidrs {
+				alloc.space.Claim(cidr.Addr)
+			}
+		}
+	}
+	return true
 }
 
 func (alloc *Allocator) persistOwned() {

--- a/test/362_ipalloc_range_change.sh
+++ b/test/362_ipalloc_range_change.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "IPAM alloc range change"
+
+weave_on $HOST1 launch --ipalloc-range 10.2.0.0/16
+weave_on $HOST1 prime
+weave_on $HOST1 stop
+weave_on $HOST1 launch --ipalloc-range 10.3.0.0/16
+# Ensure allocations can proceed
+assert_raises "timeout 10 cat <( start_container $HOST1 )"
+
+end_suite

--- a/test/380_ipam_seed_2_test.sh
+++ b/test/380_ipam_seed_2_test.sh
@@ -19,4 +19,12 @@ weave_on $HOST2 connect $HOST1
 assert_raises "exec_on $HOST1 c1 $PING c2"
 assert_raises "exec_on $HOST2 c2 $PING c1"
 
+# Now restart one router with a different peername
+docker_on $HOST2 rm -f c2 >/dev/null
+weave_on $HOST2 forget $HOST1
+weave_on $HOST2 stop
+weave_on $HOST2 launch --name ::3
+# Check that this host has not retained the previous IPAM data
+assert "weave_on $HOST2 status ipam" ""
+
 end_suite


### PR DESCRIPTION
Fixes #2209 and fixes #2246

Now, we don't use the persisted data if there is no name, if the name doesn't match, if there is no ring, or if the ring doesn't match.

Including new smoke-tests.