### PR TITLE
Make NPC only look at IP addresses on running pods

### DIFF
--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -302,8 +302,9 @@ func (ns *ns) deleteNamespace(obj *coreapi.Namespace) error {
 }
 
 func hasIP(pod *coreapi.Pod) bool {
-	// Ensure pod has an IP address and isn't sharing the host network namespace
-	return len(pod.Status.PodIP) > 0 && !pod.Spec.HostNetwork
+	// Ensure pod isn't dead, has an IP address and isn't sharing the host network namespace
+	return pod.Status.Phase != "Succeeded" && pod.Status.Phase != "Failed" &&
+		len(pod.Status.PodIP) > 0 && !pod.Spec.HostNetwork
 }
 
 func equals(a, b map[string]string) bool {


### PR DESCRIPTION
This is an improvement on the behaviour reported at #2632 - a complete fix will need to cover the case where the observed lifetimes of two pods overlap.

I am relying on the pod phases being as documented at http://kubernetes.io/docs/user-guide/pod-states/

Empirically this fixes the problem that any 'completed' or 'failed' pods can remain showing their old IP address, that is re-used by a later pod invocation.