### PR TITLE
Use 'bash' image instead of 'weaveworks/ubuntu'

### DIFF
--- a/site/faq.md
+++ b/site/faq.md
@@ -91,14 +91,6 @@ You must permit traffic to flow through TCP 6783 and UDP 6783/6784,
 which are Weave’s control and data ports.
 
 
-**<a name=own-image></a>Q: Why do you use your own Docker image `weaveworks/ubuntu`?**
-
-The official Ubuntu image does not contain the `ping` and `nc`
-commands which are used in many of our examples throughout the
-documentation. The `weaveworks/ubuntu` image is simply the official
-Ubuntu image with those two commands added.
-
-
 **See Also**
 
  * [Troubleshooting Weave](/site/troubleshooting.md)

--- a/site/features.md
+++ b/site/features.md
@@ -81,7 +81,7 @@ See [Integrating Docker via the API Proxy](/site/weave-docker-api.md).
 Weave Net can also be used as a [Docker plugin](https://docs.docker.com/engine/extend/plugins_network/).  A Docker network 
 named `weave` is created by `weave launch`, which is used as follows:
 
-    $ docker run --net=weave -ti weaveworks/ubuntu
+    $ docker run --net=weave -ti bash
 
 Using the Weave plugin enables you to take advantage of [Docker's network functionality](https://docs.docker.com/engine/extend/plugins_network/).
 
@@ -114,8 +114,8 @@ For a discussion on how Weave Net uses IPAM, see [Automatic IP Address Managemen
 Named containers are automatically registered in [weaveDNS](/site/weavedns.md), 
 and are discoverable by using standard, simple name lookups:
 
-    host1$ docker run -dti --name=service weaveworks/ubuntu
-    host1$ docker run -ti weaveworks/ubuntu
+    host1$ docker run -dti --name=service bash
+    host1$ docker run -ti bash
     root@7b21498fb103:/# ping service
 
 WeaveDNS also supports [load balancing](/site/weavedns/load-balance-fault-weavedns.md), [fault resilience](/site/weavedns/load-balance-fault-weavedns.md) and [hot swapping](/site/weavedns/managing-entries-weavedns.md). 

--- a/site/ipam/allocation-multi-ipam.md
+++ b/site/ipam/allocation-multi-ipam.md
@@ -15,13 +15,13 @@ allocation of an address from a particular subnet, set the
 `WEAVE_CIDR` environment variable to `net:<subnet>` when creating the
 container, for example:
 
-    host1$ docker run -e WEAVE_CIDR=net:10.2.7.0/24 -ti weaveworks/ubuntu
+    host1$ docker run -e WEAVE_CIDR=net:10.2.7.0/24 -ti bash
 
 You can ask for multiple addresses in different subnets and add in
 manually-assigned addresses (outside the automatic allocation range),
 for instance:
 
-    host1$ docker run -e WEAVE_CIDR="net:10.2.7.0/24 net:10.2.8.0/24 ip:10.3.9.1/24" -ti weaveworks/ubuntu
+    host1$ docker run -e WEAVE_CIDR="net:10.2.7.0/24 net:10.2.8.0/24 ip:10.3.9.1/24" -ti bash
 
 >**Note:** The ".0" and ".-1" addresses in a subnet are not used, as required by
 [RFC 1122](https://tools.ietf.org/html/rfc1122#page-29)).

--- a/site/plugin.md
+++ b/site/plugin.md
@@ -20,7 +20,7 @@ See [Using Weave Net](/site/using-weave.md#peer-connections) for a discussion on
 
 After you've launched Weave Net and peered your hosts,  you can start containers using the following, for example:
 
-    $ docker run --net=weave -ti weaveworks/ubuntu
+    $ docker run --net=weave -ti bash
 
 on any of the hosts, and they can all communicate with each other
 using any protocol, even multicast.
@@ -29,8 +29,8 @@ In order to use Weave Net's [Service Discovery](/site/weavedns.md) you
 must pass the additional arguments `--dns` and `-dns-search`, for
 which a helper is provided in the Weave script:
 
-    $ docker run --net=weave -h foo.weave.local $(weave dns-args) -tdi weaveworks/ubuntu
-    $ docker run --net=weave -h bar.weave.local $(weave dns-args) -ti weaveworks/ubuntu
+    $ docker run --net=weave -h foo.weave.local $(weave dns-args) -tdi bash
+    $ docker run --net=weave -h bar.weave.local $(weave dns-args) -ti bash
     # ping foo
 
 
@@ -43,11 +43,11 @@ Just launch the Weave Net router onto each host and make a peer connection with 
 
 then run your containers using the Docker command-line:
 
-    host1$ docker run --net=weave -ti weaveworks/ubuntu
+    host1$ docker run --net=weave -ti bash
     root@1458e848cd90:/# hostname -i
     10.32.0.2
 
-    host2$ docker run --net=weave -ti weaveworks/ubuntu
+    host2$ docker run --net=weave -ti bash
     root@8cc4b5dc5722:/# ping 10.32.0.2
 
     PING 10.32.0.2 (10.32.0.2) 56(84) bytes of data.

--- a/site/using-weave.md
+++ b/site/using-weave.md
@@ -21,7 +21,7 @@ On `$HOST1` run:
 
     host1$ weave launch
     host1$ eval $(weave env)
-    host1$ docker run --name a1 -ti weaveworks/ubuntu
+    host1$ docker run --name a1 -ti bash
 
 Where, 
 
@@ -44,7 +44,7 @@ Where,
 > host1$ sudo -s
 > host1# weave launch
 > host1# eval $(weave env)
-> host1# docker run --name a1 -ti weaveworks/ubuntu
+> host1# docker run --name a1 -ti bash
 > ```
 > Do *not* prefix individual commands with `sudo`, since some commands
 > modify environment entries and hence they all need to be executed from
@@ -63,7 +63,7 @@ To launch Weave Net on an additional host and create a peer connection, run the 
 
     host2$ weave launch $HOST1
     host2$ eval $(weave env)
-    host2$ docker run --name a2 -ti weaveworks/ubuntu
+    host2$ docker run --name a2 -ti bash
 
 As noted above, the same steps are repeated for `$HOST2`. The only difference, besides the application container’s name, is that `$HOST2` is told to peer with Weave Net on `$HOST1` during launch. 
 

--- a/site/using-weave/application-isolation.md
+++ b/site/using-weave/application-isolation.md
@@ -26,13 +26,13 @@ specified.
 
 Next, launch the two netcat containers onto the default subnet:
 
-    host1$ docker run --name a1 -ti weaveworks/ubuntu
-    host2$ docker run --name a2 -ti weaveworks/ubuntu
+    host1$ docker run --name a1 -ti bash
+    host2$ docker run --name a2 -ti bash
 
 And then to test the isolation, launch a few more containers onto a different subnet:
 
-    host1$ docker run -e WEAVE_CIDR=net:10.2.2.0/24 --name b1 -ti weaveworks/ubuntu
-    host2$ docker run -e WEAVE_CIDR=net:10.2.2.0.24 --name b2 -ti weaveworks/ubuntu
+    host1$ docker run -e WEAVE_CIDR=net:10.2.2.0/24 --name b1 -ti bash
+    host2$ docker run -e WEAVE_CIDR=net:10.2.2.0.24 --name b2 -ti bash
 
 Ping each container to confirm that they can talk to each other, but not to the containers of our first subnet:
 
@@ -54,7 +54,7 @@ Ping each container to confirm that they can talk to each other, but not to the 
 
 If required, a container can also be attached to multiple subnets when it is started using:
 
-    host1$ docker run -e WEAVE_CIDR="net:default net:10.2.2.0/24" -ti weaveworks/ubuntu
+    host1$ docker run -e WEAVE_CIDR="net:default net:10.2.2.0/24" -ti bash
 
 `net:default` is used to request the allocation of an address from the default subnet in addition to one from an explicitly specified range.
 

--- a/site/using-weave/dynamically-attach-containers.md
+++ b/site/using-weave/dynamically-attach-containers.md
@@ -8,13 +8,13 @@ When containers may not know the network to which they will be attached, Weave N
 
 To illustrate...
 
-    host1$ C=$(docker run -e WEAVE_CIDR=none -dti weaveworks/ubuntu)
+    host1$ C=$(docker run -e WEAVE_CIDR=none -dti bash)
     host1$ weave attach $C
     10.2.1.3
 
 where,
 
- *  `C=$(docker run -e WEAVE_CIDR=none -dti weaveworks/ubuntu)` starts a container and assigns its ID to a variable
+ *  `C=$(docker run -e WEAVE_CIDR=none -dti bash)` starts a container and assigns its ID to a variable
  *  `weave attach` – the Weave Net command to attach to the specified container
  *  `10.2.1.3` - the allocated IP address output by `weave attach`, in this case in the default subnet
 

--- a/site/using-weave/manual-ip-address.md
+++ b/site/using-weave/manual-ip-address.md
@@ -21,12 +21,12 @@ For example, we can launch a couple of containers on `$HOST1` and
 
 On `$HOST1`:
 
-    host1$ docker run -e WEAVE_CIDR=10.2.1.1/24 -ti weaveworks/ubuntu
+    host1$ docker run -e WEAVE_CIDR=10.2.1.1/24 -ti bash
     root@7ca0f6ecf59f:/#
 
 And `$HOST2`:
 
-    host2$ docker run -e WEAVE_CIDR=10.2.1.2/24 -ti weaveworks/ubuntu
+    host2$ docker run -e WEAVE_CIDR=10.2.1.2/24 -ti bash
     root@04c4831fafd3:/#
 
 Then test that the container on `$HOST2` can be reached from the container on `$HOST1`:

--- a/site/weave-docker-api/automatic-discovery-proxy.md
+++ b/site/weave-docker-api/automatic-discovery-proxy.md
@@ -37,7 +37,7 @@ For example, you can launch the proxy using all three flags, as follows:
 
 After launching the Weave Net proxy with these flags, running a container named `aws-12798186823-foo` without labels results in weaveDNS registering the hostname `my-app-foo` and not `aws-12798186823-foo`.
 
-    host1$ docker run -ti --name=aws-12798186823-foo weaveworks/ubuntu ping my-app-foo
+    host1$ docker run -ti --name=aws-12798186823-foo bash ping my-app-foo
     PING my-app-foo.weave.local (10.32.0.2) 56(84) bytes of data.
     64 bytes from my-app-foo.weave.local (10.32.0.2): icmp_seq=1 ttl=64 time=0.027 ms
     64 bytes from my-app-foo.weave.local (10.32.0.2): icmp_seq=2 ttl=64 time=0.067 ms
@@ -45,7 +45,7 @@ After launching the Weave Net proxy with these flags, running a container named 
 Also, running a container named `foo` with the label
 `hostname-label=aws-12798186823-foo` leads to the same hostname registration.
 
-    host1$ docker run -ti --name=foo --label=hostname-label=aws-12798186823-foo weaveworks/ubuntu ping my-app-foo
+    host1$ docker run -ti --name=foo --label=hostname-label=aws-12798186823-foo bash ping my-app-foo
     PING my-app-foo.weave.local (10.32.0.2) 56(84) bytes of data.
     64 bytes from my-app-foo.weave.local (10.32.0.2): icmp_seq=1 ttl=64 time=0.031 ms
     64 bytes from my-app-foo.weave.local (10.32.0.2): icmp_seq=2 ttl=64 time=0.042 ms

--- a/site/weave-docker-api/ipam-proxy.md
+++ b/site/weave-docker-api/ipam-proxy.md
@@ -8,16 +8,16 @@ If [automatic IP address allocation](/site/ipam.md) is enabled in Weave Net (by 
 then containers started via the proxy are automatically assigned an IP address, *without having to specify any
 special environment variables or any other options*.
 
-    host1$ docker run -ti weaveworks/ubuntu
+    host1$ docker run -ti bash
 
 To use a specific subnet, you can pass a `WEAVE_CIDR` to the container, for example:
 
-    host1$ docker run -ti -e WEAVE_CIDR=net:10.32.2.0/24 weaveworks/ubuntu
+    host1$ docker run -ti -e WEAVE_CIDR=net:10.32.2.0/24 bash
 
 To start a container without connecting it to the Weave network, pass
 `WEAVE_CIDR=none`, for example:
 
-    host1$ docker run -ti -e WEAVE_CIDR=none weaveworks/ubuntu
+    host1$ docker run -ti -e WEAVE_CIDR=none bash
 
 ###Disabling Automatic IP Address Allocation
 
@@ -33,7 +33,7 @@ Containers started with a `WEAVE_CIDR` environment variable are handled as befor
 To automatically assign an address in this mode, start the
 container with a blank `WEAVE_CIDR`, for example:
 
-    host1$ docker run -ti -e WEAVE_CIDR="" weaveworks/ubuntu
+    host1$ docker run -ti -e WEAVE_CIDR="" bash
     
 **See Also**
 

--- a/site/weave-docker-api/launching-without-proxy.md
+++ b/site/weave-docker-api/launching-without-proxy.md
@@ -7,7 +7,7 @@ menu_order: 50
 If you don't want to use the proxy, you can also launch
 containers on to the Weave network using `weave run`:
 
-    $ weave run -ti weaveworks/ubuntu
+    $ weave run -ti bash
 
 The arguments after `run` are passed through to `docker run`. Therefore you
 can freely specify whatever Docker options you need. 
@@ -17,14 +17,14 @@ this example, it obtains an automatically allocated IP.
 
 You can specify IP addresses manually instead:
 
-    $ weave run 10.2.1.1/24 -ti weaveworks/ubuntu
+    $ weave run 10.2.1.1/24 -ti bash
 
 `weave run` rewrites `/etc/hosts` in the same way
 [the proxy does](/site/weave-docker-api/name-resolution-proxy.md). If you need to keep
 the original file, specify `--no-rewrite-hosts` when running
 the container:
 
-    $ weave run --no-rewrite-hosts 10.2.1.1/24 -ti weaveworks/ubuntu
+    $ weave run --no-rewrite-hosts 10.2.1.1/24 -ti bash
 
 There are some limitations to starting containers using `weave run`:
 

--- a/site/weave-docker-api/using-proxy.md
+++ b/site/weave-docker-api/using-proxy.md
@@ -16,17 +16,17 @@ Weave network.
 
 To create and start a container via the Weave Net proxy run:
 
-    host1$ docker run -ti weaveworks/ubuntu
+    host1$ docker run -ti bash
 
 or, equivalently run:
 
-    host1$ docker create -ti --name=foo weaveworks/ubuntu
+    host1$ docker create -ti --name=foo bash
     host1$ docker start foo
 
 Specific IP addresses and networks can be supplied in the `WEAVE_CIDR`
 environment variable, for example:
 
-    host1$ docker run -e WEAVE_CIDR=10.2.1.1/24 -ti weaveworks/ubuntu
+    host1$ docker run -e WEAVE_CIDR=10.2.1.1/24 -ti bash
 
 Multiple IP addresses and networks can be supplied in the `WEAVE_CIDR`
 variable by space-separating them, as in

--- a/site/weavedns.md
+++ b/site/weavedns.md
@@ -27,9 +27,9 @@ resolution, and will register themselves if they either have a
 hostname in the weaveDNS domain (`weave.local` by default) or are given an explicit container name:
 
 ```
-host1$ docker run -dti --name=pingme weaveworks/ubuntu
-host1$ docker run -ti  --hostname=ubuntu.weave.local weaveworks/ubuntu
-root@ubuntu:/# ping pingme
+host1$ docker run -dti --name=pingme bash
+host1$ docker run -ti  --hostname=bash.weave.local bash
+bash-4.4# ping pingme
 ...
 ```
 

--- a/site/weavedns/load-balance-fault-weavedns.md
+++ b/site/weavedns/load-balance-fault-weavedns.md
@@ -15,18 +15,18 @@ some ping tests.
 ```
 host2$ weave launch $HOST1
 host2$ eval $(weave env)
-host2$ docker run -dti --name=pingme weaveworks/ubuntu
+host2$ docker run -dti --name=pingme bash
 
-root@ubuntu:/# ping -nq -c 1 pingme
+bash-4.4# ping -nq -c 1 pingme
 PING pingme.weave.local (10.32.0.2) 56(84) bytes of data.
 ...
-root@ubuntu:/# ping -nq -c 1 pingme
+bash-4.4# ping -nq -c 1 pingme
 PING pingme.weave.local (10.40.0.1) 56(84) bytes of data.
 ...
-root@ubuntu:/# ping -nq -c 1 pingme
+bash-4.4# ping -nq -c 1 pingme
 PING pingme.weave.local (10.40.0.1) 56(84) bytes of data.
 ...
-root@ubuntu:/# ping -nq -c 1 pingme
+bash-4.4# ping -nq -c 1 pingme
 PING pingme.weave.local (10.32.0.2) 56(84) bytes of data.
 ...
 ```

--- a/site/weavedns/managing-domains-weavedns.md
+++ b/site/weavedns/managing-domains-weavedns.md
@@ -25,7 +25,7 @@ behaviour.
 docker run -ti \
   --dns-search=zone1.weave.local --dns-search=zone2.weave.local \
   --dns-search=corp1.com --dns-search=corp2.com \
-  --dns-search=weave.local weaveworks/ubuntu
+  --dns-search=weave.local bash
 ```
 
 ## <a name="local-domain"></a>Using a different local domain

--- a/site/weavedns/managing-entries-weavedns.md
+++ b/site/weavedns/managing-entries-weavedns.md
@@ -20,7 +20,7 @@ If you want to give the container a name in DNS *other* than its
 hostname, you can register it using the `dns-add` command. For example:
 
 ```
-$ C=$(docker run -ti weaveworks/ubuntu)
+$ C=$(docker run -ti bash)
 $ weave dns-add $C -h pingme2.weave.local
 ```
 


### PR DESCRIPTION
`bash` is `alpine` with the bash shell added.

I'm not entirely happy about the change: the default bash prompt is different from the alpine `sh` prompt, in that it doesn't show the hostname, and this removes some information from some of the examples.

`weaveworks/ubuntu` has a different `nc`, but it looks like all the examples are specified to work the same on `alpine`
