### PR TITLE
Prevent from creating multiple flows for non-real broadcasts

### DIFF
--- a/router/flow.go
+++ b/router/flow.go
@@ -84,19 +84,24 @@ func (mfop *MultiFlowOp) Discards() bool {
 	return true
 }
 
-// Flatten out a FlowOp to eliminate any MultiFlowOps
-func FlattenFlowOp(fop FlowOp) []FlowOp {
-	return collectFlowOps(nil, fop)
+// Flatten out a FlowOp to eliminate any MultiFlowOps and return a broadcast hint
+// which is true if any MultiFlowOps has set it to true.
+func FlattenFlowOp(fop FlowOp) (fops []FlowOp, broadcast bool) {
+	return collectFlowOps(nil, false, fop)
 }
 
-func collectFlowOps(into []FlowOp, fop FlowOp) []FlowOp {
+func collectFlowOps(into []FlowOp, broadcast bool, fop FlowOp) ([]FlowOp, bool) {
+	var bcast bool
+
 	if mfop, ok := fop.(*MultiFlowOp); ok {
+		broadcast = broadcast || mfop.broadcast
 		for _, op := range mfop.ops {
-			into = collectFlowOps(into, op)
+			into, bcast = collectFlowOps(into, broadcast, op)
+			broadcast = broadcast || bcast
 		}
 
-		return into
+		return into, broadcast
 	}
 
-	return append(into, fop)
+	return append(into, fop), broadcast
 }


### PR DESCRIPTION
This PR prevents from installing ODP flows in the case of "non-real" broadcast (= relaying a non-broadcast packet to all ports when the router does not know to which port to send for a given `dst_mac`).

The decision about the installation is moved to `fastdp.send` function which is the only one that can create a flow.

Fixes #2428 