### PR TITLE
Merge weave-kube into the Weave Net repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ prog/weavewait/weavewait_noop
 prog/weavewait/weavewait_nomcast
 prog/weaveutil/weaveutil
 prog/*/Dockerfile.weaveworks
+prog/kube-peers/kube-peers
 prog/plugin/plugin
 testing/cover/cover
 testing/runner/runner

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ prog/weavewait/weavewait_nomcast
 prog/weaveutil/weaveutil
 prog/*/Dockerfile.weaveworks
 prog/kube-peers/kube-peers
+prog/weave-kube/kube-peers
 prog/plugin/plugin
 testing/cover/cover
 testing/runner/runner

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ prog/weavewait/weavewait
 prog/weavewait/weavewait_noop
 prog/weavewait/weavewait_nomcast
 prog/weaveutil/weaveutil
-prog/plugin/Dockerfile.*
+prog/*/Dockerfile.weaveworks
 prog/plugin/plugin
 testing/cover/cover
 testing/runner/runner

--- a/.gitmodules
+++ b/.gitmodules
@@ -103,3 +103,6 @@
 [submodule "vendor/github.com/matttproud/golang_protobuf_extensions"]
 	path = vendor/github.com/matttproud/golang_protobuf_extensions
 	url = https://github.com/matttproud/golang_protobuf_extensions
+[submodule "vendor/k8s.io/client-go"]
+	path = vendor/k8s.io/client-go
+	url = https://github.com/kubernetes/client-go

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ NETGO_CHECK=@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
 	echo "    sudo go install -tags netgo std"; \
 	false; \
 }
-BUILD_FLAGS=-i -ldflags "-extldflags \"-static\" -X main.version=$(WEAVE_VERSION)" -tags netgo
+BUILD_FLAGS=-i -ldflags "-linkmode external -extldflags -static -X main.version=$(WEAVE_VERSION)" -tags netgo
 
 PACKAGE_BASE=$(shell go list -e ./)
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ WEAVE_VERSION=git-$(shell git rev-parse --short=12 HEAD)
 WEAVER_EXE=prog/weaver/weaver
 WEAVEPROXY_EXE=prog/weaveproxy/weaveproxy
 SIGPROXY_EXE=prog/sigproxy/sigproxy
+KUBEPEERS_EXE=prog/kube-peers/kube-peers
 WEAVEWAIT_EXE=prog/weavewait/weavewait
 WEAVEWAIT_NOOP_EXE=prog/weavewait/weavewait_noop
 WEAVEWAIT_NOMCAST_EXE=prog/weavewait/weavewait_nomcast
@@ -24,7 +25,7 @@ PLUGIN_EXE=prog/plugin/plugin
 RUNNER_EXE=tools/runner/runner
 TEST_TLS_EXE=test/tls/tls
 
-EXES=$(WEAVER_EXE) $(SIGPROXY_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(WEAVEWAIT_NOMCAST_EXE) $(WEAVEUTIL_EXE) $(PLUGIN_EXE) $(TEST_TLS_EXE)
+EXES=$(WEAVER_EXE) $(SIGPROXY_EXE) $(KUBEPEERS_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(WEAVEWAIT_NOMCAST_EXE) $(WEAVEUTIL_EXE) $(PLUGIN_EXE) $(TEST_TLS_EXE)
 
 BUILD_UPTODATE=.build.uptodate
 WEAVER_UPTODATE=.weaver.uptodate
@@ -67,6 +68,7 @@ $(WEAVER_EXE): router/*.go ipam/*.go ipam/*/*.go db/*.go nameserver/*.go prog/we
 $(WEAVEPROXY_EXE): proxy/*.go prog/weaveproxy/*.go
 $(WEAVEUTIL_EXE): prog/weaveutil/*.go net/*.go
 $(SIGPROXY_EXE): prog/sigproxy/*.go
+$(KUBEPEERS_EXE): prog/kube-peers/*.go
 $(PLUGIN_EXE): prog/plugin/*.go plugin/*/*.go api/*.go common/*.go common/docker/*.go net/*.go
 $(TEST_TLS_EXE): test/tls/*.go
 $(WEAVEWAIT_NOOP_EXE): prog/weavewait/*.go
@@ -99,7 +101,7 @@ else
 endif
 	$(NETGO_CHECK)
 
-$(WEAVEUTIL_EXE):
+$(WEAVEUTIL_EXE) $(KUBEPEERS_EXE):
 	go build $(BUILD_FLAGS) -o $@ ./$(@D)
 	$(NETGO_CHECK)
 

--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,8 @@ $(BUILD_UPTODATE): build/*
 %/Dockerfile.$(DOCKERHUB_USER): %/Dockerfile.template
 	sed -e "s/DOCKERHUB_USER/$(DOCKERHUB_USER)/" $^ > $@
 
-$(WEAVER_UPTODATE): prog/weaver/Dockerfile $(WEAVER_EXE)
-	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -t $(WEAVER_IMAGE) prog/weaver
+$(WEAVER_UPTODATE): prog/weaver/Dockerfile.$(DOCKERHUB_USER) $(WEAVER_EXE) $(WEAVEEXEC_UPTODATE)
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -f prog/weaver/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVER_IMAGE) prog/weaver
 	touch $@
 
 $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile prog/weaveexec/symlink $(DOCKER_DISTRIB) weave $(SIGPROXY_EXE) $(WEAVEPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(WEAVEWAIT_NOMCAST_EXE) $(WEAVEUTIL_EXE)
@@ -147,7 +147,7 @@ $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile prog/weaveexec/symlink $(DOCKER
 	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -t $(WEAVEEXEC_IMAGE) prog/weaveexec
 	touch $@
 
-$(PLUGIN_UPTODATE): prog/plugin/Dockerfile.$(DOCKERHUB_USER) $(PLUGIN_EXE) $(WEAVEEXEC_UPTODATE)
+$(PLUGIN_UPTODATE): prog/plugin/Dockerfile.$(DOCKERHUB_USER) $(PLUGIN_EXE) $(WEAVER_UPTODATE)
 	$(SUDO) docker build -f prog/plugin/Dockerfile.$(DOCKERHUB_USER) -t $(PLUGIN_IMAGE) prog/plugin
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PUBLISH=publish_weave publish_weaveexec publish_plugin
+PUBLISH=publish_weave publish_weaveexec publish_plugin publish_weave-kube
 
 .DEFAULT: all
 .PHONY: all exes testrunner update tests lint publish $(PUBLISH) clean clean-bin prerequisites build run-smoketests
@@ -31,17 +31,19 @@ BUILD_UPTODATE=.build.uptodate
 WEAVER_UPTODATE=.weaver.uptodate
 WEAVEEXEC_UPTODATE=.weaveexec.uptodate
 PLUGIN_UPTODATE=.plugin.uptodate
+WEAVEKUBE_UPTODATE=.weavekube.uptodate
 WEAVEDB_UPTODATE=.weavedb.uptodate
 
-IMAGES_UPTODATE=$(WEAVER_UPTODATE) $(WEAVEEXEC_UPTODATE) $(PLUGIN_UPTODATE) $(WEAVEDB_UPTODATE)
+IMAGES_UPTODATE=$(WEAVER_UPTODATE) $(WEAVEEXEC_UPTODATE) $(PLUGIN_UPTODATE) $(WEAVEKUBE_UPTODATE) $(WEAVEDB_UPTODATE)
 
 WEAVER_IMAGE=$(DOCKERHUB_USER)/weave
 WEAVEEXEC_IMAGE=$(DOCKERHUB_USER)/weaveexec
 PLUGIN_IMAGE=$(DOCKERHUB_USER)/plugin
+WEAVEKUBE_IMAGE=$(DOCKERHUB_USER)/weave-kube
 BUILD_IMAGE=$(DOCKERHUB_USER)/weavebuild
 WEAVEDB_IMAGE=$(DOCKERHUB_USER)/weavedb
 
-IMAGES=$(WEAVER_IMAGE) $(WEAVEEXEC_IMAGE) $(PLUGIN_IMAGE) $(WEAVEDB_IMAGE)
+IMAGES=$(WEAVER_IMAGE) $(WEAVEEXEC_IMAGE) $(PLUGIN_IMAGE) $(WEAVEKUBE_IMAGE) $(WEAVEDB_IMAGE)
 
 WEAVE_EXPORT=weave.tar.gz
 
@@ -151,6 +153,11 @@ $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile prog/weaveexec/symlink $(DOCKER
 
 $(PLUGIN_UPTODATE): prog/plugin/Dockerfile.$(DOCKERHUB_USER) $(PLUGIN_EXE) $(WEAVER_UPTODATE)
 	$(SUDO) docker build -f prog/plugin/Dockerfile.$(DOCKERHUB_USER) -t $(PLUGIN_IMAGE) prog/plugin
+	touch $@
+
+$(WEAVEKUBE_UPTODATE): prog/weave-kube/Dockerfile.$(DOCKERHUB_USER) $(KUBEPEERS_EXE) $(PLUGIN_UPTODATE)
+	cp $(KUBEPEERS_EXE) prog/weave-kube/
+	$(SUDO) docker build -f prog/weave-kube/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVEKUBE_IMAGE) prog/weave-kube
 	touch $@
 
 $(WEAVEDB_UPTODATE): prog/weavedb/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ $(BUILD_UPTODATE): build/*
 	$(SUDO) docker build -t $(BUILD_IMAGE) build/
 	touch $@
 
+%/Dockerfile.$(DOCKERHUB_USER): %/Dockerfile.template
+	sed -e "s/DOCKERHUB_USER/$(DOCKERHUB_USER)/" $^ > $@
+
 $(WEAVER_UPTODATE): prog/weaver/Dockerfile $(WEAVER_EXE)
 	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -t $(WEAVER_IMAGE) prog/weaver
 	touch $@
@@ -143,9 +146,6 @@ $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile prog/weaveexec/symlink $(DOCKER
 	cp $(DOCKER_DISTRIB) prog/weaveexec/docker.tgz
 	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -t $(WEAVEEXEC_IMAGE) prog/weaveexec
 	touch $@
-
-prog/plugin/Dockerfile.$(DOCKERHUB_USER): prog/plugin/Dockerfile.template
-	sed -e "s/DOCKERHUB_USER/$(DOCKERHUB_USER)/" $^ > $@
 
 $(PLUGIN_UPTODATE): prog/plugin/Dockerfile.$(DOCKERHUB_USER) $(PLUGIN_EXE) $(WEAVEEXEC_UPTODATE)
 	$(SUDO) docker build -f prog/plugin/Dockerfile.$(DOCKERHUB_USER) -t $(PLUGIN_IMAGE) prog/plugin

--- a/bin/release
+++ b/bin/release
@@ -157,7 +157,21 @@ draft() {
         --name "weave" \
         --file "./weave"
 
+    github-release release $RELEASE_ARGS \
+        --user $GITHUB_USER \
+        --repo weave-kube \
+        --tag $LATEST_TAG \
+        --name "$RELEASE_NAME $VERSION" \
+        --description "$RELEASE_DESCRIPTION"
+
     sed -i -e s/:latest/:$VERSION/ -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset.yaml
+    github-release upload \
+        --user $GITHUB_USER \
+        --repo weave-kube \
+        --tag $LATEST_TAG \
+        --name "weave-daemonset.yaml" \
+        --file "./prog/weave-kube/weave-daemonset.yaml"
+
     github-release upload \
         --user $GITHUB_USER \
         --repo weave \
@@ -243,6 +257,33 @@ publish() {
             --tag latest_release \
             --name "weave" \
             --file "./weave"
+
+        github-release publish \
+            --user $GITHUB_USER \
+            --repo weave-kube \
+            --tag $LATEST_TAG
+
+        if github-release info --user $GITHUB_USER --repo weave-kube \
+            --tag latest_release >/dev/null 2>&1; then
+            github-release delete \
+                --user $GITHUB_USER \
+                --repo weave-kube \
+                --tag latest_release
+        fi
+
+        github-release release \
+            --user $GITHUB_USER \
+            --repo weave-kube \
+            --tag latest_release \
+            --name "$RELEASE_NAME latest ($VERSION)" \
+            --description "[Release Notes](https://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG)"
+
+        github-release upload \
+            --user $GITHUB_USER \
+            --repo weave-kube \
+            --tag latest_release \
+            --name "weave-daemonset.yaml" \
+            --file "./prog/weave-kube/weave-daemonset.yaml"
 
         github-release upload \
             --user $GITHUB_USER \

--- a/bin/release
+++ b/bin/release
@@ -157,6 +157,14 @@ draft() {
         --name "weave" \
         --file "./weave"
 
+    sed -i -e s/:latest/:$VERSION/ -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset.yaml
+    github-release upload \
+        --user $GITHUB_USER \
+        --repo weave \
+        --tag $LATEST_TAG \
+        --name "weave-daemonset.yaml" \
+        --file "./prog/weave-kube/weave-daemonset.yaml"
+
     echo "** Draft $TYPE $RELEASE_NAME $VERSION created at"
     echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG"
 }
@@ -235,6 +243,13 @@ publish() {
             --tag latest_release \
             --name "weave" \
             --file "./weave"
+
+        github-release upload \
+            --user $GITHUB_USER \
+            --repo weave \
+            --tag latest_release \
+            --name "weave-daemonset.yaml" \
+            --file "./prog/weave-kube/weave-daemonset.yaml"
 
         echo "** Release $RELEASE_NAME $VERSION published at"
         echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -107,6 +107,15 @@ the build script will complain otherwise.
 N.B. if you're testing the release process, push to your fork
 instead!
 
+While the git.io link for weave-kube is still pointing to the
+weave-kube repository, we also need to update the tag there:
+
+    cd ../weave-kube
+    git tag -a -m "Release $TAG" $TAG
+    git tag -af -m "Release $TAG" latest_release $TAG
+    git push -f git@github.com:weaveworks/weave latest_release
+
+
 ### Publish Release & Distributable Artefacts
 
 You can now publish the release and upload the remaining

--- a/prog/kube-peers/main.go
+++ b/prog/kube-peers/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"k8s.io/client-go/1.4/kubernetes"
+	"k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/1.4/rest"
+)
+
+func getKubePeers() ([]string, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	nodeList, err := c.Nodes().List(api.ListOptions{})
+	if err != nil {
+		// Fallback for cases (e.g. from kube-up.sh) where kube-proxy is not running on master
+		config.Host = "http://localhost:8080"
+		log.Print("error contacting APIServer: ", err, "; trying with fallback: ", config.Host)
+		c, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		nodeList, err = c.Nodes().List(api.ListOptions{})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	addresses := make([]string, 0, len(nodeList.Items))
+	for _, peer := range nodeList.Items {
+		for _, addr := range peer.Status.Addresses {
+			if addr.Type == "InternalIP" {
+				addresses = append(addresses, addr.Address)
+			}
+		}
+	}
+	return addresses, nil
+}
+
+func main() {
+	peers, err := getKubePeers()
+	if err != nil {
+		log.Fatalf("Could not get peers: %v", err)
+	}
+	for _, addr := range peers {
+		fmt.Println(addr)
+	}
+}

--- a/prog/plugin/Dockerfile.template
+++ b/prog/plugin/Dockerfile.template
@@ -1,3 +1,3 @@
-FROM DOCKERHUB_USER/weaveexec
+FROM DOCKERHUB_USER/weave
 ADD ./plugin /home/weave/
 ENTRYPOINT ["/home/weave/plugin"]

--- a/prog/weave-kube/Dockerfile.template
+++ b/prog/weave-kube/Dockerfile.template
@@ -1,0 +1,3 @@
+FROM DOCKERHUB_USER/plugin
+ADD ./launch.sh ./kube-peers /home/weave/
+ENTRYPOINT ["/home/weave/launch.sh"]

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+
+set -e
+
+# Default if not supplied - same as weave net default
+IPALLOC_RANGE=${IPALLOC_RANGE:-10.32.0.0/12}
+HTTP_ADDR=${WEAVE_HTTP_ADDR:-127.0.0.1:6784}
+
+# kube-proxy requires that bridged traffic passes through netfilter
+if [ ! -f /proc/sys/net/bridge/bridge-nf-call-iptables ] ; then
+    echo /proc/sys/net/bridge/bridge-nf-call-iptables not found >&2
+    exit 1
+fi
+
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
+
+# Create CNI config, if not already there
+if [ ! -f /etc/cni/net.d/10-weave.conf ] ; then
+    mkdir -p /etc/cni/net.d
+    cat > /etc/cni/net.d/10-weave.conf <<EOF
+{
+    "name": "weave",
+    "type": "weave-net"
+}
+EOF
+fi
+
+install_cni_plugin() {
+    mkdir -p $1 || return 1
+    cp /home/weave/plugin $1/weave-net
+    cp /home/weave/plugin $1/weave-ipam
+}
+
+# Install CNI plugin binary to typical CNI bin location
+# with fall-back to CNI directory used by kube-up on GCI OS
+if [ ! -f /opt/cni/bin/weave-net ] ; then
+    if ! install_cni_plugin /opt/cni/bin ; then
+        install_cni_plugin /host_home/kubernetes/bin
+    fi
+fi
+
+# Need to create bridge before running weaver so we can use the peer address
+# (because of https://github.com/weaveworks/weave/issues/2480)
+/home/weave/weave --local create-bridge --force --expect-npc
+
+# Kubernetes sets HOSTNAME to the host's hostname
+# when running a pod in host namespace.
+NICKNAME_ARG=""
+if [ -n "$HOSTNAME" ] ; then
+    NICKNAME_ARG="--nickname=$HOSTNAME"
+fi
+
+BRIDGE_OPTIONS="--datapath=datapath"
+if [ "$(/home/weave/weave --local bridge-type)" = "bridge" ] ; then
+    # TODO: Call into weave script to do this
+    if ! ip link show vethwe-pcap >/dev/null 2>&1 ; then
+        ip link add name vethwe-bridge type veth peer name vethwe-pcap
+        ip link set vethwe-bridge up
+        ip link set vethwe-pcap up
+        ip link set vethwe-bridge master weave
+    fi
+    BRIDGE_OPTIONS="--iface=vethwe-pcap"
+fi
+
+if [ -z "$KUBE_PEERS" ]; then
+    if ! KUBE_PEERS=$(/home/weave/kube-peers) || [ -z "$KUBE_PEERS" ]; then
+        echo Failed to get peers >&2
+        exit 1
+    fi
+fi
+
+peer_count() {
+    echo $#
+}
+
+if [ -z "$IPALLOC_INIT" ]; then
+    IPALLOC_INIT="consensus=$(peer_count $KUBE_PEERS)"
+fi
+
+/home/weave/weaver --port=6783 $BRIDGE_OPTIONS \
+     --http-addr=127.0.0.1:6784 --docker-api='' --no-dns \
+     --ipalloc-range=$IPALLOC_RANGE $NICKNAME_ARG \
+     --ipalloc-init $IPALLOC_INIT \
+     --name=$(cat /sys/class/net/weave/address) "$@" \
+     $KUBE_PEERS &
+WEAVE_PID=$!
+
+# Wait for weave process to become responsive
+while true ; do
+    curl $HTTP_ADDR/status >/dev/null 2>&1 && break
+    if ! kill -0 $WEAVE_PID >/dev/null 2>&1 ; then
+        echo Weave process has died >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+reclaim_ips() {
+    ID=$1
+    shift
+    for CIDR in "$@" ; do
+        curl -s -S -X PUT "$HTTP_ADDR/ip/$ID/$CIDR" || true
+    done
+}
+
+# Tell the newly-started weave about existing weave bridge IPs
+/usr/bin/weaveutil container-addrs weave weave:expose | while read ID IFACE MAC IPS; do
+    reclaim_ips "weave:expose" $IPS
+done
+# Tell weave about existing weave process IPs
+/usr/bin/weaveutil process-addrs weave | while read ID IFACE MAC IPS; do
+    reclaim_ips "_" $IPS
+done
+
+# Expose the weave network so host processes can communicate with pods
+/home/weave/weave --local expose $WEAVE_EXPOSE_IP
+
+wait $WEAVE_PID

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -1,0 +1,70 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        name: weave-net
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [
+            {
+              "key": "dedicated",
+              "operator": "Equal",
+              "value": "master",
+              "effect": "NoSchedule"
+            }
+          ]
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: weave
+          image: weaveworks/weave-kube:latest
+          imagePullPolicy: Always
+          command:
+            - /home/weave/launch.sh
+          livenessProbe:
+            initialDelaySeconds: 30
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 6784
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: weavedb
+              mountPath: /weavedb
+            - name: cni-bin
+              mountPath: /opt
+            - name: cni-bin2
+              mountPath: /host_home
+            - name: cni-conf
+              mountPath: /etc
+          resources:
+            requests:
+              cpu: 10m
+        - name: weave-npc
+          image: weaveworks/weave-npc:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 10m
+          securityContext:
+            privileged: true
+      restartPolicy: Always
+      volumes:
+        - name: weavedb
+          emptyDir: {}
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-bin2
+          hostPath:
+            path: /home
+        - name: cni-conf
+          hostPath:
+            path: /etc

--- a/prog/weaver/Dockerfile.template
+++ b/prog/weaver/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM scratch
+FROM DOCKERHUB_USER/weaveexec
 MAINTAINER Weaveworks Inc <help@weave.works>
 LABEL works.weave.role=system
 WORKDIR /home/weave


### PR DESCRIPTION
This PR brings in code and artefacts from the https://github.com/weaveworks/weave-kube repo.

It also re-arranges the Docker image dependencies. Previously we had:

```
scratch <- weave
scratch <- alpine <- weaveexec <- plugin
```

Now we have:

```
scratch <- alpine <- weaveexec <- weave <- plugin <- weave-kube
```

This ensures that `weave-kube` has the `weaver` and `plugin` files it needs, while avoiding any double-copying of binaries.  It does mean that the `weave` container looks much bigger than before.

Note that `kube-peers` is kept as a separate executable rather than merging into `weaveutils`, since it would make the `weaveutils` binary 4x larger and hence (probably) slower to start up. 
