### PR TITLE
Protect against Docker hanging trying to talk to a non-existent plugin

### DIFF
--- a/weave
+++ b/weave
@@ -1740,6 +1740,7 @@ launch_router() {
 
     # Create a data-only container for persistence data
     if ! docker inspect -f ' ' $DB_CONTAINER_NAME > /dev/null 2>&1 ; then
+       protect_against_docker_hang
        docker create -v /weavedb --name=$DB_CONTAINER_NAME \
            --label=weavevolumes $WEAVEDB_IMAGE >/dev/null
     fi
@@ -1803,6 +1804,7 @@ launch_proxy() {
     mkdir -p /var/run/weave
     # Create a data-only container to mount the weavewait files from
     if ! docker inspect -f ' ' $VOLUMES_CONTAINER_NAME > /dev/null 2>&1 ; then
+       protect_against_docker_hang
        docker create -v /w -v /w-noop -v /w-nomcast --name=$VOLUMES_CONTAINER_NAME \
            --label=weavevolumes --entrypoint=/bin/false $EXEC_IMAGE >/dev/null
     fi
@@ -1862,6 +1864,13 @@ warn_plugin_active() {
 stop_plugin() {
     util_op remove-plugin-network weave || warn_plugin_active
     stop $PLUGIN_CONTAINER_NAME "Plugin"
+}
+
+protect_against_docker_hang() {
+    # If the plugin is not running, remove its socket so Docker doesn't try to talk to it
+    if !check_running $PLUGIN_CONTAINER_NAME 2>/dev/null ; then
+        rm -f /run/docker/plugins/weave.sock /run/docker/plugins/weavemesh.sock
+    fi
 }
 
 ##########################################################################################


### PR DESCRIPTION
Remove the Unix socket from the filesystem before doing volume operations, if the plugin is not running.

Fixes #2286

(Note the comparable problem for network operations is not helped by this measure.  I.e. if you:

````
$ weave launch
$ docker kill weaveplugin
$ weave reset
````

then `weave reset` will hang for a while trying to remove the `weave` network.)