### PR TITLE
Log dropped policy controller traffic via NFLOG

### DIFF
--- a/weave
+++ b/weave
@@ -601,7 +601,7 @@ create_bridge() {
             # Steer traffic via the NPC
             run_iptables -N WEAVE-NPC >/dev/null 2>&1 || true
             add_iptables_rule filter FORWARD -o $BRIDGE -j WEAVE-NPC
-            add_iptables_rule filter FORWARD -o $BRIDGE -j LOG --log-prefix=WEAVE-NPC:
+            add_iptables_rule filter FORWARD -o $BRIDGE -m state --state NEW -j NFLOG --nflog-group 86
             add_iptables_rule filter FORWARD -o $BRIDGE -j DROP
         else
             # Work around the situation where there are no rules allowing traffic


### PR DESCRIPTION
Send blocked NEW connection attempts to NFLOG group 86 for accounting by the weave-npc process; required by weaveworks/weave-npc#7.