### PR TITLE
Fix "ipset add" behavior, when the record already exists.

### DIFF
--- a/npc/ipset/ipset.go
+++ b/npc/ipset/ipset.go
@@ -2,6 +2,7 @@ package ipset
 
 import (
 	"os/exec"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -38,7 +39,11 @@ func (i *ipset) Create(ipsetName Name, ipsetType Type) error {
 }
 
 func (i *ipset) AddEntry(ipsetName Name, entry string) error {
-	return doExec("add", string(ipsetName), entry)
+	err := doExec("add", string(ipsetName), entry)
+	if err != nil && strings.Contains(err.Error(), "Element cannot be added to the set: it's already added") {
+		return nil
+	}
+	return err
 }
 
 func (i *ipset) DelEntry(ipsetName Name, entry string) error {


### PR DESCRIPTION
I caught some very nasty bug, where weave-npc containers where dying and restarting all the time on all hosts with this message:
```
time="2016-11-13T00:31:59Z" level=fatal msg="add pod: ipset [add weave-k?Z;25^M}|1s7P3|H9i;*;MhG 10.32.0.5] failed: ipset v6.29: Element cannot be added to the set: it's already added\n: exit status 1"
```

It might happen to be a workaround for another weave bug, which caused it in the first place. I.e. why would weave try to add an ip with "ipset add" if it had done it before.
Nevertheless, it seems safe enough to merge, even if the original bug, which sounds like some race condition, persists.
