### PR TITLE
Check that weave router is running before launching plugin

### DIFF
--- a/test/090_docker_restart_policy_2_test.sh
+++ b/test/090_docker_restart_policy_2_test.sh
@@ -23,8 +23,8 @@ assert_raises "! check_restart $HOST1 weave"
 assert_raises "! check_restart $HOST1 weaveproxy"
 assert_raises "! check_restart $HOST1 weaveplugin"
 
-# Relaunch the plugin to prevent the `weave stop` in `end_suite`
+# Relaunch to prevent the `weave stop` in `end_suite`
 # timing out trying to remove the plugin network
-weave_on $HOST1 launch-plugin
+weave_on $HOST1 launch --no-restart
 
 end_suite

--- a/weave
+++ b/weave
@@ -1978,6 +1978,10 @@ EOF
         echo $PROXY_CONTAINER
         ;;
     launch-plugin)
+        if ! check_running $CONTAINER_NAME 2>/dev/null ; then
+            echo "ERROR:" $CONTAINER_NAME "container must be running before plugin can be launched" >&2
+            exit 1
+        fi
         launch_plugin_if_not_running "$@"
         echo $PLUGIN_CONTAINER
         ;;


### PR DESCRIPTION
Fixes #2293.

I decided to error the entire `launch-plugin` operation if `weave` is not running; if I just errored on the network creation then there is no way to re-try that operation; next time round the code will see the plugin is running and return early.

Fundamentally, it doesn't seem to be very useful to run the plugin *and* output an error.
