### PR TITLE
Finding and running tests no longer depends on current directory.

### DIFF
--- a/test/601_proxy_docker_py_test.sh
+++ b/test/601_proxy_docker_py_test.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
-. ./600_proxy_docker_py.sh
+. "$(dirname "$0")/600_proxy_docker_py.sh"
 
 docker_py_test 0 4

--- a/test/602_proxy_docker_py_test.sh
+++ b/test/602_proxy_docker_py_test.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
-. ./600_proxy_docker_py.sh
+. "$(dirname "$0")/600_proxy_docker_py.sh"
 
 docker_py_test 1 4

--- a/test/603_proxy_docker_py_test.sh
+++ b/test/603_proxy_docker_py_test.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
-. ./600_proxy_docker_py.sh
+. "$(dirname "$0")/600_proxy_docker_py.sh"
 
 docker_py_test 2 4

--- a/test/604_proxy_docker_py_test.sh
+++ b/test/604_proxy_docker_py_test.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
-. ./600_proxy_docker_py.sh
+. "$(dirname "$0")/600_proxy_docker_py.sh"
 
 docker_py_test 3 4

--- a/test/670_proxy_tls_test.sh
+++ b/test/670_proxy_tls_test.sh
@@ -13,6 +13,6 @@ weave_on $HOST1 launch-proxy \
   --tlscert   $PWD/tls/$HOST1.pem \
   --tlskey    $PWD/tls/$HOST1-key.pem
 
-assert_raises "DOCKER_CERT_PATH=./tls proxy docker_on $HOST1 --tlsverify ps"
+assert_raises "DOCKER_CERT_PATH=$(dirname "$0")/tls proxy docker_on $HOST1 --tlsverify ps"
 
 end_suite

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -26,7 +26,7 @@ run_on $HOST3 "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN 
 
 [ -n "$COVERAGE" ] && COVERAGE_ARGS="\\n          env:\\n            - name: EXTRA_ARGS\\n              value: \"-test.coverprofile=/home/weave/cover.prof --\""
 
-sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never$COVERAGE_ARGS%" ../prog/weave-kube/weave-daemonset.yaml | run_on $HOST1 "kubectl apply -f -"
+sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never$COVERAGE_ARGS%" "$(dirname "$0")/../prog/weave-kube/weave-daemonset.yaml" | run_on $HOST1 "kubectl apply -f -"
 
 sleep 5
 

--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -10,7 +10,7 @@ if ! bash "$DIR/sanity_check.sh"; then
 fi
 whitely echo ...ok
 
-TESTS="${@:-$(find . -name '*_test.sh')}"
+TESTS="${@:-$(find "$DIR" -name '*_test.sh')}"
 RUNNER_ARGS=""
 
 # If running on circle, use the scheduler to work out what tests to run

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-. "$(dirname "$0")/config.sh"
+. ./config.sh
 
 (cd ./tls && ./tls $HOSTS)
 


### PR DESCRIPTION
Currently, depending on your current directory, `make`, tests, etc. may or may not run smoothly.
This is a pre-change refactoring for the #2647 work.