### PR TITLE
Better value for --ipalloc-range in attach-router

### DIFF
--- a/weave
+++ b/weave
@@ -1704,7 +1704,7 @@ setup_awsvpc() {
 # Recreate the parameter values that are set when the router is first launched
 fetch_router_args() {
     CONTAINER_ARGS=$(docker inspect -f '{{.Args}}' $CONTAINER_NAME) || return 1
-    IPRANGE=$(echo $CONTAINER_ARGS | grep -o -e '-ipalloc-range [^ ]*') || true
+    IPRANGE=$(echo $CONTAINER_ARGS | grep -o -E -e '-ipalloc-range [0-9/.]+') || true
     NO_DNS_OPT=$(echo $CONTAINER_ARGS | grep -o -e '--no-dns') || true
 }
 


### PR DESCRIPTION
The previous regex matched a blank `--ipalloc-range` together with the following parameter, which defeated the whole point of the check.

I contemplated using `CIDR_REGEXP` but we explicitly are not trying to check the value, just trying to spot if it was in the args.

Fixes #2567 