### PR TITLE
Have 'weave reset' remove NPC rules

### DIFF
--- a/weave
+++ b/weave
@@ -795,6 +795,11 @@ destroy_bridge() {
     run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p udp --dst $DOCKER_BRIDGE_IP --dport $(($PORT + 1)) -j DROP >/dev/null 2>&1 || true
 
     run_iptables -t filter -D FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT 2>/dev/null || true
+    run_iptables -F WEAVE-NPC >/dev/null 2>&1 || true
+    run_iptables -t filter -D FORWARD -o $BRIDGE -j WEAVE-NPC 2>/dev/null || true
+    run_iptables -t filter -D FORWARD -o $BRIDGE -m state --state NEW -j NFLOG --nflog-group 86 2>/dev/null || true
+    run_iptables -t filter -D FORWARD -o $BRIDGE -j DROP 2>/dev/null || true
+    run_iptables -X WEAVE-NPC >/dev/null 2>&1 || true
     run_iptables -t nat -F WEAVE >/dev/null 2>&1 || true
     run_iptables -t nat -D POSTROUTING -j WEAVE >/dev/null 2>&1 || true
     run_iptables -t nat -D POSTROUTING -o $BRIDGE -j ACCEPT >/dev/null 2>&1 || true


### PR DESCRIPTION
So that an installation can use weave-npc, then do `weave reset`, then use Weave Net without npc.
