### PR TITLE
Perform arp configuration for plugin-connected containers

### DIFF
--- a/plugin/net/watcher.go
+++ b/plugin/net/watcher.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 
 	weaveapi "github.com/weaveworks/weave/api"
+	"github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/common/docker"
+	weavenet "github.com/weaveworks/weave/net"
 )
 
 const (
@@ -43,6 +45,9 @@ func (w *watcher) ContainerStarted(id string) {
 			fqdn := fmt.Sprintf("%s.%s", info.Config.Hostname, info.Config.Domainname)
 			if err := w.weave.RegisterWithDNS(id, fqdn, net.IPAddress); err != nil {
 				w.driver.warn("ContainerStarted", "unable to register %s with weaveDNS: %s", id, err)
+			}
+			if err := common.ConfigureARPforVeths(info.State.Pid, weavenet.VethName); err != nil {
+				w.driver.warn("ContainerStarted", "unable to configure interfaces: %s", err)
 			}
 		}
 	}

--- a/plugin/net/watcher.go
+++ b/plugin/net/watcher.go
@@ -32,9 +32,14 @@ func (w *watcher) ContainerStarted(id string) {
 		w.driver.warn("ContainerStarted", "error inspecting container %s: %s", id, err)
 		return
 	}
-	// check that it's on our network, via the endpointID
+	// check that it's on our network
 	for _, net := range info.NetworkSettings.Networks {
-		if w.driver.HasEndpoint(net.EndpointID) {
+		network, err := w.driver.findNetworkInfo(net.NetworkID)
+		if err != nil {
+			w.driver.warn("ContainerStarted", "unable to find network %s info: %s", net.NetworkID, err)
+			continue
+		}
+		if network.isOurs {
 			fqdn := fmt.Sprintf("%s.%s", info.Config.Hostname, info.Config.Domainname)
 			if err := w.weave.RegisterWithDNS(id, fqdn, net.IPAddress); err != nil {
 				w.driver.warn("ContainerStarted", "unable to register %s with weaveDNS: %s", id, err)

--- a/prog/plugin/main.go
+++ b/prog/plugin/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"strings"
 	"syscall"
 
@@ -121,7 +122,8 @@ func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddre
 }
 
 func listenAndServe(dockerClient *docker.Client, weave *weaveapi.Client, address string, endChan chan<- error, scope string, withIpam bool) (net.Listener, error) {
-	d, err := netplugin.New(dockerClient, weave, scope)
+	name := strings.TrimSuffix(path.Base(address), ".sock")
+	d, err := netplugin.New(dockerClient, weave, name, scope)
 	if err != nil {
 		return nil, err
 	}

--- a/weave
+++ b/weave
@@ -1747,6 +1747,7 @@ launch_plugin_if_not_running() {
     if ! PLUGIN_CONTAINER=$(docker run -d --name=$PLUGIN_CONTAINER_NAME \
         $(docker_run_options) \
         $RESTART_POLICY \
+        --pid=host \
         -v /run/docker/plugins:/run/docker/plugins \
         -e WEAVE_HTTP_ADDR \
         $WEAVEPLUGIN_DOCKER_ARGS $PLUGIN_IMAGE $COVERAGE_ARGS \


### PR DESCRIPTION
Fixes #1726, the last remaining part.

Note that we are only reacting to container `start` events, so not doing the arp stuff when a user `docker network connect`s a container.  See #1914 
