### PR TITLE
Fix 320_claim_3_test.sh

### DIFF
--- a/test/320_claim_3_test.sh
+++ b/test/320_claim_3_test.sh
@@ -2,14 +2,29 @@
 
 . ./config.sh
 
-UNIVERSE=10.32.0.0/12
-C1=10.40.0.1
+UNIVERSE=10.2.0.0/16
+C1=10.2.128.1
+C4=10.2.128.4
 
 delete_persistence() {
     for host in "$@" ; do
         docker_on $host rm -v weavedb >/dev/null
         docker_on $host rm weave >/dev/null
     done
+}
+
+wait_for_container_ip() {
+    host=$1
+    container=$2
+    for i in $(seq 1 120); do
+        echo "Waiting for $container ip at $host"
+        if container_ip $host $container > /dev/null 2>&1 ; then
+            return
+        fi
+        sleep 1
+    done
+    echo "Timed out waiting for $container ip at $host" >&2
+    exit 1
 }
 
 start_suite "Claiming addresses"
@@ -55,21 +70,23 @@ stop_weave_on $HOST2
 weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE $HOST3
 
 stop_weave_on $HOST1
-stop_weave_on $HOST2
 stop_weave_on $HOST3
-delete_persistence $HOST1 $HOST2 $HOST3
 
+# Delete persistence data on host1, so that host1 would try to establish a ring.
+delete_persistence $HOST1
 weave_on $HOST1 launch --ipalloc-range $UNIVERSE $HOST2
+
 # Start another container on host1. The starting should block, because host1 is
 # not able to establish the ring due to host2 being offline.
-CMD="proxy_start_container $HOST1 --name c4 -e WEAVE_CIDR=10.32.0.4/12"
+CMD="proxy_start_container $HOST1 --name c4 -e WEAVE_CIDR=$C4/12"
 assert_raises "timeout 5 cat <( $CMD )" 124
+
 # However, allocation for an external subnet should not block.
-assert_raises "proxy_start_container $HOST1 -e WEAVE_CIDR=10.48.0.1/12"
+assert_raises "proxy_start_container $HOST1 -e WEAVE_CIDR=10.3.0.1/12"
 
 # Launch host2, so that host1 can establish the ring.
 weave_on $HOST2 launch --ipalloc-range $UNIVERSE $HOST1
-weave_on $HOST1 prime
-assert_raises "[ $(container_ip $HOST1 c4) == 10.32.0.4 ]"
+wait_for_container_ip $HOST1 c4
+assert_raises "[ $(container_ip $HOST1 c4) == $C4 ]"
 
 end_suite


### PR DESCRIPTION
UPDATED.

The problem was that the claim at https://github.com/weaveworks/weave/pull/2278/files#diff-1b73b6468431320099c9cbd2340c9a01L65 was sometimes failing because of `10.32.0.0/13` being assigned to `host2`. As a consequence, the assertion at https://github.com/weaveworks/weave/pull/2278/files#diff-1b73b6468431320099c9cbd2340c9a01L73 was failing.

The fix ensures that we always try to claim at `host1` for IP addr from the range assigned to the host. It's done by reusing the IP addr of `c4`. 