### PR TITLE
Move container attachment from sh to Go

### DIFF
--- a/net/arp.go
+++ b/net/arp.go
@@ -1,4 +1,4 @@
-package common
+package net
 
 import "fmt"
 import "io"

--- a/net/bridge.go
+++ b/net/bridge.go
@@ -1,0 +1,53 @@
+package net
+
+import (
+	"github.com/vishvananda/netlink"
+)
+
+type BridgeType int
+
+const (
+	WeaveBridgeName = "weave"
+	DatapathName    = "datapath"
+
+	None BridgeType = iota
+	Bridge
+	Fastdp
+	BridgedFastdp
+	Inconsistent
+)
+
+func DetectBridgeType(weaveBridgeName, datapathName string) BridgeType {
+	bridge, _ := netlink.LinkByName(weaveBridgeName)
+	datapath, _ := netlink.LinkByName(datapathName)
+
+	switch {
+	case bridge == nil && datapath == nil:
+		return None
+	case isBridge(bridge) && datapath == nil:
+		return Bridge
+	case isDatapath(bridge) && datapath == nil:
+		return Fastdp
+	case isDatapath(datapath) && isBridge(bridge):
+		return BridgedFastdp
+	default:
+		return Inconsistent
+	}
+}
+
+func isBridge(link netlink.Link) bool {
+	_, isBridge := link.(*netlink.Bridge)
+	return isBridge
+}
+
+func isDatapath(link netlink.Link) bool {
+	switch link.(type) {
+	case *netlink.GenericLink:
+		return link.Type() == "openvswitch"
+	case *netlink.Device:
+		// Assume it's our openvswitch device, and the kernel has not been updated to report the kind.
+		return true
+	default:
+		return false
+	}
+}

--- a/net/ethtool.go
+++ b/net/ethtool.go
@@ -1,0 +1,52 @@
+package net
+
+import "fmt"
+import "syscall"
+import "unsafe"
+
+const (
+	SIOCETHTOOL     = 0x8946     // linux/sockios.h
+	ETHTOOL_STXCSUM = 0x00000017 // linux/ethtool.h
+	IFNAMSIZ        = 16         // linux/if.h
+)
+
+// linux/if.h 'struct ifreq'
+type IFReqData struct {
+	Name [IFNAMSIZ]byte
+	Data uintptr
+}
+
+// linux/ethtool.h 'struct ethtool_value'
+type EthtoolValue struct {
+	Cmd  uint32
+	Data uint32
+}
+
+// Disable TX checksum offload on specified interface
+func EthtoolTXOff(name string) error {
+	if len(name)+1 > IFNAMSIZ {
+		return fmt.Errorf("name too long")
+	}
+
+	value := EthtoolValue{ETHTOOL_STXCSUM, 0}
+	request := IFReqData{Data: uintptr(unsafe.Pointer(&value))}
+
+	copy(request.Name[:], name)
+
+	socket, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(socket)
+
+	_, _, errno := syscall.RawSyscall(syscall.SYS_IOCTL,
+		uintptr(socket),
+		uintptr(SIOCETHTOOL),
+		uintptr(unsafe.Pointer(&request)))
+
+	if errno != 0 {
+		return errno
+	}
+
+	return nil
+}

--- a/net/netns.go
+++ b/net/netns.go
@@ -1,0 +1,37 @@
+package net
+
+import (
+	"runtime"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+func WithNetNS(ns netns.NsHandle, work func() error) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	oldNs, err := netns.Get()
+	if err == nil {
+		defer oldNs.Close()
+
+		err = netns.Set(ns)
+		if err == nil {
+			defer netns.Set(oldNs)
+
+			err = work()
+		}
+	}
+
+	return err
+}
+
+func WithNetNSLink(ns netns.NsHandle, ifName string, work func(link netlink.Link) error) error {
+	return WithNetNS(ns, func() error {
+		link, err := netlink.LinkByName(ifName)
+		if err != nil {
+			return err
+		}
+		return work(link)
+	})
+}

--- a/net/route.go
+++ b/net/route.go
@@ -3,6 +3,7 @@ package net
 import (
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/vishvananda/netlink"
 )
@@ -54,4 +55,17 @@ func forEachRoute(ignoreIfaceNames map[string]struct{}, check func(r netlink.Rou
 		}
 	}
 	return nil
+}
+
+func AddRoute(link netlink.Link, scope netlink.Scope, dst *net.IPNet, gw net.IP) error {
+	err := netlink.RouteAdd(&netlink.Route{
+		LinkIndex: link.Attrs().Index,
+		Scope:     scope,
+		Dst:       dst,
+		Gw:        gw,
+	})
+	if os.IsExist(err) { // squash duplicate route errors
+		err = nil
+	}
+	return err
 }

