### PR TITLE
Fix weave-kube launch.sh version usage

### DIFF
--- a/prog/plugin/main.go
+++ b/prog/plugin/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/weaveworks/weave/plugin/skel"
 )
 
-var version = "(unreleased version)"
+var version = "unreleased"
 
 var Log = common.Log
 

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -30,7 +30,7 @@ EOF
 fi
 
 SOURCE_BINARY=/usr/bin/weaveutil
-VERSION=$(/home/weave/weaver $EXTRA_ARGS --version | sed -E 's/weave router (.*?)/\1/')
+VERSION=$(/home/weave/weaver $EXTRA_ARGS --version | sed -e 's/weave router //')
 PLUGIN="weave-plugin-$VERSION"
 
 install_cni_plugin() {

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -30,7 +30,7 @@ EOF
 fi
 
 SOURCE_BINARY=/usr/bin/weaveutil
-VERSION=$(/home/weave/weaver --version | sed -E 's/weave router (.*?)/\1/')
+VERSION=$(/home/weave/weaver $EXTRA_ARGS --version | sed -E 's/weave router (.*?)/\1/')
 PLUGIN="weave-plugin-$VERSION"
 
 install_cni_plugin() {

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -35,8 +35,8 @@ PLUGIN="weave-plugin-$VERSION"
 
 install_cni_plugin() {
     mkdir -p $1 || return 1
-    if [ ! -f $1/$PLUGIN ]; then
-        cp "$SOURCE_BINARY" $1/$PLUGIN
+    if [ ! -f "$1/$PLUGIN" ]; then
+        cp "$SOURCE_BINARY" "$1/$PLUGIN"
     fi
 }
 
@@ -44,7 +44,7 @@ upgrade_cni_plugin_symlink() {
     # Remove potential temporary symlink from previous failed upgrade:
     rm -f $1/$2.tmp
     # Atomically create a symlink to the plugin:
-    ln -s $1/$PLUGIN $1/$2.tmp && mv -f $1/$2.tmp $1/$2
+    ln -s "$1/$PLUGIN" $1/$2.tmp && mv -f $1/$2.tmp $1/$2
 }
 
 upgrade_cni_plugin() {

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	version     = "(unreleased)"
+	version     = "unreleased"
 	metricsAddr string
 )
 

--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/weaveworks/weave/proxy"
 )
 
-var version = "(unreleased version)"
+var version = "unreleased"
 
 var Log = common.Log
 

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -27,7 +27,7 @@ import (
 	weave "github.com/weaveworks/weave/router"
 )
 
-var version = "(unreleased version)"
+var version = "unreleased"
 
 var Log = common.Log
 

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -302,7 +302,7 @@ latest snapshot release using:
     sudo chmod a+x /usr/local/bin/weave
     weave setup
 
-Snapshot releases report the script version as "(unreleased version)",
+Snapshot releases report the script version as "unreleased",
 and the container image versions as git hashes.
 
 

--- a/weave
+++ b/weave
@@ -3,9 +3,9 @@ set -e
 
 [ -n "$WEAVE_DEBUG" ] && set -x
 
-SCRIPT_VERSION="(unreleased version)"
+SCRIPT_VERSION="unreleased"
 IMAGE_VERSION=latest
-[ "$SCRIPT_VERSION" = "(unreleased version)" ] || IMAGE_VERSION=$SCRIPT_VERSION
+[ "$SCRIPT_VERSION" = "unreleased" ] || IMAGE_VERSION=$SCRIPT_VERSION
 IMAGE_VERSION=${WEAVE_VERSION:-$IMAGE_VERSION}
 
 # - Docker versions prior to 1.6 cannot pull images from DockerHub


### PR DESCRIPTION
The version string can be anything, including the default `"(unreleased version)"`, so must be quoted when used in a shell command-line.

Also we must supply extra args when the program is compiled with code-coverage.