### PR TITLE
Discovered peers persistence

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -255,7 +255,8 @@ func main() {
 	router := weave.NewNetworkRouter(config, networkConfig, name, nickName, overlay, db)
 	Log.Println("Our name is", router.Ourself)
 
-	if peers, err = router.InitialPeers(resume, peers); err != nil {
+	var indirectPeers []string
+	if peers, indirectPeers, err = router.InitialPeers(resume, peers); err != nil {
 		Log.Fatal("Unable to get initial peer set: ", err)
 	}
 
@@ -327,7 +328,7 @@ func main() {
 	}
 
 	router.Start()
-	if errors := router.InitiateConnections(peers, false); len(errors) > 0 {
+	if errors := router.InitiateConnections(peers, indirectPeers, false); len(errors) > 0 {
 		Log.Fatal(common.ErrorMessages(errors))
 	}
 	checkFatal(router.CreateRestartSentinel())
@@ -501,7 +502,7 @@ func determineQuorum(initPeerCountFlag int, router *weave.NetworkRouter) uint {
 		return uint(initPeerCountFlag/2 + 1)
 	}
 
-	peers := router.ConnectionMaker.Targets(true)
+	peers, _ := router.ConnectionMaker.Targets(true)
 
 	// Guess a suitable quorum size based on the list of peer
 	// addresses.  The peer list might or might not contain an

--- a/router/http.go
+++ b/router/http.go
@@ -14,7 +14,7 @@ func (router *NetworkRouter) HandleHTTP(muxRouter *mux.Router) {
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, fmt.Sprint("unable to parse form: ", err), http.StatusBadRequest)
 		}
-		if errors := router.InitiateConnections(r.Form["peer"], r.FormValue("replace") == "true"); len(errors) > 0 {
+		if errors := router.InitiateConnections(r.Form["peer"], nil, r.FormValue("replace") == "true"); len(errors) > 0 {
 			http.Error(w, common.ErrorMessages(errors), http.StatusBadRequest)
 		}
 	})

--- a/test/176_discovered_peer_persistence_3_test.sh
+++ b/test/176_discovered_peer_persistence_3_test.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Check resume uses persisted discovered peers"
+
+# Create a 'chain' of direct connections, letting the full mesh establish via
+# discovery. We set the consensus value in such a way that all three peers are
+# needed - this way `weave prime` blocks until the mesh is fully established.
+weave_on $HOST1 launch --ipalloc-init consensus=4
+weave_on $HOST2 launch --ipalloc-init consensus=4 $HOST1
+weave_on $HOST3 launch --ipalloc-init consensus=4 $HOST2
+weave_on $HOST1 prime
+
+# Stop them all
+weave_on $HOST1 stop
+weave_on $HOST2 stop
+weave_on $HOST3 stop
+
+# Resume first and last nodes in the chain
+weave_on $HOST1 launch --resume
+weave_on $HOST3 launch --resume
+
+# Ensure they're connected
+start_container $HOST1 --name c1
+start_container $HOST3 --name c3
+
+assert_raises "exec_on $HOST1 c1 $PING $(container_ip $HOST3 c3)"
+
+end_suite


### PR DESCRIPTION
Extends weaveworks/weave#2305, which should be merged first. Only the last two commits in this PR are relevant.

Depends on weaveworks/mesh#46, which should also be merged first.

Fixes #2187.

There are some issues:
1. The supporting mesh PR is a bit grotty - see there for commentary.
2. Due to the way `ConnectionMaker` periodically synchronises the set of targets to `cm.directPeers` + the subset of `cm.peers` to which it does not have connections, it was necessary to introduce a third data structure (`cm.indirectPeers`) to include discovered peers from a previous run in the synchronisation. Whereas previously we would stop trying to connect to 'indirect' peers if they had disappeared from `cm.peers`, that is no longer the case after a resume; `cm.indirectPeers` can accumulate garbage which is only collected by `weave stop` (Note `weave forget` does not help, because that only removes things from `cm.directPeers`).
