### PR TITLE
Add kernel version, Docker version and awsvpc setting to checkpoint info

### DIFF
--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -84,6 +84,15 @@ func (c *Client) Info() string {
 	return fmt.Sprintf("Docker API on %s: %v", c.Endpoint(), env)
 }
 
+func (c *Client) DockerVersion() string {
+	if env, err := c.Version(); err == nil {
+		if v, found := env.Map()["Version"]; found {
+			return v
+		}
+	}
+	return "unknown"
+}
+
 // AddObserver adds an observer for docker events
 func (c *Client) AddObserver(ob ContainerObserver) error {
 	go func() {

--- a/prog/weaver/checkpoint.go
+++ b/prog/weaver/checkpoint.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/weaveworks/go-checkpoint"
+)
+
+var checker *checkpoint.Checker
+var newVersion atomic.Value
+
+const (
+	updateCheckPeriod = 6 * time.Hour
+)
+
+func checkForUpdates() {
+	newVersion.Store("")
+
+	handleResponse := func(r *checkpoint.CheckResponse, err error) {
+		if err != nil {
+			Log.Printf("Error checking version: %v", err)
+			return
+		}
+		if r.Outdated {
+			newVersion.Store(r.CurrentVersion)
+			Log.Printf("Weave version %s is available; please update at %s",
+				r.CurrentVersion, r.CurrentDownloadURL)
+		}
+	}
+
+	// Start background version checking
+	params := checkpoint.CheckParams{
+		Product:       "weave-net",
+		Version:       version,
+		SignatureFile: "",
+	}
+	checker = checkpoint.CheckInterval(&params, updateCheckPeriod, handleResponse)
+}

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -204,8 +204,6 @@ func main() {
 
 	Log.Println("Command line options:", options())
 
-	checkForUpdates()
-
 	if prof != "" {
 		defer profile.Start(profile.CPUProfile, profile.ProfilePath(prof), profile.NoShutdownHook).Stop()
 	}
@@ -257,6 +255,13 @@ func main() {
 		}
 		dockerCli = dc
 	}
+
+	network := ""
+	if isAWSVPC {
+		network = "awsvpc"
+	}
+	checkForUpdates(dockerCli.DockerVersion(), network)
+
 	observeContainers := func(o docker.ContainerObserver) {
 		if dockerCli != nil {
 			if err := dockerCli.AddObserver(o); err != nil {

--- a/site/installing-weave.md
+++ b/site/installing-weave.md
@@ -31,11 +31,19 @@ With Weave Net downloaded onto your VMs or hosts, you are ready to launch a Weav
 Weave Net [periodically contacts Weaveworks servers for available
 versions](https://github.com/weaveworks/go-checkpoint).  New versions
 are announced in the log and in [the status
-summary](/site/troubleshooting.md#weave-status).  To disable this
-check, run the following before launching Weave Net:
+summary](/site/troubleshooting.md#weave-status).
+
+The information sent in this check is:
+
+ * Host UUID hash
+ * Kernel version
+ * Docker version
+ * Weave Net version
+ * Network mode, e.g. 'awsvpc'
+
+To disable this check, run the following before launching Weave Net:
 
     export CHECKPOINT_DISABLE=1
-
 
 ###Guides for Specific Platforms
 


### PR DESCRIPTION
Fixes #2310 

I couldn't find any library anywhere that did the necessary kernel wrangling, until after I wrote my own, when I found https://github.com/docker/docker/blob/master/pkg/platform/.  I don't like the way they report errors unconditionally via `logrus` so didn't use it.

(No errors are documented for `uname(2)` except "bad pointer" which can't happen here)