### PR TITLE
Detect looping flows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "tools"]
 	path = tools
 	url = https://github.com/weaveworks/build-tools
-[submodule "vendor/github.com/vishvananda/netlink"]
-	path = vendor/github.com/vishvananda/netlink
-	url = https://github.com/vishvananda/netlink.git
 [submodule "vendor/github.com/gorilla/mux"]
 	path = vendor/github.com/gorilla/mux
 	url = https://github.com/gorilla/mux.git
@@ -118,3 +115,6 @@
 [submodule "vendor/github.com/spf13/pflag"]
 	path = vendor/github.com/spf13/pflag
 	url = https://github.com/spf13/pflag
+[submodule "vendor/github.com/vishvananda/netlink"]
+	path = vendor/github.com/vishvananda/netlink
+	url = https://github.com/brb/netlink

--- a/net/bridge.go
+++ b/net/bridge.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	"github.com/Sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
 
@@ -49,5 +50,33 @@ func isDatapath(link netlink.Link) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func DetectHairpin(portIfName string, log *logrus.Logger) {
+	link, err := netlink.LinkByName(portIfName)
+	if err != nil {
+		log.Errorf("Unable to find link %q: %s", portIfName, err)
+	}
+
+	ch := make(chan netlink.LinkUpdate)
+	// See EnsureInterface for why done channel is not passed
+	if err := netlink.LinkSubscribe(ch, nil); err != nil {
+		log.Errorf("Unable to subscribe to netlink updates: %s", err)
+	}
+
+	pi, err := netlink.LinkGetProtinfo(link)
+	if err != nil {
+		log.Errorf("Unable to get link protinfo %q: %s", portIfName, err)
+	}
+	if pi.Hairpin {
+		log.Errorf("Hairpin mode enabled on %q", portIfName)
+	}
+
+	for up := range ch {
+		if up.Attrs().Name == portIfName && up.Attrs().Protinfo != nil &&
+			up.Attrs().Protinfo.Hairpin {
+			log.Errorf("Hairpin mode enabled on %q", portIfName)
+		}
 	}
 }

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -226,6 +226,10 @@ func main() {
 	overlay, bridge := createOverlay(datapathName, ifaceName, isAWSVPC, config.Host, config.Port, bufSzMB)
 	networkConfig.Bridge = bridge
 
+	if bridge != nil {
+		go weavenet.DetectHairpin("vethwe-bridge", Log)
+	}
+
 	name := peerName(routerName, bridge.Interface())
 
 	if nickName == "" {

--- a/router/network_router.go
+++ b/router/network_router.go
@@ -124,6 +124,13 @@ func (router *NetworkRouter) handleCapturedPacket(key PacketKey) FlowOp {
 }
 
 func (router *NetworkRouter) handleForwardedPacket(key ForwardPacketKey) FlowOp {
+	srcMac := net.HardwareAddr(key.SrcMAC[:])
+	dstMac := net.HardwareAddr(key.DstMAC[:])
+
+	if key.SrcPeer == router.Ourself.Peer {
+		log.Warn("Received own packet to peer ", key.DstPeer, " from MAC (", srcMac, ") to (", dstMac, ")")
+	}
+
 	if key.DstPeer != router.Ourself.Peer {
 		// it's not for us, we're just relaying it
 		router.PacketLogging.LogForwardPacket("Relaying", key)
@@ -133,9 +140,6 @@ func (router *NetworkRouter) handleForwardedPacket(key ForwardPacketKey) FlowOp 
 	// At this point, it's either unicast to us, or a broadcast
 	// (because the DstPeer on a forwarded broadcast packet is
 	// always set to the peer being forwarded to)
-
-	srcMac := net.HardwareAddr(key.SrcMAC[:])
-	dstMac := net.HardwareAddr(key.DstMAC[:])
 
 	switch newSrcMac, conflictPeer := router.Macs.AddForced(srcMac, key.SrcPeer); {
 	case newSrcMac:

--- a/test/705_detect_hairpin_test.sh
+++ b/test/705_detect_hairpin_test.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+. ./config.sh
+
+start_suite "Detect hairpin mode"
+
+weave_on $HOST1 launch
+
+assert_raises "run_on $HOST1 sudo ip link set vethwe-bridge type bridge_slave hairpin on"
+assert_raises "docker_on $HOST1 logs weave 2>&1 | grep -q 'Hairpin mode enabled on \"vethwe-bridge\"'"
+
+end_suite


### PR DESCRIPTION
This PR includes the following changes:

* Detect loops in fastdp flows (see commit message for a meaning of loops in terms of fastdp).
* Detect enabling of hairpin mode.
* Logging of a case when own packet is received from a remote peer.

BLOCKERS: https://github.com/vishvananda/netlink/pull/179 (I've temporarily changed the vendored netlink dep).

Fixes #2650 