### PR TITLE
Don't release CNI-allocated IP address when container dies

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -322,7 +322,7 @@ func (alloc *Allocator) Claim(ident string, cidr address.CIDR, isContainer, noEr
 // ContainerDied called from the updater interface.  Async.
 func (alloc *Allocator) ContainerDied(ident string) {
 	alloc.actionChan <- func() {
-		if alloc.hasOwned(ident) {
+		if alloc.hasOwnedByContainer(ident) {
 			alloc.debugln("Container", ident, "died; noting to remove later")
 			alloc.dead[ident] = alloc.now()
 		}
@@ -335,7 +335,7 @@ func (alloc *Allocator) ContainerDied(ident string) {
 // ContainerDestroyed called from the updater interface.  Async.
 func (alloc *Allocator) ContainerDestroyed(ident string) {
 	alloc.actionChan <- func() {
-		if alloc.hasOwned(ident) {
+		if alloc.hasOwnedByContainer(ident) {
 			alloc.debugln("Container", ident, "destroyed; removing addresses")
 			alloc.delete(ident)
 			delete(alloc.dead, ident)
@@ -996,9 +996,9 @@ func (alloc *Allocator) persistOwned() {
 
 // Owned addresses
 
-func (alloc *Allocator) hasOwned(ident string) bool {
-	_, b := alloc.owned[ident]
-	return b
+func (alloc *Allocator) hasOwnedByContainer(ident string) bool {
+	d, b := alloc.owned[ident]
+	return b && d.IsContainer
 }
 
 // NB: addr must not be owned by ident already

--- a/test/830_cni_plugin_test.sh
+++ b/test/830_cni_plugin_test.sh
@@ -45,7 +45,7 @@ C2IP=$(container_ip $HOST1 c2)
 assert_raises "exec_on $HOST1 c1 $PING $C2IP"
 assert_raises "exec_on $HOST1 c2 $PING $C1IP"
 
-# Now remove and start a new container to see if IP address re-use breaks things
+# Now remove and start a new container to see if anything breaks
 docker_on $HOST1 rm -f c2
 
 C3=$(docker_on $HOST1 run --net=none --name=c3 -dt $SMALL_IMAGE /bin/sh)
@@ -56,7 +56,9 @@ EOF
 
 C3IP=$(container_ip $HOST1 c3)
 
-assert_raises "exec_on $HOST1 c1 $PING $C2IP"
+# CNI shouldn't re-use the address until we call DEL
+assert_raises "[ $C2IP != $C3IP ]"
+assert_raises "exec_on $HOST1 c1 $PING $C3IP"
 
 
 # Ensure existing containers can reclaim their IP addresses after CNI has been used -- see #2548


### PR DESCRIPTION
The CNI spec doesn't say we can release the address at this time, so best not to.

Currently the Weave Net plugin will error if you call DEL after the container has died, so  this change means the address will leak, but this will probably be amended in the CNI spec and libraries - see https://github.com/containernetworking/cni/issues/309

Note this change is based on the observation that `api.AllocateIP` doesn't set `check-alive` so `IsContainer` gets set to `false`.