### PR TITLE
Replace iptables block with resolver override

### DIFF
--- a/test/700_status_and_report_test.sh
+++ b/test/700_status_and_report_test.sh
@@ -3,8 +3,6 @@
 . ./config.sh
 
 UNIVERSE=10.2.0.0/16
-IPTABLES_BACKUP=/tmp/700_status_and_report_test.iptables
-CHECKPOINT_URL=https://checkpoint-api.weave.works/v1/check/weave-net
 
 start_suite "weave status/report"
 
@@ -35,33 +33,18 @@ assert_raises "weave_on $HOST1 status | grep 'version check update disabled'"
 
 
 
-# Block outgoing traffic to Weave's checkpoint API, to prevent retrieval of latest version:
-run_on $HOST1 "sudo iptables-save > $IPTABLES_BACKUP"
-[ -z "$DEBUG" ] || greyly echo "Backed iptables rules up:"
-[ -z "$DEBUG" ] || run_on $HOST1 cat $IPTABLES_BACKUP
-[ -z "$DEBUG" ] || greyly echo "Updating iptables rules."
-run_on $HOST1 sudo iptables -A OUTPUT -p tcp -d checkpoint-api.weave.works --dport 443 -j REJECT --reject-with tcp-reset
-[ -z "$DEBUG" ] || greyly echo "Updated iptables rules:"
-[ -z "$DEBUG" ] || run_on $HOST1 sudo iptables -L
-[ -z "$DEBUG" ] || greyly echo "Test access to checkpoint:"
-[ -z "$DEBUG" ] || run_on $HOST1 "curl -X GET $CHECKPOINT_URL || true"
-
 weave_on $HOST1 reset
-
-CHECKPOINT_DISABLE="" weave_on $HOST1 launch
+# Guarantee the version check fails by feeding an unresponsive IP address into the resolver
+$SSH $HOST1 tee /tmp/hosts.checkpoint-api > /dev/null <<EOF
+127.0.0.1 localhost
+127.1.1.1 checkpoint-api.weave.works
+EOF
+CHECKPOINT_DISABLE="" WEAVE_DOCKER_ARGS="-v /tmp/hosts.checkpoint-api:/etc/hosts" weave_on $HOST1 launch
 
 assert "weave_on $HOST1 report -f '{{.VersionCheck.Enabled}}'" "true"
 assert "weave_on $HOST1 report -f '{{.VersionCheck.Success}}'" "false"
 assert "weave_on $HOST1 report -f '{{.VersionCheck.NewVersion}}'" ""
 assert_raises "weave_on $HOST1 status | grep 'failed to check latest version - see logs; next check at'"
-
-
-[ -z "$DEBUG" ] || greyly echo "Reverting iptables rules."
-run_on $HOST1 "sudo iptables-restore < $IPTABLES_BACKUP"
-[ -z "$DEBUG" ] || greyly echo "Reverted iptables rules:"
-[ -z "$DEBUG" ] || run_on $HOST1 sudo iptables -L
-[ -z "$DEBUG" ] || greyly echo "Test access to checkpoint:"
-[ -z "$DEBUG" ] || run_on $HOST1 curl -X GET $CHECKPOINT_URL
 
 
 


### PR DESCRIPTION
Unfortunately our assumption regarding `checkpoint-api.weave.works` having a stable IP address proved to be wrong, and we were seeing occasional failures where the iptables rule blocked a different IP than the one being used by the router. Instead, override the `/etc/hosts` used by the router to resolve checkpoint-api to return an unresponsive IP in the loopback subnet.