### PR TITLE
Small doc fixes

### DIFF
--- a/site/weave-docker-api/using-proxy.md
+++ b/site/weave-docker-api/using-proxy.md
@@ -20,9 +20,8 @@ To create and start a container via the Weave Net proxy run:
 
 or, equivalently run:
 
-    host1$ docker create -ti ubuntu
-    5ef831df61d50a1a49272357155a976595e7268e590f0a2c75693337b14e1382
-    host1$ docker start 5ef831df61d50a1a49272357155a976595e7268e590f0a2c75693337b14e1382
+    host1$ docker create -ti --name=foo ubuntu
+    host1$ docker start foo
 
 Specific IP addresses and networks can be supplied in the `WEAVE_CIDR`
 environment variable, for example:

--- a/site/weavedns/managing-domains-weavedns.md
+++ b/site/weavedns/managing-domains-weavedns.md
@@ -10,12 +10,10 @@ The following topics are discussed:
 
 ## <a name="domain-search-path"></a>Configuring the domain search paths
 
-If you don't supply a domain search path (with `--dns-search=`),
-`weave run ...` tells a container to look for "bare" hostnames, like
-`pingme`, in its own domain (or in `weave.local` if it has no domain).
-That's why you can just invoke `ping pingme` above -- since the
-hostname is `ubuntu.weave.local`, it will look for
-`pingme.weave.local`.
+If you don't supply a domain search path (with `--dns-search=`), Weave
+Net (via the [proxy](/site/weave-docker-api.md) or via `weave run`)
+tells a container to look for "bare" hostnames, like `pingme`, in its
+own domain (or in `weave.local` if it has no domain).
 
 If you want to supply other entries for the domain search path,
 e.g. if you want containers in different sub-domains to resolve


### PR DESCRIPTION
Fix a couple of things I noticed in passing:
- implying that users should read and type in the enormous hex ID of a container
- telling users to look "above" when we're at the top of a file

ping @abuehrle for doc review.