### PR TITLE
WeaveCloud/Cortex integration

### DIFF
--- a/prog/weave-kube/weave-monitoring-svc.yaml
+++ b/prog/weave-kube/weave-monitoring-svc.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+   name: weave-monitoring-net
+   namespace: kube-system
+   annotations:
+     prometheus.io.scrape: "true"
+spec:
+   selector:
+      name: weave-net
+   clusterIP: None
+   ports:
+   - port: 6782
+---
+apiVersion: v1
+kind: Service
+metadata:
+   name: weave-monitoring-npc
+   namespace: kube-system
+   annotations:
+     prometheus.io.scrape: "true"
+spec:
+   selector:
+      name: weave-net
+   clusterIP: None
+   ports:
+   - port: 8686


### PR DESCRIPTION
This PR adds a configuration of headless services used by Prometheus to query `weave-{net/npc}` metrics endpoints. The services make an assumption that `weave-{net,npc}` metrics are served on tcp:8685 and tcp:8686 ports, respectively.

Relevant Prometheus configurations (incl. a configmap for queries proposed in weaveworks/service#935) be found at https://gist.github.com/brb/435d940a15b4443f5353aa7424ff469e

Keep in mind, that the current `weave-net` pod of the `weave-net` daemonset does not expose metrics. For testing purpose, you can use `brb0/weave-{npc,kube}:latest` (`sed -i "s/weaveworks/brb0/" prog/weave-kube/weave-daemonset.yaml`). **<- UPDATED:** only applies for `weave-npc`.

Fixes https://github.com/weaveworks/weave-kube/issues/43