### PR TITLE
Add support for atomic and versioned upgrades of CNI plugin.

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -29,18 +29,49 @@ if [ ! -f /etc/cni/net.d/10-weave.conf ] ; then
 EOF
 fi
 
+SOURCE_BINARY=/usr/bin/weaveutil
+VERSION=$(/home/weave/weaver --version | sed -E 's/weave router (.*?)/\1/')
+PLUGIN="weave-plugin-$VERSION"
+
 install_cni_plugin() {
     mkdir -p $1 || return 1
-    cp /usr/bin/weaveutil $1/weave-net
-    cp /usr/bin/weaveutil $1/weave-ipam
+    if [ ! -f $1/$PLUGIN ]; then
+        cp "$SOURCE_BINARY" $1/$PLUGIN
+    fi
+}
+
+upgrade_cni_plugin_symlink() {
+    # Remove potential temporary symlink from previous failed upgrade:
+    rm -f $1/$2.tmp
+    # Atomically create a symlink to the plugin:
+    ln -s $1/$PLUGIN $1/$2.tmp && mv -f $1/$2.tmp $1/$2
+}
+
+upgrade_cni_plugin() {
+    # Check if weave-net and weave-ipam are (legacy) copies of the plugin, and
+    # if so remove these so symlinks can be used instead from now onwards.
+    if [ -f $1/weave-net  -a ! -L $1/weave-net  ];  then rm $1/weave-net;   fi
+    if [ -f $1/weave-ipam -a ! -L $1/weave-ipam ];  then rm $1/weave-ipam;  fi
+
+    # Create two symlinks to the plugin, as it has a different 
+    # behaviour depending on its name:
+    if [ "$(readlink -f $1/weave-net)" != "$1/$PLUGIN" ]; then
+        upgrade_cni_plugin_symlink $1 weave-net
+    fi
+    if [ "$(readlink -f $1/weave-ipam)" != "$1/$PLUGIN" ]; then
+        upgrade_cni_plugin_symlink $1 weave-ipam
+    fi
 }
 
 # Install CNI plugin binary to typical CNI bin location
-# with fall-back to CNI directory used by kube-up on GCI OS
-if [ ! -f /opt/cni/bin/weave-net ] ; then
-    if ! install_cni_plugin /opt/cni/bin ; then
-        install_cni_plugin /host_home/kubernetes/bin
-    fi
+# with fall-back to CNI directory used by kube-up on GCI OS.
+if install_cni_plugin /opt/cni/bin ; then
+    upgrade_cni_plugin /opt/cni/bin
+elif install_cni_plugin /host_home/kubernetes/bin ; then
+    upgrade_cni_plugin /host_home/kubernetes/bin
+else
+    echo "Failed to install the Weave CNI plugin" >&2
+    exit 1
 fi
 
 # Need to create bridge before running weaver so we can use the peer address


### PR DESCRIPTION
Fixes #2586

Manual tests:

1. Fresh installation:

```
$ rm -fr foo
$ ./test.sh 
$ ls -al foo/
total 12172
drwxrwxr-x 2 vagrant vagrant     4096 Nov  3 13:36 .
drwxrwxrwt 9 root    root        4096 Nov  3 13:36 ..
lrwxrwxrwx 1 vagrant vagrant       29 Nov  3 13:36 weave-ipam -> weave-plugin-git-bb639dbf322b
lrwxrwxrwx 1 vagrant vagrant       29 Nov  3 13:36 weave-net -> weave-plugin-git-bb639dbf322b
-rwxr-xr-x 1 vagrant vagrant 12454168 Nov  3 13:36 weave-plugin-git-bb639dbf322b
```

2. Idempotency of duplicate installation:

```
$ rm -fr foo
$ ./test.sh 
$ ./test.sh 
$ ls -al foo
total 12172
drwxrwxr-x 2 vagrant vagrant     4096 Nov  3 13:37 .
drwxrwxrwt 9 root    root        4096 Nov  3 13:37 ..
lrwxrwxrwx 1 vagrant vagrant       29 Nov  3 13:37 weave-ipam -> weave-plugin-git-bb639dbf322b
lrwxrwxrwx 1 vagrant vagrant       29 Nov  3 13:37 weave-net -> weave-plugin-git-bb639dbf322b
-rwxr-xr-x 1 vagrant vagrant 12454168 Nov  3 13:37 weave-plugin-git-bb639dbf322b
```

3. Upgrade from older "symlinked" version:

