### PR TITLE
Fix "weave ps" output when weave is not running

### DIFF
--- a/net/netns.go
+++ b/net/netns.go
@@ -1,11 +1,14 @@
 package net
 
 import (
+	"errors"
 	"runtime"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )
+
+var ErrLinkNotFound = errors.New("Link not found")
 
 // NB: The following function is unsafe, because:
 //     - It changes a network namespace (netns) of an OS thread which runs
@@ -42,6 +45,9 @@ func WithNetNSLinkUnsafe(ns netns.NsHandle, ifName string, work func(link netlin
 	return WithNetNSUnsafe(ns, func() error {
 		link, err := netlink.LinkByName(ifName)
 		if err != nil {
+			if err.Error() == errors.New("Link not found").Error() {
+				return ErrLinkNotFound
+			}
 			return err
 		}
 		return work(link)

--- a/prog/weaveutil/addrs.go
+++ b/prog/weaveutil/addrs.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/fsouza/go-dockerclient"
 	"github.com/vishvananda/netlink"
+
 	"github.com/weaveworks/weave/common"
+	weavenet "github.com/weaveworks/weave/net"
 )
 
 func containerAddrs(args []string) error {
@@ -21,6 +23,9 @@ func containerAddrs(args []string) error {
 
 	pred, err := common.ConnectedToBridgePredicate(bridgeName)
 	if err != nil {
+		if err == weavenet.ErrLinkNotFound {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
The #2418 has changed a behaviour of `weave ps` cmd when weave is not running: instead of outputting an empty line, the cmd returns `Link not found` error.

To fix that, we check (in an ugly way, because the netlink package does not export sentinel errors) whether the "weave" bridge can be found, as it has been done before through bunch of indirections.