### PR TITLE
Fixed broken link to plugin.md to weave-docker-api.md.

### DIFF
--- a/site/weave-docker-api.md
+++ b/site/weave-docker-api.md
@@ -28,7 +28,7 @@ Docker containers are started with the --net flag, for example:
 
 Note that if a Docker container is started with the --net flag, then the Weave Docker API Proxy
 is automatically disabled and is not used to attach containers. 
-See [Integrating Docker via the Network Plugin](plugin.md).
+See [Integrating Docker via the Network Plugin](/site/plugin.md).
 
 **3.** Containers can also be attached to the Weave network with `weave run` commands. This method also
 does not use the Weave Docker API Proxy. 


### PR DESCRIPTION
On https://www.weave.works/docs/net/latest/weave-docker-api/

> Note that if a Docker container is started with the –net flag, then the Weave Docker API Proxy is automatically disabled and is not used to attach containers. See Integrating Docker via the Network Plugin.

has a dead link to https://www.weave.works/docs/net/latest/weave-docker-api/plugin.md
This PR fixes it.