### PR TITLE
Move sleep on reset from IPAM Allocator to weave script

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -419,7 +419,6 @@ func (alloc *Allocator) Shutdown() {
 			alloc.persistRing()
 			alloc.space.Clear()
 			alloc.gossip.GossipBroadcast(alloc.Gossip())
-			time.Sleep(100 * time.Millisecond)
 		}
 		doneChan <- struct{}{}
 	}

--- a/weave
+++ b/weave
@@ -2308,6 +2308,7 @@ EOF
         plugin_disabled || util_op remove-plugin-network weave || warn_plugin_active
         warn_if_stopping_proxy_in_env
         call_weave DELETE /peer >/dev/null 2>&1 || true
+        fractional_sleep 0.5 # Allow some time for broadcast updates to go out
         for NAME in $PLUGIN_CONTAINER_NAME $CONTAINER_NAME $PROXY_CONTAINER_NAME ; do
             docker stop  $NAME >/dev/null 2>&1 || true
             docker rm -f $NAME >/dev/null 2>&1 || true


### PR DESCRIPTION
Since the implementation of `GossipBroadcast` requires a call back into the IPAM actor to encode the message, with the previous implementation it wouldn't actually get sent until after the sleep finishes.
Since we only use this function in one place, move the sleep out to the caller.