### PR TITLE
Re-add expose to ensure it gets run on all nodes

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -155,4 +155,7 @@ if [ ! -f /etc/cni/net.d/10-weave.conf ] ; then
 EOF
 fi
 
+# Expose the weave network so host processes can communicate with pods
+/home/weave/weave --local expose $WEAVE_EXPOSE_IP
+
 wait $WEAVE_PID

--- a/site/kube-addon.md
+++ b/site/kube-addon.md
@@ -126,3 +126,6 @@ The list of variables you can set is:
 * IPALLOC\_INIT - set the initialization mode of the [IP Address
   Manager](/site/operational-guide/concepts.md#ip-address-manager)
   (defaults to consensus amongst the KUBE\_PEERS)
+* WEAVE\_EXPOSE\_IP - set the IP address used as a gateway from the
+  Weave network to the host network - this is useful if you are
+  configuring the addon as a static pod.


### PR DESCRIPTION
Fixes #2673.

Previous change in a07e3301b1a8 meant that if there are no pods on this node then the 'expose' never gets run.

Also I documented the use of `WEAVE_EXPOSE_IP`, from https://github.com/weaveworks/weave-kube/pull/36