### PR TITLE
make claim block if the IPAM ring is not established

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -276,7 +276,7 @@ func (alloc *Allocator) Lookup(ident string, r address.Range) ([]address.CIDR, e
 }
 
 // Claim an address that we think we should own (Sync)
-func (alloc *Allocator) Claim(ident string, cidr address.CIDR, isContainer, noErrorOnUnknown bool) error {
+func (alloc *Allocator) Claim(ident string, cidr address.CIDR, isContainer, noErrorOnUnknown bool, hasBeenCancelled func() bool) error {
 	resultChan := make(chan error)
 	op := &claim{
 		resultChan:       resultChan,
@@ -284,6 +284,7 @@ func (alloc *Allocator) Claim(ident string, cidr address.CIDR, isContainer, noEr
 		cidr:             cidr,
 		isContainer:      isContainer,
 		noErrorOnUnknown: noErrorOnUnknown,
+		hasBeenCancelled: hasBeenCancelled,
 	}
 	alloc.doOperation(op, &alloc.pendingClaims)
 	return <-resultChan

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -27,7 +27,7 @@ func (alloc *Allocator) SimplyAllocate(ident string, cidr address.CIDR) (address
 }
 
 func (alloc *Allocator) SimplyClaim(ident string, cidr address.CIDR) error {
-	return alloc.Claim(ident, cidr, true, true)
+	return alloc.Claim(ident, cidr, true, true, returnFalse)
 }
 
 func TestAllocFree(t *testing.T) {


### PR DESCRIPTION
This PR aligns the behaviour of Claim with Allocate which blocks until the ring has been established.

Fixes #2232 