### PR TITLE
Fix "weave ps" output when weave is not running

### DIFF
--- a/prog/weaveutil/addrs.go
+++ b/prog/weaveutil/addrs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/fsouza/go-dockerclient"
@@ -21,6 +22,9 @@ func containerAddrs(args []string) error {
 
 	pred, err := common.ConnectedToBridgePredicate(bridgeName)
 	if err != nil {
+		if err.Error() == errors.New("Link not found").Error() {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
The #2418 has changed a behaviour of `weave ps` cmd when weave is not running: instead of outputting an empty line, the cmd returns `Link not found` error.

To fix that, we check (in an ugly way, because the netlink package does not export sentinel errors) whether the "weave" bridge can be found, as it has been done before through bunch of indirections.