### PR TITLE
Update CI VMs to Ubuntu 16.04 and Docker 1.11

### DIFF
--- a/bin/circle-dependencies-post
+++ b/bin/circle-dependencies-post
@@ -2,9 +2,6 @@
 
 set -e
 
-# We need jq to analyse the PR files JSON, so install that first
-sudo apt-get -q update && sudo apt-get -q install bc jq
-
 echo "TEST_AND_PUBLISH=1" > "$STATE"
 
 if [ -n "$CI_PULL_REQUEST" -a "$CI_PULL_REQUEST" = "$CI_PULL_REQUESTS" ] ; then

--- a/test/gce.sh
+++ b/test/gce.sh
@@ -76,13 +76,18 @@ curl -sSL https://get.docker.com/gpg | sudo apt-key add -
 curl -sSL https://get.docker.com/ | sed -e s/docker-engine/docker-engine=1.11.2-0~xenial/ | sh
 apt-get update -qq;
 apt-get install -q -y --force-yes --no-install-recommends ethtool;
+apt-get install -q -y bc jq;
 usermod -a -G docker vagrant;
 echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock -H unix:///var/run/alt-docker.sock -H tcp://0.0.0.0:2375 -s overlay"' >> /etc/default/docker;
 service docker restart
 EOF
 	# It seems we need a short delay for docker to start up, so I put this in
 	# a separate ssh connection.  This installs nsenter.
-	ssh -t $name sudo docker run --rm -v /usr/local/bin:/target jpetazzo/nsenter
+	ssh -t $name sudo bash -x -s <<EOF
+docker run --rm -v /usr/local/bin:/target jpetazzo/nsenter
+docker pull alpine
+docker pull aanand/docker-dnsutils
+EOF
 }
 
 function copy_hosts {

--- a/test/gce.sh
+++ b/test/gce.sh
@@ -34,7 +34,7 @@ function vm_names {
 # Delete all vms in this account
 function destroy {
 	names="$(vm_names)"
-	if [ $(gcloud compute instances list --zone $ZONE -q $names | wc -l) -le 1 ] ; then
+	if [ $(gcloud compute instances list --zones $ZONE -q $names | wc -l) -le 1 ] ; then
 		return 0
 	fi
 	for i in {0..10}; do

--- a/test/gce.sh
+++ b/test/gce.sh
@@ -10,8 +10,9 @@ set -e
 : ${KEY_FILE:=/tmp/gce_private_key.json}
 : ${SSH_KEY_FILE:=$HOME/.ssh/gce_ssh_key}
 : ${PROJECT:=positive-cocoa-90213}
-: ${IMAGE:=ubuntu-14-04}
-: ${TEMPLATE_NAME:=test-template-10}
+: ${IMAGE_FAMILY:=ubuntu-1604-lts}
+: ${IMAGE_PROJECT:=ubuntu-os-cloud}
+: ${TEMPLATE_NAME:=test-template-11}
 : ${ZONE:=us-central1-a}
 : ${NUM_HOSTS:=5}
 SUFFIX=""
@@ -72,7 +73,7 @@ function install_docker_on {
 	name=$1
 	ssh -t $name sudo bash -x -s <<EOF
 curl -sSL https://get.docker.com/gpg | sudo apt-key add -
-curl -sSL https://get.docker.com/ | sh
+curl -sSL https://get.docker.com/ | sed -e s/docker-engine/docker-engine=1.11.2-0~xenial/ | sh
 apt-get update -qq;
 apt-get install -q -y --force-yes --no-install-recommends ethtool;
 usermod -a -G docker vagrant;
@@ -124,7 +125,7 @@ function setup {
 }
 
 function make_template {
-	gcloud compute instances create $TEMPLATE_NAME --image $IMAGE --zone $ZONE
+	gcloud compute instances create $TEMPLATE_NAME --image-family=$IMAGE_FAMILY --image-project=$IMAGE_PROJECT --zone $ZONE
 	gcloud compute config-ssh --ssh-key-file $SSH_KEY_FILE
 	name="$TEMPLATE_NAME.$ZONE.$PROJECT"
 	try_connect $name


### PR DESCRIPTION
This is a precursor to run Kubernetes smoke tests.

The current most up-to-date Docker version is 1.12.1 which [failed some Python tests](https://circleci.com/gh/weaveworks/weave/6920), so I went back to 1.11.3.  The previous version we were using, 1.10.3, is not shipped by Docker for Ubuntu 16.04, and the Ubuntu 1.10.3 [rejects our embedded Docker over the 'host' param](https://circleci.com/gh/weaveworks/weave/6924).

I took the opportunity to pre-load a few things into the image to shave off a few seconds from every test run.

`systemctl` waits for the Docker restart, so we don't need "a short delay".
