### PR TITLE
Ignore IPAM requests for space until we have a ring

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -512,9 +512,11 @@ func (alloc *Allocator) OnGossipUnicast(sender mesh.PeerName, msg []byte) error 
 	alloc.actionChan <- func() {
 		switch msg[0] {
 		case msgSpaceRequest:
-			// some other peer asked us for space
+			alloc.debugln("Peer", sender, "asked me for space")
 			r, err := decodeRange(msg[1:])
-			if err == nil {
+			// If we don't have a ring, just ignore a request for space.
+			// They'll probably ask again later.
+			if err == nil && !alloc.ring.Empty() {
 				alloc.donateSpace(r, sender)
 			}
 			resultChan <- err
@@ -823,7 +825,6 @@ func (alloc *Allocator) donateSpace(r address.Range, to mesh.PeerName) {
 	// more.
 	defer alloc.sendRingUpdate(to)
 
-	alloc.debugln("Peer", to, "asked me for space")
 	chunk, ok := alloc.space.Donate(r)
 	if !ok {
 		free := alloc.space.NumFreeAddressesInRange(r)

--- a/test/320_claim_3_test.sh
+++ b/test/320_claim_3_test.sh
@@ -3,6 +3,7 @@
 . ./config.sh
 
 UNIVERSE=10.32.0.0/12
+C1=10.40.0.1
 
 delete_persistence() {
     for host in "$@" ; do
@@ -13,12 +14,11 @@ delete_persistence() {
 
 start_suite "Claiming addresses"
 
-weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE
+weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE $HOST2
 weave_on $HOST2 launch-router --ipalloc-range $UNIVERSE $HOST1
 
-start_container $HOST1 --name=c1
-start_container $HOST2 --name=c2
-C1=$(container_ip $HOST1 c1)
+start_container $HOST1 $C1/12 --name=c1
+start_container $HOST2        --name=c2
 assert_raises "exec_on $HOST2 c2 $PING $C1"
 
 stop_weave_on $HOST1

--- a/test/320_claim_3_test.sh
+++ b/test/320_claim_3_test.sh
@@ -13,8 +13,8 @@ delete_persistence() {
 
 start_suite "Claiming addresses"
 
-weave_on $HOST1 launch-router
-weave_on $HOST2 launch-router $HOST1
+weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE
+weave_on $HOST2 launch-router --ipalloc-range $UNIVERSE $HOST1
 
 start_container $HOST1 --name=c1
 start_container $HOST2 --name=c2
@@ -28,8 +28,8 @@ stop_weave_on $HOST2
 delete_persistence $HOST1 $HOST2
 
 # Start hosts in reverse order so c1's address has to be claimed from host2
-weave_on $HOST2 launch-router
-weave_on $HOST1 launch-router $HOST2
+weave_on $HOST2 launch-router --ipalloc-range $UNIVERSE
+weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE $HOST2
 
 # Start another container on host2, so if it hasn't relinquished c1's
 # address it would give that out as the first available.
@@ -47,12 +47,12 @@ delete_persistence $HOST1 $HOST2
 
 # Now make host1 attempt to claim from host2, when host2 is stopped
 # the point being to check whether host1 will hang trying to talk to host2
-weave_on $HOST2 launch-router
+weave_on $HOST2 launch-router --ipalloc-range $UNIVERSE
 # Introduce host3 to remember the IPAM CRDT when we stop host2
-weave_on $HOST3 launch-router $HOST2
+weave_on $HOST3 launch-router --ipalloc-range $UNIVERSE $HOST2
 weave_on $HOST3 prime
 stop_weave_on $HOST2
-weave_on $HOST1 launch-router $HOST3
+weave_on $HOST1 launch-router --ipalloc-range $UNIVERSE $HOST3
 
 stop_weave_on $HOST1
 stop_weave_on $HOST2


### PR DESCRIPTION
Fixes #2275 

In the case that we do receive a ring very soon, the consequence of this change is that the requestor doesn't hear back so retries within 5 seconds.

I also moved the debug message so we still see it on requests that are ignored.