### PR TITLE
Add MTU to connection status

### DIFF
--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -211,7 +211,7 @@ var targetsTemplate = defTemplate("targetsTemplate", `\
 
 var connectionsTemplate = defTemplate("connectionsTemplate", `\
 {{range .Router.Connections}}\
-{{if .Outbound}}->{{else}}<-{{end}} {{printf "%-21v" .Address}} {{printf "%-11v" .State}} {{.Info}}
+{{if .Outbound}}->{{else}}<-{{end}} {{printf "%-21v" .Address}} {{printf "%-11v" .State}} {{.Info}} {{range $key,$element := .Attrs}}{{if ne $key "name"}}{{$key}}={{$element}}{{end}}{{end}}
 {{end}}\
 `)
 

--- a/router/awsvpc.go
+++ b/router/awsvpc.go
@@ -32,8 +32,8 @@ func (conn *AWSVPCConnection) Stop() {}
 func (conn *AWSVPCConnection) ControlMessage(tag byte, msg []byte) {
 }
 
-func (conn *AWSVPCConnection) DisplayName() string {
-	return "awsvpc"
+func (conn *AWSVPCConnection) Attrs() map[string]interface{} {
+	return map[string]interface{}{"name": "awsvpc"}
 }
 
 // OverlayForwarder

--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -771,8 +771,8 @@ func (fwd *fastDatapathForwarder) ControlMessage(tag byte, msg []byte) {
 	}
 }
 
-func (fwd *fastDatapathForwarder) DisplayName() string {
-	return "fastdp"
+func (fwd *fastDatapathForwarder) Attrs() map[string]interface{} {
+	return map[string]interface{}{"name": "fastdp", "mtu": fwd.fastdp.iface.MTU}
 }
 
 func (fwd *fastDatapathForwarder) handleHeartbeatAck() {

--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -424,7 +424,7 @@ func (fwd *overlaySwitchForwarder) ControlMessage(tag byte, msg []byte) {
 	}
 }
 
-func (fwd *overlaySwitchForwarder) DisplayName() string {
+func (fwd *overlaySwitchForwarder) Attrs() map[string]interface{} {
 	var best OverlayForwarder
 
 	fwd.lock.Lock()
@@ -434,8 +434,8 @@ func (fwd *overlaySwitchForwarder) DisplayName() string {
 	fwd.lock.Unlock()
 
 	if best != nil {
-		return best.DisplayName()
+		return best.Attrs()
 	}
 
-	return "none"
+	return nil
 }

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -606,8 +606,8 @@ func (fwd *sleeveForwarder) ControlMessage(tag byte, msg []byte) {
 	}
 }
 
-func (fwd *sleeveForwarder) DisplayName() string {
-	return "sleeve"
+func (fwd *sleeveForwarder) Attrs() map[string]interface{} {
+	return map[string]interface{}{"name": "sleeve", "mtu": fwd.mtu}
 }
 
 func (fwd *sleeveForwarder) Stop() {

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -131,7 +131,7 @@ To view detailed information on the local Weave Net router's type `weave status 
 
 ```
 $ weave status connections
-<- 192.168.48.12:33866   established unencrypted fastdp 7e:21:4a:70:2f:45(host2)
+<- 192.168.48.12:33866   established unencrypted fastdp 7e:21:4a:70:2f:45(host2) mtu=1410
 <- 192.168.48.13:60773   pending     encrypted   fastdp 7e:ae:cd:d5:23:8d(host3)
 -> 192.168.48.14:6783    retrying    dial tcp4 192.168.48.14:6783: no route to host
 -> 192.168.48.15:6783    failed      dial tcp4 192.168.48.15:6783: no route to host, retry: 2015-08-06 18:55:38.246910357 +0000 UTC
@@ -153,7 +153,7 @@ The columns are as follows:
     * `established` - TCP connection and corresponding UDP path are up
  * Info - the failure reason for failed and retrying connections, or
    the encryption mode, data transport method, remote peer name and
-   nickname for pending and established connections
+   nickname for pending and established connections, mtu if known
 
 ### <a name="weave-status-peers"></a>List Peers
 

--- a/test/700_status_and_report_2_test.sh
+++ b/test/700_status_and_report_2_test.sh
@@ -9,6 +9,7 @@ start_suite "weave status/report"
 
 
 weave_on $HOST1 launch --ipalloc-range $UNIVERSE --name 8a:3e:3e:3e:3e:3e --nickname nicknamington
+weave_on $HOST2 launch --ipalloc-range $UNIVERSE
 
 check() {
     assert "weave_on $HOST1 status | grep -oP '(?<= $1: ).*'" "$3"
@@ -27,6 +28,9 @@ assert_raises "weave_on $HOST1 report | grep nicknamington"
 weave_on $HOST1 connect 10.2.2.1
 assert "weave_on $HOST1 status targets" "10.2.2.1"
 assert "weave_on $HOST1 status connections | tr -s ' ' | cut -d ' ' -f 2" "10.2.2.1:6783"
+weave_on $HOST1 connect $HOST2
+sleep 1
+assert "weave_on $HOST1 status connections | grep -q 'mtu=1410'"
 
 assert "weave_on $HOST1 report -f '{{.VersionCheck.Enabled}}'" "false"
 assert_raises "weave_on $HOST1 status | grep 'version check update disabled'"


### PR DESCRIPTION
Fixes #2389 

I carry the data through Mesh in a map to make it generic; AWSVPC declines to supply it in this implementation.

Sample output:

````
$ weave status connections
<- 192.168.48.1:59366    established sleeve 6a:41:53:e1:d7:29(vagrant-ubuntu-wily-64) mtu=1438
<- 192.168.48.11:42128   established fastdp 5e:7e:09:ac:95:94(host1) mtu=1410
$ weave report
...
        "Connections": [
            {
                "Address": "192.168.48.1:59366",
                "Outbound": false,
                "State": "established",
                "Info": "sleeve 6a:41:53:e1:d7:29(vagrant-ubuntu-wily-64)",
                "Data": {
                    "mtu": 1438
                }
            },
            {
                "Address": "192.168.48.11:42128",
                "Outbound": false,
                "State": "established",
                "Info": "fastdp 5e:7e:09:ac:95:94(host1)",
                "Data": {
                    "mtu": 1410
                }
            }
        ],
...
````
