### PR TITLE
Proxy shouldn't weave-attach containers which are using a network plugin

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -534,7 +534,9 @@ func callWeaveAttach(container *docker.Container, args []string) error {
 }
 
 func (proxy *Proxy) weaveCIDRs(networkMode string, env []string) ([]string, error) {
-	if networkMode == "host" || strings.HasPrefix(networkMode, "container:") {
+	if networkMode == "host" || strings.HasPrefix(networkMode, "container:") ||
+		// Anything else, other than blank/none/default/bridge, is some sort of network plugin
+		(networkMode != "" && networkMode != "none" && networkMode != "default" && networkMode != "bridge") {
 		return nil, fmt.Errorf("the container has '--net=%s'", networkMode)
 	}
 	for _, e := range env {


### PR DESCRIPTION
Fixes #1988 per the last sentence in the description:

> I suppose the proxy could ignore all containers created with a network other than `default`, `bridge`, `none` or unset.

"unset" equates to `default`, as far as I can see.

Note this would be a breaking change for someone who is deliberately using the Weave proxy together with another plugin.  Those folks (if they exist) can `docker network connect foo`, I guess.

(note that `docker run --net a --net b ...` only connects to network `b`)