### PR TITLE
Log errors arising from reading resolv.conf

### DIFF
--- a/nameserver/dns_test.go
+++ b/nameserver/dns_test.go
@@ -19,8 +19,8 @@ type mockUpstream struct {
 	config *dns.ClientConfig
 }
 
-func (mu *mockUpstream) Config() *dns.ClientConfig {
-	return mu.config
+func (mu *mockUpstream) Config() (*dns.ClientConfig, error) {
+	return mu.config, nil
 }
 
 func startServer(t *testing.T, upstream *dns.ClientConfig) (*DNSServer, *Nameserver, int, int) {

--- a/nameserver/status.go
+++ b/nameserver/status.go
@@ -36,9 +36,10 @@ func NewStatus(ns *Nameserver, dnsServer *DNSServer) *Status {
 			entry.Tombstone})
 	}
 
+	upstreamConfig, _ := dnsServer.upstream.Config()
 	return &Status{
 		dnsServer.domain,
-		dnsServer.upstream.Config().Servers,
+		upstreamConfig.Servers,
 		dnsServer.address,
 		dnsServer.ttl,
 		entryStatusSlice}


### PR DESCRIPTION
With no logging of errors, it can be difficult to diagnose problems.