### PR TITLE
remove dire warnings about 'eval' when using plugin

### DIFF
--- a/site/features.md
+++ b/site/features.md
@@ -88,11 +88,6 @@ Using the Weave plugin enables you to take advantage of [Docker's network functi
 Also, Weave’s Docker Network plugin doesn't require an external cluster store and you can start and stop containers even 
 when there are network connectivity problems.
 
-
-
->*Note:* The plugin is an *alternative* to the proxy, and therefore you do
-*not* need to run `eval $(weave env)` beforehand.
-
 See [Using the Weave Docker Network Plugin](/site/plugin.md) for more details.
 
 

--- a/site/plugin.md
+++ b/site/plugin.md
@@ -25,8 +25,6 @@ After you've launched Weave Net and peered your hosts,  you can start containers
 on any of the hosts, and they can all communicate with each other
 using any protocol, even multicast.
 
->**Warning!** It is inadvisable to attach containers to the Weave network using the Weave Docker Networking Plugin and Weave Docker API Proxy simultaneously. Such containers will end up with two Weave network interfaces and two IP addresses, which is rarely desirable. To ensure that the proxy is not being used, do not run `eval $(weave env)`, or `docker $(weave config) ...`.
-
 In order to use Weave Net's [Service Discovery](/site/weavedns.md) you
 must pass the additional arguments `--dns` and `-dns-search`, for
 which a helper is provided in the Weave script:

--- a/site/using-weave.md
+++ b/site/using-weave.md
@@ -50,9 +50,6 @@ Where,
 > modify environment entries and hence they all need to be executed from
 > the same shell.
 
-> **Important!** If you intend to use the
-> [Weave Docker Network Plugin](/site/plugin.md) do not run `eval $(weave env)`.
-
 Weave Net must be launched once per host. The relevant container images will be pulled down from Docker Hub on demand during `weave launch`. 
 
 You can also preload the images by running `weave setup`. Preloaded images are useful for automated deployments, and ensure there are no delays during later operations.


### PR DESCRIPTION
since as of #2330 the proxy ignores containers started with specified user networks.

cc @abuehrle 