### PR TITLE
Improve Dockerfile template substitution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ prog/weavewait/weavewait
 prog/weavewait/weavewait_noop
 prog/weavewait/weavewait_nomcast
 prog/weaveutil/weaveutil
-prog/plugin/Dockerfile
+prog/plugin/Dockerfile.*
 prog/plugin/plugin
 testing/cover/cover
 testing/runner/runner

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PUBLISH=publish_weave publish_weaveexec publish_plugin
 
 .DEFAULT: all
-.PHONY: all exes testrunner update tests lint publish $(PUBLISH) clean clean-bin prerequisites build run-smoketests prog/plugin/Dockerfile
+.PHONY: all exes testrunner update tests lint publish $(PUBLISH) clean clean-bin prerequisites build run-smoketests
 
 # If you can use docker without being root, you can do "make SUDO="
 SUDO=$(shell docker info >/dev/null 2>&1 || echo "sudo -E")
@@ -144,11 +144,11 @@ $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile prog/weaveexec/symlink $(DOCKER
 	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -t $(WEAVEEXEC_IMAGE) prog/weaveexec
 	touch $@
 
-prog/plugin/Dockerfile: prog/plugin/Dockerfile.template
+prog/plugin/Dockerfile.$(DOCKERHUB_USER): prog/plugin/Dockerfile.template
 	sed -e "s/DOCKERHUB_USER/$(DOCKERHUB_USER)/" $^ > $@
 
-$(PLUGIN_UPTODATE): prog/plugin/Dockerfile $(PLUGIN_EXE) $(WEAVEEXEC_UPTODATE)
-	$(SUDO) docker build -t $(PLUGIN_IMAGE) prog/plugin
+$(PLUGIN_UPTODATE): prog/plugin/Dockerfile.$(DOCKERHUB_USER) $(PLUGIN_EXE) $(WEAVEEXEC_UPTODATE)
+	$(SUDO) docker build -f prog/plugin/Dockerfile.$(DOCKERHUB_USER) -t $(PLUGIN_IMAGE) prog/plugin
 	touch $@
 
 $(WEAVEDB_UPTODATE): prog/weavedb/Dockerfile


### PR DESCRIPTION
Encode `$(DOCKERHUB_USER)` into the name of the generated Dockerfile so we only rebuild on change.