### PR TITLE
CNI plugin assigns an IP to the bridge by itself

### DIFF
--- a/site/cni-plugin.md
+++ b/site/cni-plugin.md
@@ -35,11 +35,6 @@ for a discussion on peer connections.
 
     weave launch <peer hosts>
 
-Next, assign an IP address to the Weave bridge and [enable access to containers from the host](/site/using-weave/host-network-integration.md),
-which is required by Kubernetes, by running the following:
-
-    weave expose
-
 ####Using the CNI network configuration file
 
 All CNI plugins are configured by a JSON file in the directory
@@ -49,7 +44,10 @@ file named `10-weave.conf`, which you can alter to suit your needs.
 See the [CNI Spec](https://github.com/appc/cni/blob/master/SPEC.md#network-configuration)
 for details on the format and contents of this file.
 
-By default, the Weave CNI plugin adds a default route out via the Weave bridge, so your containers can access resources on the internet.  If you do not want this, add a section to the config file that specifies no routes:
+By default, the Weave CNI plugin adds a default route out via an IP
+address on the Weave bridge, so your containers can access resources
+on the internet.  If you do not want this, add a section to the config
+file that specifies no routes:
 
     "ipam": {
         "routes": [ ]

--- a/test/830_cni_plugin_test.sh
+++ b/test/830_cni_plugin_test.sh
@@ -15,7 +15,6 @@ run_on $HOST1 sudo mkdir -p /opt/cni/bin
 # setup-cni is a subset of 'weave setup', without doing any 'docker pull's
 weave_on $HOST1 setup-cni
 weave_on $HOST1 launch
-weave_on $HOST1 expose
 
 C1=$(docker_on $HOST1 run --net=none --name=c1 -dt $SMALL_IMAGE /bin/sh)
 C2=$(docker_on $HOST1 run --net=none --name=c2 -dt $SMALL_IMAGE /bin/sh)


### PR DESCRIPTION
No need to call `weave expose` before use.  This simplifies set-up for Kubernetes, etc.

It only does if the config doesn't specify any routes or gateway, which may be too restrictive, but I guess we can wait for customer feedback.

CC @abuehrle for review of doc change