### PR TITLE
Fix check before removing plugin sockets

### DIFF
--- a/weave
+++ b/weave
@@ -2322,6 +2322,7 @@ EOF
             docker stop  $NAME >/dev/null 2>&1 || true
             docker rm -f $NAME >/dev/null 2>&1 || true
         done
+        protect_against_docker_hang
         VOLUME_CONTAINERS=$(docker ps -qa --filter label=weavevolumes)
         [ -n "$VOLUME_CONTAINERS" ] && docker rm -v $VOLUME_CONTAINERS  >/dev/null 2>&1 || true
         conntrack -D -p udp --dport $PORT >/dev/null 2>&1 || true

--- a/weave
+++ b/weave
@@ -1868,7 +1868,7 @@ stop_plugin() {
 
 protect_against_docker_hang() {
     # If the plugin is not running, remove its socket so Docker doesn't try to talk to it
-    if !check_running $PLUGIN_CONTAINER_NAME 2>/dev/null ; then
+    if ! check_running $PLUGIN_CONTAINER_NAME 2>/dev/null ; then
         rm -f /run/docker/plugins/weave.sock /run/docker/plugins/weavemesh.sock
     fi
 }


### PR DESCRIPTION
Fixes the fix in #2292.

Also extend to `weave reset`, in case the plugin was killed before it got a chance to remove its sockets.