### PR TITLE
Refactor plugin to create veths in CreateEndpoint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,3 +76,6 @@
 [submodule "vendor/github.com/aws/aws-sdk-go"]
 	path = vendor/github.com/aws/aws-sdk-go
 	url = https://github.com/aws/aws-sdk-go
+[submodule "vendor/golang.org/x/sys"]
+	path = vendor/golang.org/x/sys
+	url = https://go.googlesource.com/sys


### PR DESCRIPTION
Re-doing #1808, which was pulled because we were uncertain about the semantics of create/delete vs join/leave.  Subsequent Docker changes indicate that this is not something to worry about.

Fixes #1803.

By moving endpoint creation into CreateEndpoint we can return the MAC address at the time Docker expects. We find the endpoint later simply by looking it up with the same name, derived from the endpoint ID.

The second commit was also tagged onto #1808; changes from using 5 chars from the endpoint-ID to using 8, to reduce the chance of collision from ~1/1000 to ~1/64K. This is not backwards-compatible, e.g. if you stop/upgrade/start the plugin it will log a warning and leak the veth when asked to remove an endpoint.