### PR TITLE
weave-kube smoke test

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -86,7 +86,7 @@ if [ -z "$IPALLOC_INIT" ]; then
     IPALLOC_INIT="consensus=$(peer_count $KUBE_PEERS)"
 fi
 
-/home/weave/weaver --port=6783 $BRIDGE_OPTIONS \
+/home/weave/weaver $EXTRA_ARGS --port=6783 $BRIDGE_OPTIONS \
      --http-addr=$HTTP_ADDR --status-addr=$STATUS_ADDR --docker-api='' --no-dns \
      --ipalloc-range=$IPALLOC_RANGE $NICKNAME_ARG \
      --ipalloc-init $IPALLOC_INIT \

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -1,0 +1,64 @@
+#! /bin/bash
+
+. ./config.sh
+
+tear_down_kubeadm() {
+    for host in $HOSTS; do
+        # If we don't stop kubelet, it will restart all the containers we're trying to kill
+        run_on $host "sudo systemctl stop kubelet"
+        rm_containers $host $(docker_on $host ps -aq)
+        run_on $host "test ! -d /var/lib/kubelet || sudo find /var/lib/kubelet -execdir findmnt -n -t tmpfs -o TARGET -T {} \; | uniq | xargs -r sudo umount"
+        run_on $host "sudo rm -r -f /etc/kubernetes /var/lib/kubelet /var/lib/etcd"
+    done
+}
+
+start_suite "Test weave-kube image with Kubernetes"
+
+TOKEN=112233.445566778899000
+HOST1IP=$($SSH $HOST1 "getent hosts $HOST1 | cut -f 1 -d ' '")
+SUCCESS="6 established"
+
+tear_down_kubeadm
+
+run_on $HOST1 "sudo systemctl start kubelet && sudo kubeadm init --token=$TOKEN"
+run_on $HOST2 "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP"
+run_on $HOST3 "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP"
+
+cat ../prog/weave-kube/weave-daemonset.yaml | run_on $HOST1 "kubectl apply -f -"
+
+sleep 5
+
+wait_for_connections() {
+    for i in $(seq 1 30); do
+        if run_on $HOST1 "curl -sS http://127.0.0.1:6784/status | grep \"$SUCCESS\"" ; then
+            return
+        fi
+        echo "Waiting for connections"
+        sleep 1
+    done
+    echo "Timed out waiting for connections to establish" >&2
+    exit 1
+}
+
+assert_raises wait_for_connections
+
+# See if we can get some pods running that connect to the network
+run_on $HOST1 "kubectl run hello --image=weaveworks/hello-world --replicas=3"
+
+wait_for_pods() {
+    for i in $(seq 1 30); do
+        if run_on $HOST1 "kubectl get pods | grep 'hello.*Running'" ; then
+            return
+        fi
+        echo "Waiting for pods"
+        sleep 1
+    done
+    echo "Timed out waiting for pods" >&2
+    exit 1
+}
+
+assert_raises wait_for_pods
+
+tear_down_kubeadm
+
+end_suite

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -24,7 +24,7 @@ run_on $HOST1 "sudo systemctl start kubelet && sudo kubeadm init --token=$TOKEN"
 run_on $HOST2 "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP"
 run_on $HOST3 "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP"
 
-cat ../prog/weave-kube/weave-daemonset.yaml | run_on $HOST1 "kubectl apply -f -"
+sed -e 's/imagePullPolicy: Always/imagePullPolicy: Never/' ../prog/weave-kube/weave-daemonset.yaml | run_on $HOST1 "kubectl apply -f -"
 
 sleep 5
 

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -24,7 +24,9 @@ run_on $HOST1 "sudo systemctl start kubelet && sudo kubeadm init --token=$TOKEN"
 run_on $HOST2 "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP"
 run_on $HOST3 "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP"
 
-sed -e 's/imagePullPolicy: Always/imagePullPolicy: Never/' ../prog/weave-kube/weave-daemonset.yaml | run_on $HOST1 "kubectl apply -f -"
+[ -n "$COVERAGE" ] && COVERAGE_ARGS="\\n          env:\\n            - name: EXTRA_ARGS\\n              value: \"-test.coverprofile=/home/weave/cover.prof --\""
+
+sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never$COVERAGE_ARGS%" ../prog/weave-kube/weave-daemonset.yaml | run_on $HOST1 "kubectl apply -f -"
 
 sleep 5
 


### PR DESCRIPTION
This builds on #2551 and #2563, builds another new image with Kubernetes packages pre-loaded and adds one smoke-test script to try it out.

Currently the only thing the test does is checks to see whether 3 peers form 6 established connections.

If something should go wrong mid-test it will likely cause havoc during the rest of the run, because kubelet will be restarting things.  I considered adding the kubeadm tear-down steps (which are here in `840_weave_kube_3_test.sh`) to `config.sh` but it seemed overkill.