### PR TITLE
Rename weave_connection_termination_count metric

### DIFF
--- a/prog/weaver/metrics.go
+++ b/prog/weaver/metrics.go
@@ -56,7 +56,7 @@ var metrics []metric = []metric{
 			ch <- intGauge(desc, len(s.Router.Connections)-established, "non-established")
 			ch <- intGauge(desc, established, "established")
 		}},
-	{desc("weave_connection_termination_count", "Number of peer-to-peer connections terminated."),
+	{desc("weave_connection_terminations_total", "Number of peer-to-peer connections terminated."),
 		func(s WeaveStatus, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
 			ch <- uint64Counter(desc, uint64(s.Router.TerminationCount))
 		}},


### PR DESCRIPTION
To follow [the Prometheus naming conventions](https://prometheus.io/docs/practices/naming/): _"should have a suffix describing the unit, in plural form. Note that an accumulating count has total as a suffix, in addition to the unit if applicable"_