### PR TITLE
Enable arp_accept when configuring ARP cache

### DIFF
--- a/net/arp.go
+++ b/net/arp.go
@@ -17,6 +17,9 @@ func ConfigureARPCache(name string) error {
 	if err := sysctl(fmt.Sprintf("net/ipv4/neigh/%s/ucast_solicit", name), "1"); err != nil {
 		return err
 	}
+	if err := sysctl(fmt.Sprintf("net/ipv4/conf/%s/arp_accept", name), "1"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/test/830_cni_plugin_test.sh
+++ b/test/830_cni_plugin_test.sh
@@ -45,7 +45,6 @@ assert_raises "exec_on $HOST1 c2 $PING $C1IP"
 
 # Now remove and start a new container to see if IP address re-use breaks things
 docker_on $HOST1 rm -f c2
-sleep 1
 
 docker_on $HOST1 run --net=none --name=c3 -dt $SMALL_IMAGE /bin/sh
 

--- a/weave
+++ b/weave
@@ -425,7 +425,8 @@ delete_iptables_rule() {
 configure_arp_cache() {
     $2 sh -c "echo 5 >/proc/sys/net/ipv4/neigh/$1/base_reachable_time &&
               echo 2 >/proc/sys/net/ipv4/neigh/$1/delay_first_probe_time &&
-              echo 1 >/proc/sys/net/ipv4/neigh/$1/ucast_solicit"
+              echo 1 >/proc/sys/net/ipv4/neigh/$1/ucast_solicit &&
+              echo 1 >/proc/sys/net/ipv4/conf/$1/arp_accept"
 }
 
 # Send out an ARP announcement


### PR DESCRIPTION
Enabling `arp_accept` makes fail-overs faster. This is so, because it prevents the kernel from dropping unsolicited ARP requests.

The disadvantage of the setting is that containers / weave bridge become prone to the ARP spoofing attacks.

Keep in mind, that the documentation about `arp_accept` is a bit misleading in [Documentation/networking/ip-sysctl.txt](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt): regardless whether an entry with IP addr == unsolicited ARP request IP addr exists in the ARP table, the kernel might drop the request if the last update of the entry is within `LOCKTIME` boundaries. Please see https://github.com/weaveworks/weave/issues/2316#issuecomment-236975722 for further details.

Fixes #2329 and #2316.