### PR TITLE
Parallelise sanity checks in order to speed them up.

### DIFF
--- a/bin/circle-test-smoke
+++ b/bin/circle-test-smoke
@@ -9,5 +9,7 @@ if [ -n "$TEST_AND_PUBLISH" ] ; then
     cd $SRCDIR/test
     eval $(./gce.sh hosts)
     export COVERAGE=true
+    export WEAVE_NET_SANITY_CHECKS_FILES="/tmp/weave_net_sanity_check_*.log"
     ./run_all.sh
+    cp $WEAVE_NET_SANITY_CHECKS_FILES $CIRCLE_ARTIFACTS
 fi

--- a/bin/circle-test-smoke
+++ b/bin/circle-test-smoke
@@ -9,7 +9,6 @@ if [ -n "$TEST_AND_PUBLISH" ] ; then
     cd $SRCDIR/test
     eval $(./gce.sh hosts)
     export COVERAGE=true
-    export WEAVE_NET_SANITY_CHECKS_FILES="/tmp/weave_net_sanity_check_*.log"
+    export WEAVE_NET_SANITY_CHECKS_FILES="$CIRCLE_ARTIFACTS/weave_net_sanity_check_*.log"
     ./run_all.sh
-    cp $WEAVE_NET_SANITY_CHECKS_FILES $CIRCLE_ARTIFACTS
 fi

--- a/test/sanity_check.sh
+++ b/test/sanity_check.sh
@@ -9,7 +9,7 @@ whitely echo Ping each host from the other
 for host in $HOSTS; do
     for other in $HOSTS; do
         if [ "$host" != "$other" ]; then
-            run_on $host $PING $other &
+            echo $(run_on $host $PING $other) &
             pids="$pids $!"
         fi
     done

--- a/test/sanity_check.sh
+++ b/test/sanity_check.sh
@@ -16,6 +16,7 @@ function check_ping() {
     return $status
 }
 
+pids=""
 for host in $HOSTS; do
     for other in $HOSTS; do
         if [ "$host" != "$other" ]; then
@@ -25,7 +26,6 @@ for host in $HOSTS; do
     done
 done
 for pid in $pids; do wait $pid; done
-unset pids
 
 
 whitely echo Check we can reach docker
@@ -49,6 +49,7 @@ $weave_version
 EOF
 }
 
+pids=""
 for host in $HOSTS; do
     check_docker $host &
     pids="$pids $!"

--- a/test/sanity_check.sh
+++ b/test/sanity_check.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+begin=$(date +%s)
+
 whitely echo Ping each host from the other
 
 # We wrap ping and echo in a function as we want the below parallel for loop
@@ -55,3 +57,5 @@ for host in $HOSTS; do
     pids="$pids $!"
 done
 for pid in $pids; do wait $pid; done
+
+echo "Sanity checks completed successfully in $(date -u -d @$(($(date +%s)-$begin)) +"%T")."

--- a/test/sanity_check.sh
+++ b/test/sanity_check.sh
@@ -6,10 +6,20 @@ set -e
 
 whitely echo Ping each host from the other
 
+# We wrap ping and echo in a function as we want the below parallel for loop
+# to exit early in case of a failed ping, and it cannot be done concisely,
+# e.g. using a one-liner, without losing the status code for ping.
+function check_ping() {
+    local output=$(run_on $1 $PING $2)
+    local status=$?
+    echo $output
+    return $status
+}
+
 for host in $HOSTS; do
     for other in $HOSTS; do
         if [ "$host" != "$other" ]; then
-            echo $(run_on $host $PING $other) &
+            check_ping "$host" "$other" &
             pids="$pids $!"
         fi
     done

--- a/test/sanity_check.sh
+++ b/test/sanity_check.sh
@@ -5,23 +5,42 @@
 set -e
 
 whitely echo Ping each host from the other
+
 for host in $HOSTS; do
     for other in $HOSTS; do
-        [ $host = $other ] || run_on $host $PING $other
+        if [ "$host" != "$other" ]; then
+            run_on $host $PING $other &
+            pids="$pids $!"
+        fi
     done
 done
+for pid in $pids; do wait $pid; done
+unset pids
+
 
 whitely echo Check we can reach docker
 
+function check_docker() {
+    docker_version=$(docker_on $1 version)
+    docker_info=$(docker_on $1 info)
+    docker_weave_version=$(docker_on $1 inspect -f {{.Created}} weaveworks/weave:${WEAVE_VERSION:-latest})
+    weave_version=$(weave_on $1 version)
+    cat << EOF
+
+Host Version Info: $1
+=====================================
+# docker version
+$docker_version
+# docker info
+$docker_info
+# weave version
+$docker_weave_version
+$weave_version
+EOF
+}
+
 for host in $HOSTS; do
-    echo
-    echo Host Version Info: $host
-    echo =====================================
-    echo "# docker version"
-    docker_on $host version
-    echo "# docker info"
-    docker_on $host info
-    echo "# weave version"
-    docker_on $host inspect -f {{.Created}} weaveworks/weave:${WEAVE_VERSION:-latest}
-    weave_on $host version
+    check_docker $host &
+    pids="$pids $!"
 done
+for pid in $pids; do wait $pid; done


### PR DESCRIPTION
Time spent running the sanity checks becomes a blocker when trying to ramp up the number of test servers, given ping check is `O(n^2)` and docker check is `O(n)`. This change makes it closer to "perceived" `O(1)`.
This is a pre-change refactoring for the #2647 and #2648 work.