### PR TITLE
Transfer IPAM ranges to UnknownPeer if no peer is found during Shutdown

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -443,10 +443,11 @@ func (alloc *Allocator) Shutdown() {
 		alloc.cancelOps(&alloc.pendingClaims)
 		alloc.cancelOps(&alloc.pendingAllocates)
 		alloc.cancelOps(&alloc.pendingPrimes)
-		if heir := alloc.pickPeerForTransfer(); heir != mesh.UnknownPeerName {
-			alloc.ring.Transfer(alloc.ourName, heir)
+		heir := alloc.pickPeerForTransfer()
+		alloc.ring.Transfer(alloc.ourName, heir)
+		alloc.space.Clear()
+		if heir != mesh.UnknownPeerName {
 			alloc.persistRing()
-			alloc.space.Clear()
 			alloc.gossip.GossipBroadcast(alloc.Gossip())
 		}
 		doneChan <- struct{}{}


### PR DESCRIPTION
In `Shutdown`, if no peer for transfer is found, we transfer them to `mesh.UnknownPeerName` to notify the ring update tracker.

Resolves an issue, when the stale entries are left in the AWS VPC route table after `weave reset` issued on the last peer.

Fixes https://github.com/weaveworks/weave/issues/2322#issuecomment-223910199