### PR TITLE
Send out arp update from CNI plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 [submodule "vendor/github.com/coreos/go-iptables"]
 	path = vendor/github.com/coreos/go-iptables
 	url = https://github.com/coreos/go-iptables
+[submodule "vendor/github.com/j-keck/arping"]
+	path = vendor/github.com/j-keck/arping
+	url = https://github.com/j-keck/arping

--- a/plugin/net/cni.go
+++ b/plugin/net/cni.go
@@ -10,6 +10,7 @@ import (
 	"github.com/appc/cni/pkg/ipam"
 	"github.com/appc/cni/pkg/skel"
 	"github.com/appc/cni/pkg/types"
+	"github.com/j-keck/arping"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	weaveapi "github.com/weaveworks/weave/api"
@@ -151,6 +152,7 @@ func setupGuestIP4(origName, name string, ipnet net.IPNet, gw net.IP, routes []t
 	if err = netlink.AddrAdd(guest, &netlink.Addr{IPNet: &ipnet}); err != nil {
 		return fmt.Errorf("failed to add IP address to %q: %v", name, err)
 	}
+	arping.GratuitousArpOverIfaceByName(ipnet.IP, name)
 	for _, r := range routes {
 		if r.GW != nil {
 			err = addRoute(guest, netlink.SCOPE_UNIVERSE, &r.Dst, r.GW)

--- a/test/830_cni_plugin_test.sh
+++ b/test/830_cni_plugin_test.sh
@@ -6,7 +6,8 @@ start_suite "Test CNI plugin"
 
 cni_connect() {
     pid=$(container_pid $1 $2)
-    run_on $1 CNI_VERSION=1 CNI_COMMAND=ADD CNI_CONTAINERID=c1 CNI_IFNAME=eth0 \
+    id=$(docker_on $1 inspect -f '{{.Id}}' $2)
+    run_on $1 CNI_VERSION=1 CNI_COMMAND=ADD CNI_CONTAINERID=$id CNI_IFNAME=eth0 \
     CNI_NETNS=/proc/$pid/ns/net CNI_PATH=/opt/cni/bin /opt/cni/bin/weave-net 
 }
 
@@ -41,5 +42,17 @@ C2IP=$(container_ip $HOST1 c2)
 
 assert_raises "exec_on $HOST1 c1 $PING $C2IP"
 assert_raises "exec_on $HOST1 c2 $PING $C1IP"
+
+# Now remove and start a new container to see if IP address re-use breaks things
+docker_on $HOST1 rm -f c2
+sleep 1
+
+docker_on $HOST1 run --net=none --name=c3 -dt $SMALL_IMAGE /bin/sh
+
+cni_connect $HOST1 c3 <<EOF
+{ "name": "weave", "type": "weave-net" }
+EOF
+
+assert_raises "exec_on $HOST1 c1 $PING $C2IP"
 
 end_suite


### PR DESCRIPTION
To fix issues of packets disappearing when you re-use an IP address with a different MAC.

This brings the CNI plugin closer in behaviour to the weave script.