### PR TITLE
Augment warning on active plugin endpoints

### DIFF
--- a/prog/weaveutil/plugin_network.go
+++ b/prog/weaveutil/plugin_network.go
@@ -47,6 +47,18 @@ func removePluginNetwork(args []string) error {
 	}
 	err = d.RemoveNetwork(networkName)
 	if _, ok := err.(*docker.NoSuchNetwork); !ok && err != nil {
+		if info, err2 := d.NetworkInfo(networkName); err2 == nil {
+			if len(info.Containers) > 0 {
+				containers := ""
+				for container := range info.Containers {
+					containers += fmt.Sprintf("  %.12s ", container)
+				}
+				return fmt.Errorf(`WARNING: the following containers are still attached to network %q:
+%s
+Docker operations involving those containers may pause or fail
+while Weave is not running`, networkName, containers)
+			}
+		}
 		return fmt.Errorf("unable to remove network: %s", err)
 	}
 	return nil

--- a/weave
+++ b/weave
@@ -1736,12 +1736,8 @@ plugin_disabled() {
     [ -n "$WEAVE_NO_PLUGIN" ] || ! check_docker_server_api_version 1.21
 }
 
-warn_plugin_active() {
-    echo "WARNING: docker may hang in this state; re-launch weave and remove attached containers before shutting down" >&2
-}
-
 stop_plugin() {
-    util_op remove-plugin-network weave || warn_plugin_active
+    util_op remove-plugin-network weave || true
     stop $PLUGIN_CONTAINER_NAME "Plugin"
 }
 
@@ -2178,7 +2174,7 @@ EOF
         ;;
     reset)
         [ $# -eq 0 ] || usage
-        plugin_disabled || util_op remove-plugin-network weave || warn_plugin_active
+        plugin_disabled || util_op remove-plugin-network weave || true
         warn_if_stopping_proxy_in_env
         call_weave DELETE /peer >/dev/null 2>&1 || true
         fractional_sleep 0.5 # Allow some time for broadcast updates to go out


### PR DESCRIPTION
Fixes #2320 

Example message:

````
$ weave stop-plugin
WARNING: the following containers are still attached to network "weave":
  9e396c66e0d2 
Docker operations involving those containers may pause or fail
while Weave is not running
````