### PR TITLE
Re-enable 'weave create-bridge' in fastdp mode.

### DIFF
--- a/weave
+++ b/weave
@@ -1933,22 +1933,24 @@ case "$COMMAND" in
     # intentionally undocumented since it assumes knowledge of weave
     # internals
     create-bridge)
-        cat 1>&2 <<EOF
+        if [ "$1" != "--force" ] ; then
+            cat 1>&2 <<EOF
 WARNING: 'weave create-bridge' is deprecated. Instead use 'weave attach-bridge'
 to link the docker and weave bridges after both docker and weave have been
 started. Note that, unlike 'weave create-bridge', 'weave attach-bridge' is
 compatible with fast data path.
 EOF
-        # This subcommand may be run without the docker daemon, but
-        # fastdp needs to run the router container to setup the ODP
-        # bridge, hence:
-        if [ -z "$WEAVE_NO_FASTDP" ] ; then
-            cat 1>&2 <<EOF
+            # This subcommand may be run without the docker daemon, but
+            # fastdp needs to run the router container to setup the ODP
+            # bridge, hence:
+            if [ -z "$WEAVE_NO_FASTDP" ] ; then
+                cat 1>&2 <<EOF
 
 ERROR: 'weave create-bridge' is not compatible with fast data path. If you
 really want to do this please set the WEAVE_NO_FASTDP environment variable.
 EOF
-            exit 1
+                exit 1
+            fi
         fi
         create_bridge --without-ethtool
         ;;


### PR DESCRIPTION
Fixes #2464

The deprecation message remains, so anyone trying to use it before Docker is running should realise there is a better way.