### PR TITLE
Refactor: move bridge veth creation into 'init_bridge'

### DIFF
--- a/weave
+++ b/weave
@@ -716,6 +716,8 @@ init_bridge() {
     ip link add name v${CONTAINER_IFNAME}du mtu $MTU type dummy
     ip link set dev v${CONTAINER_IFNAME}du master $BRIDGE
     ip link del dev v${CONTAINER_IFNAME}du
+
+    create_veth $BRIDGE_IFNAME $PCAP_IFNAME add_iface_bridge $BRIDGE_IFNAME
 }
 
 init_bridged_fastdp() {
@@ -852,18 +854,6 @@ ask_version() {
         echo "Unable to find $2 image." >&2
     fi
     [ -n "$DOCKERIMAGE" ] && docker run --rm --net=none -e WEAVE_CIDR=none $3 $DOCKERIMAGE $COVERAGE_ARGS --version
-}
-
-setup_router_iface_fastdp() {
-    true
-}
-
-setup_router_iface_bridge() {
-    create_veth $BRIDGE_IFNAME $PCAP_IFNAME add_iface_bridge $BRIDGE_IFNAME
-}
-
-setup_router_iface_bridged_fastdp() {
-    setup_router_iface_fastdp "$@"
 }
 
 container_in_host_ns() {
@@ -1669,7 +1659,6 @@ launch_router() {
         --http-addr $HTTP_ADDR \
         --resolv-conf "/var/run/weave/etc/$RESOLV_CONF_BASE" \
         "$@")
-    setup_router_iface_$BRIDGE_TYPE
     wait_for_status $CONTAINER_NAME http_call $HTTP_ADDR
     setup_awsvpc
     populate_router
@@ -1987,7 +1976,6 @@ EOF
         ! docker inspect -f '{{.Config.Cmd}}' $CONTAINER_NAME | grep -q -- "--awsvpc" || AWSVPC=1
         create_bridge
         fetch_router_args
-        setup_router_iface_$BRIDGE_TYPE
         wait_for_status $CONTAINER_NAME http_call $HTTP_ADDR
         setup_awsvpc
         populate_router


### PR DESCRIPTION
This simplifies the code and makes `weave create-bridge` more useful

The key change is that the veths are now created before `weaver` is running instead of afterwards, but I can't see that this would be important.  This is already the case if you stop/start `weaver`.