### PR TITLE
Fix CNI plugin calling weaveutil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ $(PLUGIN_UPTODATE): prog/plugin/Dockerfile.$(DOCKERHUB_USER) $(PLUGIN_EXE) $(WEA
 	$(SUDO) docker build -f prog/plugin/Dockerfile.$(DOCKERHUB_USER) -t $(PLUGIN_IMAGE) prog/plugin
 	touch $@
 
-$(WEAVEKUBE_UPTODATE): prog/weave-kube/Dockerfile.$(DOCKERHUB_USER) prog/weave-kube/launch.sh $(KUBEPEERS_EXE) $(PLUGIN_UPTODATE)
+$(WEAVEKUBE_UPTODATE): prog/weave-kube/Dockerfile.$(DOCKERHUB_USER) prog/weave-kube/launch.sh $(KUBEPEERS_EXE) $(WEAVER_UPTODATE)
 	cp $(KUBEPEERS_EXE) prog/weave-kube/
 	$(SUDO) docker build -f prog/weave-kube/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVEKUBE_IMAGE) prog/weave-kube
 	touch $@

--- a/net/netns.go
+++ b/net/netns.go
@@ -57,12 +57,14 @@ func WithNetNSLinkUnsafe(ns netns.NsHandle, ifName string, work func(link netlin
 	})
 }
 
+var WeaveUtilCmd = "weaveutil"
+
 // A safe version of WithNetNS* which creates a process executing
 // "nsenter --net=<ns-path> weaveutil <cmd> [args]".
 func WithNetNS(nsPath string, cmd string, args ...string) ([]byte, error) {
 	var stdout, stderr bytes.Buffer
 
-	args = append([]string{"--net=" + nsPath, "weaveutil", cmd}, args...)
+	args = append([]string{"--net=" + nsPath, WeaveUtilCmd, cmd}, args...)
 	c := exec.Command("nsenter", args...)
 	c.Stdout = &stdout
 	c.Stderr = &stderr

--- a/prog/weave-kube/Dockerfile.template
+++ b/prog/weave-kube/Dockerfile.template
@@ -1,3 +1,3 @@
-FROM DOCKERHUB_USER/plugin
+FROM DOCKERHUB_USER/weave
 ADD ./launch.sh ./kube-peers /home/weave/
 ENTRYPOINT ["/home/weave/launch.sh"]

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -31,8 +31,8 @@ fi
 
 install_cni_plugin() {
     mkdir -p $1 || return 1
-    cp /home/weave/plugin $1/weave-net
-    cp /home/weave/plugin $1/weave-ipam
+    cp /usr/bin/weaveutil $1/weave-net
+    cp /usr/bin/weaveutil $1/weave-ipam
 }
 
 # Install CNI plugin binary to typical CNI bin location

--- a/prog/weaveutil/cni.go
+++ b/prog/weaveutil/cni.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+
+	cni "github.com/appc/cni/pkg/skel"
+
+	weaveapi "github.com/weaveworks/weave/api"
+	"github.com/weaveworks/weave/common"
+	ipamplugin "github.com/weaveworks/weave/plugin/ipam"
+	netplugin "github.com/weaveworks/weave/plugin/net"
+)
+
+func cniNet(args []string) error {
+	weave := weaveapi.NewClient(os.Getenv("WEAVE_HTTP_ADDR"), common.Log)
+	n := netplugin.NewCNIPlugin(weave)
+	cni.PluginMain(n.CmdAdd, n.CmdDel)
+	return nil
+}
+
+func cniIPAM(args []string) error {
+	weave := weaveapi.NewClient(os.Getenv("WEAVE_HTTP_ADDR"), common.Log)
+	i := ipamplugin.NewIpam(weave)
+	cni.PluginMain(i.CmdAdd, i.CmdDel)
+	return nil
+}

--- a/weave
+++ b/weave
@@ -1036,7 +1036,7 @@ docker run --rm $(docker_run_options) --pid=host -i \\
  -e CNI_VERSION -e CNI_COMMAND -e CNI_CONTAINERID -e CNI_NETNS \\
  -e CNI_IFNAME -e CNI_ARGS -e CNI_PATH \\
  -v /etc/cni:/etc/cni -v /opt/cni:/opt/cni \$EXTRA_VOLUMES \\
- $PLUGIN_IMAGE $COVERAGE_ARGS $2
+--entrypoint=/usr/bin/weaveutil $EXEC_IMAGE $2
 EOF
     chmod a+x "$1"
 }
@@ -1052,8 +1052,8 @@ EOF
 
 setup_cni() {
     if [ -d $HOST_ROOT/opt/cni/bin ] ; then
-        create_cni_script $HOST_ROOT/opt/cni/bin/weave-net  --cni-net
-        create_cni_script $HOST_ROOT/opt/cni/bin/weave-ipam --cni-ipam
+        create_cni_script $HOST_ROOT/opt/cni/bin/weave-net  cni-net
+        create_cni_script $HOST_ROOT/opt/cni/bin/weave-ipam cni-ipam
     fi
     if [ -d $HOST_ROOT/etc/cni/net.d -a ! -f $HOST_ROOT/etc/cni/net.d/10-weave.conf ] ; then
         create_cni_config $HOST_ROOT/etc/cni/net.d/10-weave.conf


### PR DESCRIPTION
By the cunning tactic of embedding the CNI plugin inside `weaveutil`

Note I force all uses of `WithNetNS` in `weaveutil` to exec the current program (as defined by `/proc/self/exe`); this seemed better than having it sometimes exec `weaveutil` and sometimes self.

Fixes #2587 