### PR TITLE
Blank DNS response to AAAA queries where we have an A record

### DIFF
--- a/test/250_dns_negative_test.sh
+++ b/test/250_dns_negative_test.sh
@@ -7,9 +7,8 @@ start_suite "Negative DNS queries"
 weave_on $HOST1 launch
 start_container_with_dns $HOST1 --name c1
 
-# unsupported query types, unknown names, and unknown domains should
-# all trigger NXDOMAIN
-assert_raises "exec_on $HOST1 c1 dig MX c1.weave.local | grep -q 'status: NXDOMAIN'"
+# unsupported query types, unknown names, and unknown domains
+assert_raises "exec_on $HOST1 c1 dig MX c1.weave.local | grep -q 'status: NOERROR'"
 assert_raises "exec_on $HOST1 c1 dig A  xx.weave.local | grep -q 'status: NXDOMAIN'"
 assert_raises "exec_on $HOST1 c1 dig A  xx.invalid     | grep -q 'status: NXDOMAIN'"
 


### PR DESCRIPTION
Per RFC4074, return DNS no-error with empty answer if we have a matching name but the query is for a record type we don't support.  
Fixes #2244