```
$ rm -fr foo
$ ./test.sh 
$ mv foo/weave-plugin-git-bb639dbf322b foo/weave-plugin-old
$ ln -rnfs foo/weave-plugin-old foo/weave-ipam 
$ ln -rnfs foo/weave-plugin-old foo/weave-net 
$ ls -al foo
total 12172
drwxrwxr-x 2 vagrant vagrant     4096 Nov  3 13:40 .
drwxrwxrwt 9 root    root        4096 Nov  3 13:40 ..
lrwxrwxrwx 1 vagrant vagrant       16 Nov  3 13:40 weave-ipam -> weave-plugin-old
lrwxrwxrwx 1 vagrant vagrant       16 Nov  3 13:40 weave-net -> weave-plugin-old
-rwxr-xr-x 1 vagrant vagrant 12454168 Nov  3 13:38 weave-plugin-old
$ ./test.sh 
$ ls -al foo
total 24336
drwxrwxr-x 2 vagrant vagrant     4096 Nov  3 13:40 .
drwxrwxrwt 9 root    root        4096 Nov  3 13:40 ..
lrwxrwxrwx 1 vagrant vagrant       29 Nov  3 13:40 weave-ipam -> weave-plugin-git-bb639dbf322b
lrwxrwxrwx 1 vagrant vagrant       29 Nov  3 13:40 weave-net -> weave-plugin-git-bb639dbf322b
-rwxr-xr-x 1 vagrant vagrant 12454168 Nov  3 13:40 weave-plugin-git-bb639dbf322b
-rwxr-xr-x 1 vagrant vagrant 12454168 Nov  3 13:38 weave-plugin-old
```

N.B.: no housekeeping of old binary.

4. Upgrade from older "hard-copied" version:

```
$ rm -fr foo
$ ./test.sh 
$ rm foo/weave-net 
$ rm foo/weave-ipam 
$ mv foo/weave-plugin-git-bb639dbf322b foo/weave-net
$ cp foo/weave-net foo/weave-ipam
$ ls -al foo
total 24336
drwxrwxr-x 2 vagrant vagrant     4096 Nov  3 13:42 .
drwxrwxrwt 9 root    root        4096 Nov  3 13:42 ..
-rwxr-xr-x 1 vagrant vagrant 12454168 Nov  3 13:42 weave-ipam
-rwxr-xr-x 1 vagrant vagrant 12454168 Nov  3 13:42 weave-net
$ ./test.sh 
$ ls -al foo
total 12172
drwxrwxr-x 2 vagrant vagrant     4096 Nov  3 13:43 .
drwxrwxrwt 9 root    root        4096 Nov  3 13:43 ..
lrwxrwxrwx 1 vagrant vagrant       29 Nov  3 13:43 weave-ipam -> weave-plugin-git-bb639dbf322b
lrwxrwxrwx 1 vagrant vagrant       29 Nov  3 13:43 weave-net -> weave-plugin-git-bb639dbf322b
-rwxr-xr-x 1 vagrant vagrant 12454168 Nov  3 13:43 weave-plugin-git-bb639dbf322b
```

having:

```
$ cat test.sh 
SOURCE_BINARY=/home/vagrant/weave/prog/plugin/plugin
VERSION=$($SOURCE_BINARY --version | grep -oP '(?<=^weave plugin ).*')
PLUGIN="weave-plugin-$VERSION"

install_cni_plugin() {
    mkdir -p $1 || return 1
    if [ ! -f $1/$PLUGIN ]; then
        cp "$SOURCE_BINARY" $1/$PLUGIN
    fi
}

upgrade_cni_plugin_symlink() {
    # Remove potential temporary symlink from previous failed upgrade:
    rm -f $1/$2.tmp
    # Atomically create a symlink to the plugin:
    ln -rs $1/$PLUGIN $1/$2.tmp && mv -Tf $1/$2.tmp $1/$2
}

upgrade_cni_plugin() {
    # Check if weave-net and weave-ipam are (legacy) copies of the plugin, and
    # if so remove these so symlinks can be used instead from now onwards.
    if [ -f $1/weave-net  -a ! -L $1/weave-net  ];  then rm $1/weave-net;   fi
    if [ -f $1/weave-ipam -a ! -L $1/weave-ipam ];  then rm $1/weave-ipam;  fi

    # Create two symlinks to the plugin, as it has a different 
    # behaviour depending on its name:
    if [ "$(readlink -f $1/weave-net)" != "$1/$PLUGIN" ]; then
        upgrade_cni_plugin_symlink $1 weave-net
    fi
    if [ "$(readlink -f $1/weave-ipam)" != "$1/$PLUGIN" ]; then
        upgrade_cni_plugin_symlink $1 weave-ipam
    fi
}

# Install CNI plugin binary to typical CNI bin location
# with fall-back to CNI directory used by kube-up on GCI OS.
if install_cni_plugin /tmp/foo ; then
    upgrade_cni_plugin /tmp/foo
elif install_cni_plugin /host_home/kubernetes/bin ; then
    upgrade_cni_plugin /host_home/kubernetes/bin
else
    echo "Failed to install the Weave CNI plugin" >&2
    exit 1
fi
```