### PR TITLE
Donate CIDR-aligned ranges instead of just slicing at the mid-point.

### DIFF
--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -220,7 +220,7 @@ func (alloc *Allocator) pause() func() {
 }
 
 func TestCancel(t *testing.T) {
-	const cidr = "10.0.1.7/26"
+	const cidr = "10.0.4.0/26"
 	router := gossip.NewTestRouter(0.0)
 
 	alloc1, subnet := makeAllocator("01:00:00:02:00:00", cidr, 2)
@@ -281,7 +281,7 @@ func TestCancel(t *testing.T) {
 
 func TestCancelOnDied(t *testing.T) {
 	const (
-		cidr       = "10.0.1.7/26"
+		cidr       = "10.0.4.0/26"
 		container1 = "abcdef"
 	)
 
@@ -334,7 +334,7 @@ func TestGossipShutdown(t *testing.T) {
 }
 
 func TestNoFrag(t *testing.T) {
-	const cidr = "10.0.1.7/22"
+	const cidr = "10.0.4.0/22"
 	resultChan := make(chan int)
 	for i := 0; i < 100; i++ {
 		allocs, router, subnet := makeNetworkOfAllocators(3, cidr)
@@ -343,13 +343,13 @@ func TestNoFrag(t *testing.T) {
 		allocs[2].actionChan <- func() {
 			resultChan <- len(allocs[2].ring.Entries)
 		}
-		require.True(t, <-resultChan < 7, "excessive ring fragmentation")
+		require.True(t, <-resultChan < 6, "excessive ring fragmentation")
 		stopNetworkOfAllocators(allocs, router)
 	}
 }
 
 func TestTransfer(t *testing.T) {
-	const cidr = "10.0.1.7/22"
+	const cidr = "10.0.4.0/22"
 	allocs, router, subnet := makeNetworkOfAllocators(3, cidr)
 	defer stopNetworkOfAllocators(allocs, router)
 	alloc0 := allocs[0]
@@ -389,7 +389,7 @@ func TestTransfer(t *testing.T) {
 }
 
 func TestFakeRouterSimple(t *testing.T) {
-	const cidr = "10.0.1.7/22"
+	const cidr = "10.0.4.0/22"
 	allocs, router, subnet := makeNetworkOfAllocators(2, cidr)
 	defer stopNetworkOfAllocators(allocs, router)
 
@@ -407,7 +407,7 @@ func TestAllocatorFuzz(t *testing.T) {
 		nodes        = 5
 		maxAddresses = 1000
 		concurrency  = 5
-		cidr         = "10.0.1.7/22"
+		cidr         = "10.0.4.0/22"
 	)
 	allocs, router, subnet := makeNetworkOfAllocators(nodes, cidr)
 	defer stopNetworkOfAllocators(allocs, router)

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -343,7 +343,7 @@ func TestNoFrag(t *testing.T) {
 		allocs[2].actionChan <- func() {
 			resultChan <- len(allocs[2].ring.Entries)
 		}
-		require.True(t, <-resultChan < 5, "excessive ring fragmentation")
+		require.True(t, <-resultChan < 7, "excessive ring fragmentation")
 		stopNetworkOfAllocators(allocs, router)
 	}
 }

--- a/ipam/space/space.go
+++ b/ipam/space/space.go
@@ -122,8 +122,11 @@ func (s *Space) biggestFreeRange(r address.Range) (biggest address.Range) {
 	biggestSize := address.Count(0)
 	s.walkFree(r, func(chunk address.Range) bool {
 		if size := chunk.Size(); size >= biggestSize {
-			biggest = chunk
-			biggestSize = size
+			chunk = chunk.BiggestPow2AlignedRange()
+			if size = chunk.Size(); size >= biggestSize {
+				biggest = chunk
+				biggestSize = size
+			}
 		}
 		return false
 	})
@@ -137,9 +140,12 @@ func (s *Space) Donate(r address.Range) (address.Range, bool) {
 		return address.Range{}, false
 	}
 
-	// Donate half of that biggest free range. Note size/2 rounds down, so
-	// the resulting donation size rounds up, and in particular can't be empty.
-	biggest.Start = address.Add(biggest.Start, address.Offset(biggest.Size()/2))
+	// Donate no more than half what we have available
+	if biggest.Size() > s.NumFreeAddressesInRange(r)/2 {
+		// Note size/2 rounds down, so the resulting donation size
+		// rounds up, and in particular can't be empty.
+		biggest.Start = address.Add(biggest.Start, address.Offset(biggest.Size()/2))
+	}
 
 	s.ours = subtract(s.ours, biggest.Start, biggest.End)
 	s.free = subtract(s.free, biggest.Start, biggest.End)

--- a/ipam/space/space.go
+++ b/ipam/space/space.go
@@ -122,7 +122,7 @@ func (s *Space) biggestFreeRange(r address.Range) (biggest address.Range) {
 	biggestSize := address.Count(0)
 	s.walkFree(r, func(chunk address.Range) bool {
 		if size := chunk.Size(); size >= biggestSize {
-			chunk = chunk.BiggestPow2AlignedRange()
+			chunk = chunk.BiggestCIDRRange()
 			if size = chunk.Size(); size >= biggestSize {
 				biggest = chunk
 				biggestSize = size

--- a/net/address/address.go
+++ b/net/address/address.go
@@ -35,7 +35,7 @@ func (r Range) AsCIDRString() string {
 	return CIDR{Addr: r.Start, PrefixLen: prefixLen}.String()
 }
 
-// return the highest bit set in a
+// return the highest bit set in v
 // algorithm from http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
 func msb(v Count) Count {
 	v |= v >> 1
@@ -47,7 +47,7 @@ func msb(v Count) Count {
 	return Count((uint64(v) + 1) / 2)
 }
 
-func (r Range) BiggestPow2AlignedRange() Range {
+func (r Range) BiggestCIDRRange() Range {
 	sizeMsb := Offset(msb(r.Size()))
 	maskedSize := Offset(r.Size()) & (sizeMsb - 1)
 	maskedStart := Offset(r.Start) & (sizeMsb - 1)

--- a/net/address/address_test.go
+++ b/net/address/address_test.go
@@ -20,17 +20,17 @@ func isPower2(x Count) bool {
 }
 
 func TestBiggestPow2AlignedRange(t *testing.T) {
-	require.Equal(t, NewRange(0, 1), NewRange(0, 1).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(0, 2), NewRange(0, 3).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(1, 1), NewRange(1, 2).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(0, 0x40000000), NewRange(0, 0x7fffffff).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(0xfffffffe, 1), NewRange(0xfffffffe, 1).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0, 1), NewRange(0, 1).BiggestCIDRRange())
+	require.Equal(t, NewRange(1, 1), NewRange(1, 2).BiggestCIDRRange())
+	require.Equal(t, NewRange(2, 2), NewRange(1, 3).BiggestCIDRRange())
+	require.Equal(t, NewRange(0, 0x40000000), NewRange(0, 0x7fffffff).BiggestCIDRRange())
+	require.Equal(t, NewRange(0xfffffffe, 1), NewRange(0xfffffffe, 1).BiggestCIDRRange())
 	prop := func(start Address, size Offset) bool {
 		if size > Offset(0xffffffff)-Offset(start) { // out of range
 			return true
 		}
 		r := NewRange(start, size)
-		result := r.BiggestPow2AlignedRange()
+		result := r.BiggestCIDRRange()
 		return r.Contains(result.Start) &&
 			r.Contains(result.End-1) &&
 			isPower2(result.Size()) &&

--- a/net/address/address_test.go
+++ b/net/address/address_test.go
@@ -2,25 +2,40 @@ package address
 
 import (
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/require"
 )
 
+func isPower2(x Count) bool {
+	if x == 0 {
+		return false
+	}
+	for ; x > 1; x /= 2 {
+		if x&1 != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func TestBiggestPow2AlignedRange(t *testing.T) {
 	require.Equal(t, NewRange(0, 1), NewRange(0, 1).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(0, 2), NewRange(0, 2).BiggestPow2AlignedRange())
 	require.Equal(t, NewRange(0, 2), NewRange(0, 3).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(0, 4), NewRange(0, 7).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(1, 1), NewRange(1, 1).BiggestPow2AlignedRange())
 	require.Equal(t, NewRange(1, 1), NewRange(1, 2).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(2, 2), NewRange(1, 3).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(2, 2), NewRange(1, 4).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(4, 4), NewRange(1, 8).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(4, 4), NewRange(2, 8).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(4, 4), NewRange(4, 8).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(8, 4), NewRange(8, 7).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(8, 8), NewRange(8, 8).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(0, 0x4000), NewRange(0, 0x7fff).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(0x2000, 2), NewRange(0x2000, 3).BiggestPow2AlignedRange())
-	require.Equal(t, NewRange(0xffff, 1), NewRange(0xffff, 1).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0, 0x40000000), NewRange(0, 0x7fffffff).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0xfffffffe, 1), NewRange(0xfffffffe, 1).BiggestPow2AlignedRange())
+	prop := func(start Address, size Offset) bool {
+		if size > Offset(0xffffffff)-Offset(start) { // out of range
+			return true
+		}
+		r := NewRange(start, size)
+		result := r.BiggestPow2AlignedRange()
+		return r.Contains(result.Start) &&
+			r.Contains(result.End-1) &&
+			isPower2(result.Size()) &&
+			result.Size() > r.Size()/4 &&
+			Count(result.Start)%result.Size() == 0
+	}
+	require.NoError(t, quick.Check(prop, &quick.Config{MaxCount: 1000000}))
 }

--- a/net/address/address_test.go
+++ b/net/address/address_test.go
@@ -1,0 +1,26 @@
+package address
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBiggestPow2AlignedRange(t *testing.T) {
+	require.Equal(t, NewRange(0, 1), NewRange(0, 1).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0, 2), NewRange(0, 2).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0, 2), NewRange(0, 3).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0, 4), NewRange(0, 7).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(1, 1), NewRange(1, 1).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(1, 1), NewRange(1, 2).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(2, 2), NewRange(1, 3).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(2, 2), NewRange(1, 4).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(4, 4), NewRange(1, 8).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(4, 4), NewRange(2, 8).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(4, 4), NewRange(4, 8).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(8, 4), NewRange(8, 7).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(8, 8), NewRange(8, 8).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0, 0x4000), NewRange(0, 0x7fff).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0x2000, 2), NewRange(0x2000, 3).BiggestPow2AlignedRange())
+	require.Equal(t, NewRange(0xffff, 1), NewRange(0xffff, 1).BiggestPow2AlignedRange())
+}


### PR DESCRIPTION
If, say, we wanted to use the ranges for routing rules, having them aligned so you can describe each one with a single CIDR is useful.
Also fix up space tests to match.