### PR TITLE
Re-instate mention of checkpoint on install page

### DIFF
--- a/site/installing-weave.md
+++ b/site/installing-weave.md
@@ -26,6 +26,18 @@ With Weave Net downloaded onto your VMs or hosts, you are ready to launch a Weav
   <img src="hello-screencast.png" alt="Click to watch the screencast" />
 </a>
 
+###Checkpoint
+
+Weave Net [periodically contacts Weaveworks servers for available
+versions](https://github.com/weaveworks/go-checkpoint).  New versions
+are announced in the log and in [the status
+summary](/site/troubleshooting.md#weave-status).  To disable this
+check, run:
+
+    export CHECKPOINT_DISABLE=1
+
+before launching Weave Net.
+
 ###Guides for Specific Platforms
 
 CoreOS users see [here](/guides/networking-docker-containers-with-weave-on-coreos/) for an example of installing Weave using cloud-config.

--- a/site/installing-weave.md
+++ b/site/installing-weave.md
@@ -32,11 +32,10 @@ Weave Net [periodically contacts Weaveworks servers for available
 versions](https://github.com/weaveworks/go-checkpoint).  New versions
 are announced in the log and in [the status
 summary](/site/troubleshooting.md#weave-status).  To disable this
-check, run:
+check, run the following before launching Weave Net:
 
     export CHECKPOINT_DISABLE=1
 
-before launching Weave Net.
 
 ###Guides for Specific Platforms
 


### PR DESCRIPTION
It got lost in d1e004d

This PR replaces #2336 which was against wrong branch.

Note it needed a sub-heading because I put it under the video (not wanting to move the video "below the fold")