### PR TITLE
Scripts now source dependencies using relative paths

### DIFF
--- a/test/090_docker_restart_policy_2_test.sh
+++ b/test/090_docker_restart_policy_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Test docker restart policy"
 

--- a/test/100_cross_hosts_2_test.sh
+++ b/test/100_cross_hosts_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.4
 C2=10.2.1.7

--- a/test/105_frag_2_test.sh
+++ b/test/105_frag_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.41
 C2=10.2.1.71

--- a/test/110_encryption_2_test.sh
+++ b/test/110_encryption_2_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.4
 C2=10.2.1.7

--- a/test/115_optional_encryption_2_test.sh
+++ b/test/115_optional_encryption_2_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Optional encryption via trusted subnets"
 

--- a/test/120_discovery_3_test.sh
+++ b/test/120_discovery_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.41
 C3=10.2.1.71

--- a/test/130_expose_test.sh
+++ b/test/130_expose_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.34
 C2=10.2.1.37

--- a/test/140_weave_local_test.sh
+++ b/test/140_weave_local_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 weave_local_on() {
     host=$1

--- a/test/150_connect_forget_2_test.sh
+++ b/test/150_connect_forget_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.4
 C2=10.2.1.7

--- a/test/175_target_peer_persistence_3_test.sh
+++ b/test/175_target_peer_persistence_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 
 assert_targets() {

--- a/test/190_no_fastdp_2_test.sh
+++ b/test/190_no_fastdp_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.46
 C2=10.2.1.47

--- a/test/195_no_multicast_route_1_test.sh
+++ b/test/195_no_multicast_route_1_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 show_multicast_route_on() {
     exec_on $1 $2 ip route show 224.0.0.0/4

--- a/test/200_dns_test.sh
+++ b/test/200_dns_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.78
 C2=10.2.0.34

--- a/test/205_dns_disabled_test.sh
+++ b/test/205_dns_disabled_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.87
 

--- a/test/210_dns_cross_hosts_3_test.sh
+++ b/test/210_dns_cross_hosts_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.3.78
 C2=10.2.3.34

--- a/test/215_stale_dns_3_test.sh
+++ b/test/215_stale_dns_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Check propagation of DNS entries when gossip is delayed"
 

--- a/test/220_dns_custom_test.sh
+++ b/test/220_dns_custom_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.56.34
 C2=10.2.54.91

--- a/test/225_dns_subdomain_test.sh
+++ b/test/225_dns_subdomain_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.54.34
 C2=10.2.54.91

--- a/test/230_dns_unqualified_test.sh
+++ b/test/230_dns_unqualified_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.78
 C2=10.2.0.34

--- a/test/240_dns_add_name_test.sh
+++ b/test/240_dns_add_name_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.78
 C2=10.2.0.34

--- a/test/245_dns_case_insensitive_test.sh
+++ b/test/245_dns_case_insensitive_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.78
 C2=10.2.0.79

--- a/test/250_dns_negative_test.sh
+++ b/test/250_dns_negative_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Negative DNS queries"
 

--- a/test/255_dns_restart_test.sh
+++ b/test/255_dns_restart_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.78
 C2=10.2.0.34

--- a/test/260_dns_removal_test.sh
+++ b/test/260_dns_removal_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.67
 C2=10.2.0.43

--- a/test/265_dns_reverse_test.sh
+++ b/test/265_dns_reverse_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 IP=10.2.0.67
 

--- a/test/270_use_name_as_hostname_test.sh
+++ b/test/270_use_name_as_hostname_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 NAME=c1
 DOMAIN=weave.local

--- a/test/280_with_or_without_dns_test.sh
+++ b/test/280_with_or_without_dns_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 IP=10.2.0.34
 TARGET=seetwo.weave.local

--- a/test/290_dns_fallback_test.sh
+++ b/test/290_dns_fallback_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Resolve a non-weave address"
 

--- a/test/295_dns_large_response_test.sh
+++ b/test/295_dns_large_response_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 NAME=seetwo.weave.local
 

--- a/test/300_ip_reuse_test.sh
+++ b/test/300_ip_reuse_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.43
 C2=10.2.1.44

--- a/test/310_docker_restart_test.sh
+++ b/test/310_docker_restart_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Containers get same IP address on restart"
 

--- a/test/320_claim_3_test.sh
+++ b/test/320_claim_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 UNIVERSE=10.2.0.0/16
 C1=10.2.128.1

--- a/test/330_reset_2_test.sh
+++ b/test/330_reset_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Rolling restart with reset"
 

--- a/test/335_rmpeer_3_test.sh
+++ b/test/335_rmpeer_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "rmpeer reclaims IP addresses of lost peers"
 

--- a/test/340_observers_cannot_vote_3_test.sh
+++ b/test/340_observers_cannot_vote_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Observers can't vote"
 

--- a/test/350_observers_can_call_election_3_test.sh
+++ b/test/350_observers_can_call_election_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Observers can call election"
 

--- a/test/360_ipalloc_seed_mismatch_3_test.sh
+++ b/test/360_ipalloc_seed_mismatch_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "IPAM ring seed mismatch"
 

--- a/test/362_ipalloc_range_change_test.sh
+++ b/test/362_ipalloc_range_change_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "IPAM alloc range change"
 

--- a/test/370_persist_ipam_2_test.sh
+++ b/test/370_persist_ipam_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Checking persistence of IPAM"
 

--- a/test/380_ipam_seed_2_test.sh
+++ b/test/380_ipam_seed_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Specify initial IPAM seed"
 

--- a/test/500_weave_multi_cidr_test.sh
+++ b/test/500_weave_multi_cidr_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 NAME=multicidr.weave.local
 

--- a/test/510_detach_hide_no_ipalloc_test.sh
+++ b/test/510_detach_hide_no_ipalloc_test.sh
@@ -7,7 +7,7 @@ check() {
     assert_raises "timeout 10 cat <( $CMD )"
 }
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "'detach' and 'hide' do not require IP allocation"
 

--- a/test/600_proxy_docker_py.sh
+++ b/test/600_proxy_docker_py.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # Explicitly not called _test.sh - this isn't run, but imported by other tests.
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 IMAGE="joffrey/docker-py:1.8.1"
 

--- a/test/605_proxy_inspect_test.sh
+++ b/test/605_proxy_inspect_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Check that docker inspect returns the weave IP"
 

--- a/test/610_proxy_wait_for_weave_test.sh
+++ b/test/610_proxy_wait_for_weave_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 entrypoint() {
   docker_on $HOST1 inspect --format="{{.Config.Entrypoint}}" "$@"

--- a/test/615_proxy_rewrite_hosts_test.sh
+++ b/test/615_proxy_rewrite_hosts_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 expected_ip=10.2.1.1
 

--- a/test/620_proxy_entrypoint_command_test.sh
+++ b/test/620_proxy_entrypoint_command_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 build_image() {
     docker_on $HOST1 build -t $1 >/dev/null - <<- EOF

--- a/test/630_proxy_dns_test.sh
+++ b/test/630_proxy_dns_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.78
 C2=10.2.0.34

--- a/test/635_proxy_dns_unqualified_test.sh
+++ b/test/635_proxy_dns_unqualified_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.78
 C2=10.2.0.34

--- a/test/640_proxy_restart_reattaches_test.sh
+++ b/test/640_proxy_restart_reattaches_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 NAME=seetwo.weave.local
 

--- a/test/650_proxy_env_test.sh
+++ b/test/650_proxy_env_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 CMD="run -e WEAVE_CIDR=10.2.1.4/24 $SMALL_IMAGE $CHECK_ETHWE_UP"
 

--- a/test/655_proxy_large_http_chunks_test.sh
+++ b/test/655_proxy_large_http_chunks_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Check the proxy handles arbitrarily large http chunks"
 # docker images returns all its data as one giant http chunk.

--- a/test/660_proxy_ipam_2_test.sh
+++ b/test/660_proxy_ipam_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 UNIVERSE=10.2.2.0/24
 

--- a/test/666_abuse_of_start_test.sh
+++ b/test/666_abuse_of_start_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Abuse of 'start' operation"
 

--- a/test/670_proxy_tls_test.sh
+++ b/test/670_proxy_tls_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Boot the proxy with TLS-enabled Docker support"
 

--- a/test/680_proxy_hostname_derivation_test.sh
+++ b/test/680_proxy_hostname_derivation_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.0.78
 C2=10.2.0.34

--- a/test/685_proxy_weave_run_test.sh
+++ b/test/685_proxy_weave_run_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1=10.2.1.13
 

--- a/test/690_proxy_config_test.sh
+++ b/test/690_proxy_config_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Various launch-proxy configurations"
 

--- a/test/695_proxy_failure_modes_test.sh
+++ b/test/695_proxy_failure_modes_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Proxy failure modes"
 

--- a/test/700_status_and_report_2_test.sh
+++ b/test/700_status_and_report_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 UNIVERSE=10.2.0.0/16
 

--- a/test/705_detect_hairpin_test.sh
+++ b/test/705_detect_hairpin_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Detect hairpin mode"
 

--- a/test/800_plugin_cross_hosts_2_test.sh
+++ b/test/800_plugin_cross_hosts_2_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1_NAME=c1.weave.local
 C2_NAME=seetwo.weave.local

--- a/test/810_plugin_router_restart_test.sh
+++ b/test/810_plugin_router_restart_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 C1_NAME=c1.weave.local
 

--- a/test/820_plugin_subnet_test.sh
+++ b/test/820_plugin_subnet_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Test Docker Network plugin with specified subnet"
 

--- a/test/830_cni_plugin_test.sh
+++ b/test/830_cni_plugin_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 start_suite "Test CNI plugin"
 

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 tear_down_kubeadm() {
     for host in $HOSTS; do

--- a/test/sanity_check.sh
+++ b/test/sanity_check.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 set -e
 

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-. ./config.sh
+. "$(dirname "$0")/config.sh"
 
 (cd ./tls && ./tls $HOSTS)
 


### PR DESCRIPTION
Currently, depending on your current directory, `make`, tests, etc. may or may not run smoothly.
This is a pre-change refactoring for the #2647 work.