--- a/net/veth.go
+++ b/net/veth.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/j-keck/arping"
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
 
-	"github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/common/odp"
 )
 
@@ -73,22 +74,65 @@ func CreateAndAttachVeth(localName, peerName, bridgeName string, mtu int, init f
 	return local, nil
 }
 
-func SetupGuest(guest netlink.Link, name string, cidrs []net.IPNet) error {
+func SetupGuest(guest netlink.Link, name string) error {
 	var err error
 	if err = netlink.LinkSetName(guest, name); err != nil {
 		return err
 	}
-	if err = netlink.LinkSetUp(guest); err != nil {
+	if err = ConfigureARPCache(name); err != nil {
 		return err
 	}
-	if err = common.ConfigureARPCache(name); err != nil {
-		return err
-	}
+	return nil
+}
+
+func AddAddresses(guest netlink.Link, cidrs []*net.IPNet) error {
 	for _, ipnet := range cidrs {
-		if err = netlink.AddrAdd(guest, &netlink.Addr{IPNet: &ipnet}); err != nil {
-			return fmt.Errorf("failed to add IP address to %q: %v", name, err)
+		if err := netlink.AddrAdd(guest, &netlink.Addr{IPNet: ipnet}); err != nil {
+			return fmt.Errorf("failed to add IP address to %q: %v", guest.Attrs().Name, err)
 		}
-		arping.GratuitousArpOverIfaceByName(ipnet.IP, name)
+		arping.GratuitousArpOverIfaceByName(ipnet.IP, guest.Attrs().Name)
 	}
+	return nil
+}
+
+func interfaceExistsInNamespace(ns netns.NsHandle, ifName string) bool {
+	err := WithNetNS(ns, func() error {
+		_, err := netlink.LinkByName(ifName)
+		return err
+	})
+	return err == nil
+}
+
+func AttachContainer(ns netns.NsHandle, id, ifName, bridgeName string, mtu int, cidrs []*net.IPNet) error {
+	if !interfaceExistsInNamespace(ns, ifName) {
+		if len(id) > 5 {
+			id = id[:5]
+		}
+		name, peerName := "vethwepl"+id, "vethwg"+id
+		_, err := CreateAndAttachVeth(name, peerName, bridgeName, mtu, func(local, guest netlink.Link) error {
+			if err := netlink.LinkSetNsFd(guest, int(ns)); err != nil {
+				return fmt.Errorf("failed to move veth to container netns: %s", err)
+			}
+			if err := WithNetNS(ns, func() error {
+				return SetupGuest(guest, ifName)
+			}); err != nil {
+				return fmt.Errorf("error setting up interface: %s", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := WithNetNSLink(ns, ifName, func(guest netlink.Link) error {
+		if err := AddAddresses(guest, cidrs); err != nil {
+			return err
+		}
+		return netlink.LinkSetUp(guest)
+	}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/net/veth.go
+++ b/net/veth.go
@@ -1,0 +1,57 @@
+package net
+
+import (
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/weaveworks/weave/common/odp"
+)
+
+// create and attach local name to the Weave bridge
+func CreateAndAttachVeth(localName, peerName, bridgeName string, mtu int) (*netlink.Veth, error) {
+	maybeBridge, err := netlink.LinkByName(bridgeName)
+	if err != nil {
+		return nil, fmt.Errorf(`bridge "%s" not present; did you launch weave?`, bridgeName)
+	}
+
+	if mtu == 0 {
+		mtu = maybeBridge.Attrs().MTU
+	}
+	local := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: localName,
+			MTU:  mtu},
+		PeerName: peerName,
+	}
+	if err := netlink.LinkAdd(local); err != nil {
+		return nil, fmt.Errorf(`could not create veth pair %s-%s: %s`, local.Name, local.PeerName, err)
+	}
+
+	switch maybeBridge.(type) {
+	case *netlink.Bridge:
+		if err := netlink.LinkSetMasterByIndex(local, maybeBridge.Attrs().Index); err != nil {
+			return nil, fmt.Errorf(`unable to set master of %s: %s`, local.Name, err)
+		}
+	case *netlink.GenericLink:
+		if maybeBridge.Type() != "openvswitch" {
+			return nil, fmt.Errorf(`device "%s" is of type "%s"`, bridgeName, maybeBridge.Type())
+		}
+		if err := odp.AddDatapathInterface(bridgeName, local.Name); err != nil {
+			return nil, fmt.Errorf(`failed to attach %s to device "%s": %s`, local.Name, bridgeName, err)
+		}
+	case *netlink.Device:
+		// Assume it's our openvswitch device, and the kernel has not been updated to report the kind.
+		if err := odp.AddDatapathInterface(bridgeName, local.Name); err != nil {
+			return nil, fmt.Errorf(`failed to attach %s to device "%s": %s`, local.Name, bridgeName, err)
+		}
+	default:
+		return nil, fmt.Errorf(`device "%s" is not a bridge`, bridgeName)
+	}
+
+	if err := netlink.LinkSetUp(local); err != nil {
+		return nil, fmt.Errorf("unable to bring veth up: %s", err)
+	}
+
+	return local, nil
+}

--- a/plugin/net/cni.go
+++ b/plugin/net/cni.go
@@ -32,7 +32,7 @@ func NewCNIPlugin(weave *weaveapi.Client) *CNIPlugin {
 
 func loadNetConf(bytes []byte) (*NetConf, error) {
 	n := &NetConf{
-		BrName: "weave",
+		BrName: weavenet.WeaveBridgeName,
 	}
 	if err := json.Unmarshal(bytes, n); err != nil {
 		return nil, fmt.Errorf("failed to load netconf: %v", err)

--- a/plugin/net/cni.go
+++ b/plugin/net/cni.go
@@ -92,7 +92,7 @@ func (c *CNIPlugin) CmdAdd(args *skel.CmdArgs) error {
 		id = fmt.Sprintf("%x", data)
 	}
 
-	if err := weavenet.AttachContainer(ns, id, args.IfName, conf.BrName, conf.MTU, []*net.IPNet{&result.IP4.IP}); err != nil {
+	if err := weavenet.AttachContainer(ns, id, args.IfName, conf.BrName, conf.MTU, false, []*net.IPNet{&result.IP4.IP}); err != nil {
 		return err
 	}
 	if err := weavenet.WithNetNSLink(ns, args.IfName, func(guest netlink.Link) error {

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -101,7 +101,7 @@ func (driver *driver) JoinEndpoint(j *api.JoinRequest) (*api.JoinResponse, error
 	driver.logReq("JoinEndpoint", j, fmt.Sprintf("%s:%s to %s", j.NetworkID, j.EndpointID, j.SandboxKey))
 
 	name, peerName := vethPair(j.EndpointID)
-	if _, err := weavenet.CreateAndAttachVeth(name, peerName, WeaveBridge, 0); err != nil {
+	if _, err := weavenet.CreateAndAttachVeth(name, peerName, WeaveBridge, 0, nil); err != nil {
 		return nil, driver.error("JoinEndpoint", "%s", err)
 	}
 

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -126,8 +126,8 @@ func (driver *driver) LeaveEndpoint(leave *api.LeaveRequest) error {
 	driver.logReq("LeaveEndpoint", leave, fmt.Sprintf("%s:%s", leave.NetworkID, leave.EndpointID))
 
 	name, _ := vethPair(leave.EndpointID)
-	local := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: name}}
-	if err := netlink.LinkDel(local); err != nil {
+	veth := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: name}}
+	if err := netlink.LinkDel(veth); err != nil {
 		driver.warn("LeaveEndpoint", "unable to delete veth: %s", err)
 	}
 	return nil

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -108,7 +108,7 @@ func (driver *driver) JoinEndpoint(j *api.JoinRequest) (*api.JoinResponse, error
 	response := &api.JoinResponse{
 		InterfaceName: &api.InterfaceName{
 			SrcName:   peerName,
-			DstPrefix: "ethwe",
+			DstPrefix: weavenet.VethName,
 		},
 	}
 	if !driver.noMulticastRoute {

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -15,10 +15,6 @@ import (
 	"github.com/weaveworks/weave/plugin/skel"
 )
 
-const (
-	WeaveBridge = "weave"
-)
-
 type driver struct {
 	scope            string
 	noMulticastRoute bool
@@ -101,7 +97,7 @@ func (driver *driver) JoinEndpoint(j *api.JoinRequest) (*api.JoinResponse, error
 	driver.logReq("JoinEndpoint", j, fmt.Sprintf("%s:%s to %s", j.NetworkID, j.EndpointID, j.SandboxKey))
 
 	name, peerName := vethPair(j.EndpointID)
-	if _, err := weavenet.CreateAndAttachVeth(name, peerName, WeaveBridge, 0, nil); err != nil {
+	if _, err := weavenet.CreateAndAttachVeth(name, peerName, weavenet.WeaveBridgeName, 0, nil); err != nil {
 		return nil, driver.error("JoinEndpoint", "%s", err)
 	}
 

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -101,18 +101,15 @@ func (driver *driver) JoinEndpoint(j *api.JoinRequest) (*api.JoinResponse, error
 	driver.logReq("JoinEndpoint", j, fmt.Sprintf("%s:%s to %s", j.NetworkID, j.EndpointID, j.SandboxKey))
 
 	name, peerName := vethPair(j.EndpointID)
-	local, err := weavenet.CreateAndAttachVeth(name, peerName, WeaveBridge, 0)
-	if err != nil {
+	if _, err := weavenet.CreateAndAttachVeth(name, peerName, WeaveBridge, 0); err != nil {
 		return nil, driver.error("JoinEndpoint", "%s", err)
 	}
 
-	ifname := &api.InterfaceName{
-		SrcName:   local.PeerName,
-		DstPrefix: "ethwe",
-	}
-
 	response := &api.JoinResponse{
-		InterfaceName: ifname,
+		InterfaceName: &api.InterfaceName{
+			SrcName:   peerName,
+			DstPrefix: "ethwe",
+		},
 	}
 	if !driver.noMulticastRoute {
 		multicastRoute := api.StaticRoute{

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -11,7 +11,7 @@ import (
 	weaveapi "github.com/weaveworks/weave/api"
 	"github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/common/docker"
-	"github.com/weaveworks/weave/common/odp"
+	weavenet "github.com/weaveworks/weave/net"
 	"github.com/weaveworks/weave/plugin/skel"
 )
 
@@ -100,13 +100,10 @@ func (driver *driver) EndpointInfo(req *api.EndpointInfoRequest) (*api.EndpointI
 func (driver *driver) JoinEndpoint(j *api.JoinRequest) (*api.JoinResponse, error) {
 	driver.logReq("JoinEndpoint", j, fmt.Sprintf("%s:%s to %s", j.NetworkID, j.EndpointID, j.SandboxKey))
 
-	local, err := createAndAttach(j.EndpointID, WeaveBridge, 0)
+	name, peerName := vethPair(j.EndpointID)
+	local, err := weavenet.CreateAndAttachVeth(name, peerName, WeaveBridge, 0)
 	if err != nil {
 		return nil, driver.error("JoinEndpoint", "%s", err)
-	}
-
-	if err := netlink.LinkSetUp(local); err != nil {
-		return nil, driver.error("JoinEndpoint", "unable to bring up veth %s-%s: %s", local.Name, local.PeerName, err)
 	}
 
 	ifname := &api.InterfaceName{
@@ -128,50 +125,11 @@ func (driver *driver) JoinEndpoint(j *api.JoinRequest) (*api.JoinResponse, error
 	return response, nil
 }
 
-// create and attach local name to the Weave bridge
-func createAndAttach(id, bridgeName string, mtu int) (*netlink.Veth, error) {
-	maybeBridge, err := netlink.LinkByName(bridgeName)
-	if err != nil {
-		return nil, fmt.Errorf(`bridge "%s" not present; did you launch weave?`, bridgeName)
-	}
-
-	local := vethPair(id[:5])
-	if mtu == 0 {
-		local.Attrs().MTU = maybeBridge.Attrs().MTU
-	} else {
-		local.Attrs().MTU = mtu
-	}
-	if err := netlink.LinkAdd(local); err != nil {
-		return nil, fmt.Errorf(`could not create veth pair %s-%s: %s`, local.Name, local.PeerName, err)
-	}
-
-	switch maybeBridge.(type) {
-	case *netlink.Bridge:
-		if err := netlink.LinkSetMasterByIndex(local, maybeBridge.Attrs().Index); err != nil {
-			return nil, fmt.Errorf(`unable to set master of %s: %s`, local.Name, err)
-		}
-	case *netlink.GenericLink:
-		if maybeBridge.Type() != "openvswitch" {
-			return nil, fmt.Errorf(`device "%s" is of type "%s"`, bridgeName, maybeBridge.Type())
-		}
-		if err := odp.AddDatapathInterface(bridgeName, local.Name); err != nil {
-			return nil, fmt.Errorf(`failed to attach %s to device "%s": %s`, local.Name, bridgeName, err)
-		}
-	case *netlink.Device:
-		// Assume it's our openvswitch device, and the kernel has not been updated to report the kind.
-		if err := odp.AddDatapathInterface(bridgeName, local.Name); err != nil {
-			return nil, fmt.Errorf(`failed to attach %s to device "%s": %s`, local.Name, bridgeName, err)
-		}
-	default:
-		return nil, fmt.Errorf(`device "%s" is not a bridge`, bridgeName)
-	}
-	return local, nil
-}
-
 func (driver *driver) LeaveEndpoint(leave *api.LeaveRequest) error {
 	driver.logReq("LeaveEndpoint", leave, fmt.Sprintf("%s:%s", leave.NetworkID, leave.EndpointID))
 
-	local := vethPair(leave.EndpointID[:5])
+	name, _ := vethPair(leave.EndpointID)
+	local := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: name}}
 	if err := netlink.LinkDel(local); err != nil {
 		driver.warn("LeaveEndpoint", "unable to delete veth: %s", err)
 	}
@@ -188,13 +146,8 @@ func (driver *driver) DiscoverDelete(disco *api.DiscoveryNotification) error {
 	return nil
 }
 
-// ===
-
-func vethPair(suffix string) *netlink.Veth {
-	return &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{Name: "vethwl" + suffix},
-		PeerName:  "vethwg" + suffix,
-	}
+func vethPair(id string) (string, string) {
+	return "vethwl" + id[:5], "vethwg" + id[:5]
 }
 
 // logging

--- a/prog/weaveutil/attach.go
+++ b/prog/weaveutil/attach.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"strconv"
+	"syscall"
 
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/vishvananda/netns"
 
 	weavenet "github.com/weaveworks/weave/net"
@@ -11,7 +14,7 @@ import (
 
 func attach(args []string) error {
 	if len(args) < 4 {
-		cmdUsage("attach-container", "[--no-multicast-route] <pid> <bridge-name> <mtu> <cidr>...")
+		cmdUsage("attach-container", "[--no-multicast-route] <container-id> <bridge-name> <mtu> <cidr>...")
 	}
 
 	withMulticastRoute := true
@@ -20,23 +23,53 @@ func attach(args []string) error {
 		args = args[1:]
 	}
 
-	pid, err := strconv.Atoi(args[0])
+	pid, nsContainer, err := containerPidAndNs(args[0])
 	if err != nil {
 		return err
 	}
-	ns, err := netns.GetFromPid(pid)
-	if err != nil {
-		return err
+	if nsHost, err := netns.GetFromPid(1); err != nil {
+		return fmt.Errorf("unable to open host namespace: %s", err)
+	} else if nsHost.Equal(nsContainer) {
+		return fmt.Errorf("Container is running in the host network namespace, and therefore cannot be\nconnected to weave. Perhaps the container was started with --net=host.")
 	}
 	mtu, err := strconv.Atoi(args[2])
 	if err != nil && args[3] != "" {
-		return err
+		return fmt.Errorf("unable to parse mtu %q: %s", args[2], err)
 	}
 	cidrs, err := parseCIDRs(args[3:])
 	if err != nil {
 		return err
 	}
-	return weavenet.AttachContainer(ns, args[0], "ethwe", args[1], mtu, withMulticastRoute, cidrs)
+	err = weavenet.AttachContainer(nsContainer, fmt.Sprint(pid), "ethwe", args[1], mtu, withMulticastRoute, cidrs)
+	// If we detected an error but the container has died, tell the user that instead.
+	if err != nil && !processExists(pid) {
+		err = fmt.Errorf("Container %s died", args[0])
+	}
+	return err
+}
+
+func containerPidAndNs(containerID string) (int, netns.NsHandle, error) {
+	c, err := docker.NewVersionedClientFromEnv("1.18")
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to connect to docker: %s", err)
+	}
+	container, err := c.InspectContainer(containerID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to inspect container %s: %s", containerID, err)
+	}
+	if container.State.Pid == 0 {
+		return 0, 0, fmt.Errorf("container %s not running", containerID)
+	}
+	ns, err := netns.GetFromPid(container.State.Pid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to open namespace for container %s: %s", containerID, err)
+	}
+	return container.State.Pid, ns, nil
+}
+
+func processExists(pid int) bool {
+	err := syscall.Kill(pid, syscall.Signal(0))
+	return err == nil || err == syscall.EPERM
 }
 
 func parseCIDRs(args []string) (cidrs []*net.IPNet, err error) {
@@ -53,14 +86,10 @@ func parseCIDRs(args []string) (cidrs []*net.IPNet, err error) {
 
 func detach(args []string) error {
 	if len(args) < 2 {
-		cmdUsage("detach-container", "<pid> <cidr>...")
+		cmdUsage("detach-container", "<container-id> <cidr>...")
 	}
 
-	pid, err := strconv.Atoi(args[0])
-	if err != nil {
-		return err
-	}
-	ns, err := netns.GetFromPid(pid)
+	_, ns, err := containerPidAndNs(args[0])
 	if err != nil {
 		return err
 	}

--- a/prog/weaveutil/attach.go
+++ b/prog/weaveutil/attach.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/vishvananda/netns"
+
+	weavenet "github.com/weaveworks/weave/net"
+)
+
+func attach(args []string) error {
+	if len(args) < 4 {
+		cmdUsage("attach-container", "[--no-multicast-route] <pid> <bridge-name> <mtu> <cidr>...")
+	}
+
+	withMulticastRoute := true
+	if args[0] == "--no-multicast-route" {
+		withMulticastRoute = false
+		args = args[1:]
+	}
+
+	pid, err := strconv.Atoi(args[0])
+	if err != nil {
+		return err
+	}
+	ns, err := netns.GetFromPid(pid)
+	if err != nil {
+		return err
+	}
+	mtu, err := strconv.Atoi(args[2])
+	if err != nil && args[3] != "" {
+		return err
+	}
+	cidrs, err := parseCIDRs(args[3:])
+	if err != nil {
+		return err
+	}
+	return weavenet.AttachContainer(ns, args[0], "ethwe", args[1], mtu, withMulticastRoute, cidrs)
+}
+
+func parseCIDRs(args []string) (cidrs []*net.IPNet, err error) {
+	for _, ipstr := range args {
+		ip, ipnet, err := net.ParseCIDR(ipstr)
+		if err != nil {
+			return nil, err
+		}
+		ipnet.IP = ip // we want the specific IP plus the mask
+		cidrs = append(cidrs, ipnet)
+	}
+	return
+}
+
+func detach(args []string) error {
+	if len(args) < 2 {
+		cmdUsage("detach-container", "<pid> <cidr>...")
+	}
+
+	pid, err := strconv.Atoi(args[0])
+	if err != nil {
+		return err
+	}
+	ns, err := netns.GetFromPid(pid)
+	if err != nil {
+		return err
+	}
+	cidrs, err := parseCIDRs(args[1:])
+	if err != nil {
+		return err
+	}
+	return weavenet.DetachContainer(ns, args[0], "ethwe", cidrs)
+}

--- a/prog/weaveutil/attach.go
+++ b/prog/weaveutil/attach.go
@@ -40,7 +40,7 @@ func attach(args []string) error {
 	if err != nil {
 		return err
 	}
-	err = weavenet.AttachContainer(nsContainer, fmt.Sprint(pid), "ethwe", args[1], mtu, withMulticastRoute, cidrs)
+	err = weavenet.AttachContainer(nsContainer, fmt.Sprint(pid), weavenet.VethName, args[1], mtu, withMulticastRoute, cidrs)
 	// If we detected an error but the container has died, tell the user that instead.
 	if err != nil && !processExists(pid) {
 		err = fmt.Errorf("Container %s died", args[0])
@@ -97,5 +97,5 @@ func detach(args []string) error {
 	if err != nil {
 		return err
 	}
-	return weavenet.DetachContainer(ns, args[0], "ethwe", cidrs)
+	return weavenet.DetachContainer(ns, args[0], weavenet.VethName, cidrs)
 }

--- a/prog/weaveutil/main.go
+++ b/prog/weaveutil/main.go
@@ -19,6 +19,8 @@ func init() {
 		"create-plugin-network":  createPluginNetwork,
 		"remove-plugin-network":  removePluginNetwork,
 		"container-addrs":        containerAddrs,
+		"attach-container":       attach,
+		"detach-container":       detach,
 	}
 }
 

--- a/prog/weavewait/check_network_iface.go
+++ b/prog/weavewait/check_network_iface.go
@@ -7,6 +7,6 @@ import (
 )
 
 func checkNetwork() error {
-	_, err := weavenet.EnsureInterface("ethwe")
+	_, err := weavenet.EnsureInterface(weavenet.VethName)
 	return err
 }

--- a/prog/weavewait/check_network_iface_mcast.go
+++ b/prog/weavewait/check_network_iface_mcast.go
@@ -7,6 +7,6 @@ import (
 )
 
 func checkNetwork() error {
-	_, err := weavenet.EnsureInterfaceAndMcastRoute("ethwe")
+	_, err := weavenet.EnsureInterfaceAndMcastRoute(weavenet.VethName)
 	return err
 }

--- a/weave
+++ b/weave
@@ -847,26 +847,6 @@ netnsenter() {
     nsenter --net=$CONTAINER_NETNS "$@"
 }
 
-# connect_container_to_bridge <container interface name>
-connect_container_to_bridge() {
-    ip link add name $LOCAL_IFNAME mtu $MTU type veth peer name $GUEST_IFNAME mtu $MTU || return 1
-
-    if ! ethtool_tx_off_$BRIDGE_TYPE $GUEST_IFNAME ||
-        ! ip link set $GUEST_IFNAME netns $CONTAINER_NETNS ; then
-        # failed before we assigned the veth to the container's
-        # namespace
-        ip link del $LOCAL_IFNAME type veth || true
-        return 1
-    fi
-
-    if ! netnsenter ip link set $GUEST_IFNAME name $1 ||
-       ! ip link set $LOCAL_IFNAME up ||
-       ! add_iface_$BRIDGE_TYPE $LOCAL_IFNAME ||
-       ! configure_arp_cache $1 "netnsenter" ; then
-        return 1
-    fi
-}
-
 add_iface_fastdp() {
     util_op add-datapath-interface $DATAPATH $1
 }
@@ -940,59 +920,13 @@ attach() {
         return 1
     fi
 
-    if ! netnsenter ip link show $CONTAINER_IFNAME >/dev/null 2>&1 ; then
-        connect_container_to_bridge $CONTAINER_IFNAME || return 1
-    fi
-
-    NEW_ADDRS=
-    for ADDR in "$@" ; do
-        if netnsenter ip addr show dev $CONTAINER_IFNAME | grep -F $ADDR >/dev/null ; then
-            # address was there already
-            continue
-        fi
-        netnsenter ip addr add $ADDR dev $CONTAINER_IFNAME || return 1
-        NEW_ADDRS="$NEW_ADDRS $ADDR"
-    done
-
-    netnsenter ip link set $CONTAINER_IFNAME up || return 1
-
-    for ADDR in $NEW_ADDRS ; do
-        arp_update $CONTAINER_IFNAME $ADDR "netnsenter" || true
-    done
-
-    # Route multicast packets across the weave network.
-    # This must come last in 'attach'. If you change this, change weavewait to match.
-    #
-    # The MTU lock prevents PMTU discovery for multicast
-    # destinations. Without that, the kernel sets the DF flag on
-    # multicast packets. Since RFC1122 prohibits sending of ICMP
-    # errors for packets with multicast destinations, that causes
-    # packets larger than the PMTU to be dropped silently.
-    if [ -z "$NO_MULTICAST_ROUTE" ] ; then
-        if ! netnsenter ip route show | grep '^224\.0\.0\.0/4' >/dev/null ; then
-            netnsenter ip route add 224.0.0.0/4 dev $CONTAINER_IFNAME mtu lock $MTU
-        fi
-    fi
+    ATTACH_ARGS=""
+    [ -n "$NO_MULTICAST_ROUTE" ] && ATTACH_ARGS="--no-multicast-route"
+    util_op attach-container $ATTACH_ARGS $CONTAINER_PID $BRIDGE $MTU "$@"
 }
 
 detach() {
-    netnsenter ip link show $CONTAINER_IFNAME >/dev/null 2>&1 || return 0
-
-    for ADDR in "$@" ; do
-        if ! netnsenter ip addr show dev $CONTAINER_IFNAME | grep -F $ADDR >/dev/null ; then
-            # address is not there, leave the device alone
-            continue
-        fi
-        netnsenter ip addr del $ADDR dev $CONTAINER_IFNAME || return 1
-    done
-
-    if [ -n "$(netnsenter ip -f inet addr show dev $CONTAINER_IFNAME)" ] ; then
-        # other addresses are left, leave the device alone
-        return 0
-    fi
-
-    # Deleting the interface will delete the multicast route we set up
-    netnsenter ip link del $CONTAINER_IFNAME type veth
+    util_op detach-container $CONTAINER_PID "$@"
 }
 
 ######################################################################

--- a/weave
+++ b/weave
@@ -788,56 +788,11 @@ docker_bridge_ip() {
     DOCKER_BRIDGE_IP=${DOCKER_BRIDGE_IP#inet }
 }
 
-# the following borrows from https://github.com/jpetazzo/pipework
-
-# Set $CONTAINER_NETNS to the network namespace of container $1,
-# $LOCAL_IFNAME and $GUEST_IFNAME to suitable names for two ends of a
-# veth pair, specific to the container, and execute args $2 $3 ... as
-# a command. If an error is caused by container dying, swallow output
-# from error.
-with_container_netns() {
+do_or_die() {
     CONTAINER="$1"
-    CONTAINER_PID=$(docker inspect --format='{{.State.Pid}}' $CONTAINER) || return 1
-
-    if [ "$CONTAINER_PID" = 0 ] ; then
-        echo "Container $CONTAINER not running." >&2
-        exit 1
-    fi
-
-    if [ "$CONTAINER_PID" = "<no value>" ] ; then
-        echo "Container $CONTAINER unknown to Docker." >&2
-        exit 1
-    fi
-
-    CONTAINER_NETNS=/proc/$CONTAINER_PID/ns/net
-    LOCAL_IFNAME="v${CONTAINER_IFNAME}pl${CONTAINER_PID}"
-    GUEST_IFNAME="v${CONTAINER_IFNAME}pg${CONTAINER_PID}"
-    IP_TMPOUT=/tmp/weave_ip_out_$$
-    IP_TMPERR=/tmp/weave_ip_err_$$
-    rm -f $IP_TMPOUT $IP_TMPERR
-
-    # Run the wrapped command
-    STATUS=0
     shift 1
-    if ! "$@" >$IP_TMPOUT 2>$IP_TMPERR ; then
-        STATUS=1
-        if [ ! -d /proc/$CONTAINER_PID ] ; then
-            echo "Container $CONTAINER died" >&2
-        else
-            echo "Failure during network configuration for container $CONTAINER:" >&2
-            cat $IP_TMPERR >&2
-        fi
-    else
-        cat $IP_TMPOUT
-        cat $IP_TMPERR >&2
-    fi
-    rm -f $IP_TMPOUT $IP_TMPERR
-    return $STATUS
-}
-
-with_container_netns_or_die() {
-    if ! with_container_netns "$@" >/dev/null ; then
-        kill_container $1
+    if ! "$@" ; then
+        kill_container $CONTAINER
         exit 1
     fi
 }
@@ -893,10 +848,6 @@ ask_version() {
     [ -n "$DOCKERIMAGE" ] && docker run --rm --net=none -e WEAVE_CIDR=none $3 $DOCKERIMAGE $COVERAGE_ARGS --version
 }
 
-######################################################################
-# functions invoked through with_container_netns
-######################################################################
-
 setup_router_iface_fastdp() {
     true
 }
@@ -914,19 +865,9 @@ container_in_host_ns() {
 }
 
 attach() {
-    if container_in_host_ns ; then
-        echo "Container is running in the host network namespace, and therefore cannot be" >&2
-        echo "connected to weave. Perhaps the container was started with --net=host." >&2
-        return 1
-    fi
-
     ATTACH_ARGS=""
     [ -n "$NO_MULTICAST_ROUTE" ] && ATTACH_ARGS="--no-multicast-route"
-    util_op attach-container $ATTACH_ARGS $CONTAINER_PID $BRIDGE $MTU "$@"
-}
-
-detach() {
-    util_op detach-container $CONTAINER_PID "$@"
+    util_op attach-container $ATTACH_ARGS $CONTAINER $BRIDGE $MTU "$@"
 }
 
 ######################################################################
@@ -2052,7 +1993,7 @@ EOF
         create_bridge
         ipam_cidrs_or_die allocate $CONTAINER $CIDR_ARGS
         [ -n "$REWRITE_HOSTS" ] && extra_hosts_args "$@" && rewrite_etc_hosts $DNS_EXTRA_HOSTS
-        with_container_netns_or_die $CONTAINER attach $ALL_CIDRS
+        do_or_die $CONTAINER attach $ALL_CIDRS
         when_weave_running with_container_fqdn $CONTAINER put_dns_fqdn $ALL_CIDRS
         echo $CONTAINER
         ;;
@@ -2072,7 +2013,7 @@ EOF
         CONTAINER=$(container_id $1)
         create_bridge
         ipam_cidrs_or_die allocate $CONTAINER $CIDR_ARGS
-        with_container_netns_or_die $CONTAINER attach $ALL_CIDRS
+        do_or_die $CONTAINER attach $ALL_CIDRS
         when_weave_running with_container_fqdn $CONTAINER put_dns_fqdn $ALL_CIDRS
         echo $RES
         ;;
@@ -2108,7 +2049,7 @@ EOF
         create_bridge
         ipam_cidrs allocate $CONTAINER $CIDR_ARGS
         [ -n "$REWRITE_HOSTS" ] && rewrite_etc_hosts $DNS_EXTRA_HOSTS
-        with_container_netns $CONTAINER attach $ALL_CIDRS >/dev/null
+        attach $ALL_CIDRS >/dev/null
         when_weave_running with_container_fqdn $CONTAINER put_dns_fqdn $ALL_CIDRS
         show_addrs $ALL_CIDRS
         ;;
@@ -2118,7 +2059,7 @@ EOF
         [ $# -eq 1 ] || usage
         CONTAINER=$(container_id $1)
         ipam_cidrs lookup $CONTAINER $CIDR_ARGS
-        with_container_netns $CONTAINER detach $ALL_CIDRS >/dev/null
+        util_op detach-container $CONTAINER $ALL_CIDRS >/dev/null
         when_weave_running with_container_fqdn $CONTAINER delete_dns_fqdn $ALL_CIDRS
         for CIDR in $IPAM_CIDRS ; do
             call_weave DELETE /ip/$CONTAINER/${CIDR%/*}
@@ -2134,7 +2075,7 @@ EOF
         for CIDR in $ALL_CIDRS ; do
             call_weave PUT /ip/$CONTAINER/$CIDR?check-alive=true
         done
-        with_container_netns_or_die $CONTAINER attach $ALL_CIDRS
+        do_or_die $CONTAINER attach $ALL_CIDRS
         when_weave_running with_container_fqdn $CONTAINER put_dns_fqdn $ALL_CIDRS
         echo $RES
         ;;


### PR DESCRIPTION
Part of #1940 

Most of this is refactoring/enhancing the current plugin code to be closer to the script; see also #639 for `arping` and #1726 for `ethtool tx off`.

The plugin previously leaked a veth if something went wrong configuring it.

This PR does not mean the proxy can avoid shelling out when attaching a container.  Still to do: allocate IP addresses, rewrite hosts file, add to DNS.