### PR TITLE
Take peerName from weave bridge if not specified

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -22,8 +22,7 @@ else
     fi
 fi
 
-# Need to create bridge before running weaver so we can use the peer address
-# (because of https://github.com/weaveworks/weave/issues/2480)
+# Explicitly create the bridge so we can pass --expect-npc
 WEAVE_NPC_OPTS="--expect-npc"
 if [ "${EXPECT_NPC}" = "0" ]; then
     WEAVE_NPC_OPTS=""
@@ -69,7 +68,7 @@ fi
      --http-addr=$HTTP_ADDR --status-addr=$STATUS_ADDR --docker-api='' --no-dns \
      --ipalloc-range=$IPALLOC_RANGE $NICKNAME_ARG \
      --ipalloc-init $IPALLOC_INIT \
-     --name=$(cat /sys/class/net/weave/address) "$@" \
+     "$@" \
      $KUBE_PEERS &
 WEAVE_PID=$!
 

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -232,7 +232,7 @@ func main() {
 		}
 	}
 
-	name := peerName(routerName, bridge.Interface())
+	name := peerName(routerName)
 
 	if nickName == "" {
 		var err error
@@ -528,10 +528,11 @@ func determinePassword(password string) []byte {
 	return []byte(password)
 }
 
-func peerName(routerName string, iface *net.Interface) mesh.PeerName {
+func peerName(routerName string) mesh.PeerName {
 	if routerName == "" {
-		if iface == nil {
-			Log.Fatal("Either an interface must be specified with --datapath or --iface, or a name with --name")
+		iface, err := net.InterfaceByName(weavenet.WeaveBridgeName)
+		if err != nil {
+			Log.Fatalf("Unable to find bridge %q", weavenet.WeaveBridgeName)
 		}
 		routerName = iface.HardwareAddr.String()
 	}


### PR DESCRIPTION
Fixes #2480

Cleans up `launch.sh` slightly, but not as much as when originally filed as weave-npc needs the bridge to be set up explicitly now.