### PR TITLE
Upgrade Vagrantfile to Ubuntu 16.04 'bento' box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ require './vagrant-common.rb'
 vm_ip = "172.16.0.3" # arbitrary private IP
 
 pkgs = %w(
-  docker-engine=1.10.2-0~wily
+  docker-engine=1.10.2-0~xenial
   aufs-tools
   build-essential
   ethtool
@@ -19,7 +19,7 @@ pkgs = %w(
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/wily64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.network "private_network", ip: vm_ip
   config.vm.provider :virtualbox do |vb|

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -14,7 +14,7 @@ require '../vagrant-common.rb'
 def configure_docker(host, hostname, ip)
   pkgs = %w(docker-engine ethtool)
 
-  host.vm.box = "ubuntu/wily64"
+  host.vm.box = "bento/ubuntu-16.04"
 
   host.vm.provision :shell, :inline => "hostnamectl set-hostname "+hostname
   host.vm.network "private_network", ip: ip
@@ -22,7 +22,7 @@ def configure_docker(host, hostname, ip)
   host.vm.synced_folder ".", "/vagrant", disabled: true
 
   host.vm.provision :shell, :inline => "sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"
-  host.vm.provision :shell, :inline => "echo deb https://apt.dockerproject.org/repo ubuntu-wily main > /etc/apt/sources.list.d/docker.list"
+  host.vm.provision :shell, :inline => "echo deb https://apt.dockerproject.org/repo ubuntu-xenial main > /etc/apt/sources.list.d/docker.list"
 
   install_packages host.vm, pkgs
   tweak_docker_daemon host.vm

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -16,8 +16,9 @@ def configure_docker(host, hostname, ip)
 
   host.vm.box = "bento/ubuntu-16.04"
 
-  host.vm.provision :shell, :inline => "hostnamectl set-hostname "+hostname
+  host.vm.hostname=hostname
   host.vm.network "private_network", ip: ip
+  host.vm.provision :shell, :inline => "echo "+ip+" "+hostname+" >> /etc/hosts"
 
   host.vm.synced_folder ".", "/vagrant", disabled: true
 

--- a/vagrant-common.rb
+++ b/vagrant-common.rb
@@ -10,7 +10,7 @@ $go_path = "/usr/local/go/bin"
 def install_packages(vm, pkgs)
   vm.provision :shell, :inline => <<SCRIPT
 apt-get update -qq
-apt-get install -qq -y --force-yes --no-install-recommends #{pkgs.join(' ')}
+apt-get install -qq -y --no-install-recommends #{pkgs.join(' ')}
 SCRIPT
 end
 
@@ -66,8 +66,8 @@ def cleanup(vm)
   vm.provision :shell, :inline => <<SCRIPT
 export DEBIAN_FRONTEND=noninteractive
 ## Who the hell thinks official images have to have both of these?
-/etc/init.d/chef-client stop
-/etc/init.d/puppet stop
+[ ! -f /etc/init.d/chef-client ] || /etc/init.d/chef-client stop
+[ ! -f /etc/init.d/puppet ]      || /etc/init.d/puppet stop
 apt-get -qq remove puppet chef
 apt-get -qq autoremove
 killall -9 chef-client 2>/dev/null || true


### PR DESCRIPTION
We need to upgrade Ubuntu because 'wily' (15.10) is unsupported and so many packages (e.g. Docker RCs) are not released for it.

The 'ubuntu' boxes seem to be rather broken, e.g. create a user called 'ubuntu' instead of 'vagrant', so I moved to the 'bento' box.

As a bonus, we don't need to remove puppet and chef.

I needed to upgrade to Virtualbox 5.1 before it would work.