### PR TITLE
Use buffered writer for http headers

### DIFF
--- a/proxy/proxy_intercept.go
+++ b/proxy/proxy_intercept.go
@@ -77,24 +77,22 @@ func doRawStream(w http.ResponseWriter, resp *http.Response, client *httputil.Cl
 	}
 	defer down.Close()
 	defer up.Close()
+	defer func() {
+		if err != nil {
+			Log.Warning(err)
+		}
+	}()
 
-	if _, err := downBuf.Write([]byte("HTTP/1.1 " + resp.Status + "\n")); err != nil {
-		Log.Warning(err)
+	if _, err = downBuf.Write([]byte("HTTP/1.1 " + resp.Status + "\n")); err != nil {
 		return
 	}
-
-	if err := resp.Header.Write(downBuf); err != nil {
-		Log.Warning(err)
+	if err = resp.Header.Write(downBuf); err != nil {
 		return
 	}
-
-	if _, err := downBuf.Write([]byte("\n")); err != nil {
-		Log.Warning(err)
+	if _, err = downBuf.Write([]byte("\n")); err != nil {
 		return
 	}
-
 	if err = downBuf.Flush(); err != nil {
-		Log.Warning(err)
 		return
 	}
 

--- a/proxy/proxy_intercept.go
+++ b/proxy/proxy_intercept.go
@@ -78,17 +78,22 @@ func doRawStream(w http.ResponseWriter, resp *http.Response, client *httputil.Cl
 	defer down.Close()
 	defer up.Close()
 
-	if _, err := down.Write([]byte("HTTP/1.1 " + resp.Status + "\n")); err != nil {
+	if _, err := downBuf.Write([]byte("HTTP/1.1 " + resp.Status + "\n")); err != nil {
 		Log.Warning(err)
 		return
 	}
 
-	if err := resp.Header.Write(down); err != nil {
+	if err := resp.Header.Write(downBuf); err != nil {
 		Log.Warning(err)
 		return
 	}
 
-	if _, err := down.Write([]byte("\n")); err != nil {
+	if _, err := downBuf.Write([]byte("\n")); err != nil {
+		Log.Warning(err)
+		return
+	}
+
+	if err = downBuf.Flush(); err != nil {
 		Log.Warning(err)
 		return
 	}


### PR DESCRIPTION
As seen in wireshark, we are doing four sends for every entry in the http header, many of which contain just 2 bytes of data (and, if over TCP, 54 bytes of packet header).  This change uses the already-existing buffered writer to condense them all into one send.

I also condensed all the `if err != nil` lines into one.