### PR TITLE
Pass in default subnet when creating 'weave' plugin network.

### DIFF
--- a/prog/weaveutil/plugin_network.go
+++ b/prog/weaveutil/plugin_network.go
@@ -10,11 +10,12 @@ import (
 )
 
 func createPluginNetwork(args []string) error {
-	if len(args) != 2 {
-		cmdUsage("create-plugin-network", "<network-name> <driver-name>")
+	if len(args) != 3 {
+		cmdUsage("create-plugin-network", "<network-name> <driver-name> <default-subnet>")
 	}
 	networkName := args[0]
 	driverName := args[1]
+	subnet := args[2]
 	d, err := newDockerClient()
 	if err != nil {
 		return err
@@ -24,8 +25,11 @@ func createPluginNetwork(args []string) error {
 			Name:           networkName,
 			CheckDuplicate: true,
 			Driver:         driverName,
-			IPAM:           docker.IPAMOptions{Driver: driverName},
-			Options:        map[string]interface{}{plugin.MulticastOption: "true"},
+			IPAM: docker.IPAMOptions{
+				Driver: driverName,
+				Config: []docker.IPAMConfig{{Subnet: subnet}},
+			},
+			Options: map[string]interface{}{plugin.MulticastOption: "true"},
 		})
 	if err != docker.ErrNetworkAlreadyExists && err != nil {
 		// Despite appearances to the contrary, CreateNetwork does

--- a/weave
+++ b/weave
@@ -1782,7 +1782,8 @@ launch_plugin_if_not_running() {
         return 1
     fi
     wait_for_status $PLUGIN_CONTAINER_NAME http_call_unix $PLUGIN_CONTAINER_NAME status.sock
-    util_op create-plugin-network weave weavemesh
+    WEAVE_IPAM_SUBNET=$(call_weave GET /ipinfo/defaultsubnet)
+    util_op create-plugin-network weave weavemesh $WEAVE_IPAM_SUBNET
 }
 
 plugin_disabled() {


### PR DESCRIPTION
Fixes #2469.

New behaviour in Docker 1.12 means it disregards a plugin-supplied address pool that overlaps an existing route. When we pass in the subnet, Docker believes we really do want that address range and avoids the hang.