### PR TITLE
Add weaveutil process-addrs

### DIFF
--- a/common/process.go
+++ b/common/process.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"os"
+	"strconv"
+)
+
+func AllPids(procRoot string) ([]int, error) {
+	fh, err := os.Open(procRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+	dirNames, err := fh.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+	pids := make([]int, len(dirNames))
+	for _, dirName := range dirNames {
+		pid, err := strconv.Atoi(dirName)
+		if err != nil { // Only interested in numeric entries - skip /proc/stat, etc.
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids, err
+}

--- a/prog/weaveutil/docker_tls_args.go
+++ b/prog/weaveutil/docker_tls_args.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/weaveworks/weave/common"
 )
 
 func dockerTLSArgs(args []string) error {
@@ -15,18 +17,14 @@ func dockerTLSArgs(args []string) error {
 		cmdUsage("docker-tls-args", "")
 	}
 	procRoot := "/proc"
-	dirEntries, err := ioutil.ReadDir(procRoot)
+	pids, err := common.AllPids(procRoot)
 	if err != nil {
 		return err
 	}
 
-	for _, dirEntry := range dirEntries {
-		dirName := dirEntry.Name()
-		if _, err := strconv.Atoi(dirName); err != nil {
-			continue
-		}
-
+	for _, pid := range pids {
 		isDaemon := false
+		dirName := strconv.Itoa(pid)
 		if comm, err := ioutil.ReadFile(filepath.Join(procRoot, dirName, "comm")); err != nil {
 			continue
 		} else if string(comm) == "dockerd\n" {

--- a/prog/weaveutil/main.go
+++ b/prog/weaveutil/main.go
@@ -20,6 +20,7 @@ func init() {
 		"create-plugin-network":  createPluginNetwork,
 		"remove-plugin-network":  removePluginNetwork,
 		"container-addrs":        containerAddrs,
+		"process-addrs":          processAddrs,
 		"attach-container":       attach,
 		"detach-container":       detach,
 	}

--- a/prog/weaveutil/proc-addrs.go
+++ b/prog/weaveutil/proc-addrs.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/weaveworks/weave/common"
+	weavenet "github.com/weaveworks/weave/net"
+)
+
+func processAddrs(args []string) error {
+	if len(args) < 1 {
+		cmdUsage("process-addrs", "<bridgeName>")
+	}
+	bridgeName := args[0]
+
+	pred, err := common.ConnectedToBridgePredicate(bridgeName)
+	if err != nil {
+		if err == weavenet.ErrLinkNotFound {
+			return nil
+		}
+		return err
+	}
+
+	pids, err := common.AllPids("/proc")
+	if err != nil {
+		return err
+	}
+
+	// NB: Because network namespaces (netns) are changed many times inside the loop,
+	//     it's NOT safe to exec any code depending on the root netns without
+	//     wrapping with WithNetNS*.
+	for _, pid := range pids {
+		netDevs, err := common.GetNetDevsWithPredicate(pid, pred)
+		if err != nil {
+			return err
+		}
+		printNetDevs(strconv.Itoa(pid), netDevs)
+	}
+	return nil
+}


### PR DESCRIPTION
Similar to weaveutil container-addrs, but for use in circumstances where we can't or don't want to talk to Docker.  E.g. weave-kube.