### PR TITLE
allow to not run NPC: do not create iptables rules for NPC

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -6,6 +6,9 @@ set -e
 IPALLOC_RANGE=${IPALLOC_RANGE:-10.32.0.0/12}
 HTTP_ADDR=${WEAVE_HTTP_ADDR:-127.0.0.1:6784}
 
+# Default for network policy
+EXPECT_NPC=${EXPECT_NPC:-1}
+
 # kube-proxy requires that bridged traffic passes through netfilter
 if [ ! -f /proc/sys/net/bridge/bridge-nf-call-iptables ] ; then
     echo /proc/sys/net/bridge/bridge-nf-call-iptables not found >&2
@@ -41,7 +44,12 @@ fi
 
 # Need to create bridge before running weaver so we can use the peer address
 # (because of https://github.com/weaveworks/weave/issues/2480)
-/home/weave/weave --local create-bridge --force --expect-npc
+WEAVE_NPC_OPTS="--expect-npc"
+if [ "${EXPECT_NPC}" = "0" ]; then
+    WEAVE_NPC_OPTS=""
+else
+
+/home/weave --local create-bridge --force $WEAVE_NPC_OPTS
 
 # Kubernetes sets HOSTNAME to the host's hostname
 # when running a pod in host namespace.


### PR DESCRIPTION
We've got ability to run weave-kube as a static pod https://github.com/weaveworks/weave-kube/pull/36. But there is no posibility to run weave-npc as a static pod (static pod can't get secrets from service account).

And weave-kube doesn't work without weave-npc, because of default iptables rules for NPC.

```
-A FORWARD -o weave -j WEAVE-NPC
-A FORWARD -o weave -m state --state NEW -j NFLOG --nflog-group 86
-A FORWARD -o weave -j DROP
```