### PR TITLE
Parallelise setup.sh's individual tasks.

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+begin=$(date +%s)
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 . "$(dirname "$0")/config.sh"
@@ -59,4 +60,4 @@ for ppid in $ppids; do
     wait $ppid;
 done
 
-echo "Setup completed successfully."
+echo "Setup completed successfully in $(date -u -d @$(($(date +%s)-$begin)) +"%T")."

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -11,27 +11,52 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 echo "Copying weave images, scripts, and certificates to hosts, and"
 echo "  prefetch test images"
 
+exists_on() {
+    docker_on $1 inspect --format=" " $2 >/dev/null 2>&1
+}
+
+pull_if_missing() {
+    if ! exists_on "$1" "$2" ; then
+        echo "Pulling $2 on $1..."
+        docker_on $1 pull $2 > /dev/null
+    fi
+}
+
 setup_host() {
-    HOST=$1
-    docker_on $HOST load -i ../weave.tar.gz
+    local HOST=$1
+    docker_on $HOST load -i ../weave.tar.gz &
+    local pids="$!"
+    
     DANGLING_IMAGES="$(docker_on $HOST images -q -f dangling=true)"
     [ -n "$DANGLING_IMAGES" ] && docker_on $HOST rmi $DANGLING_IMAGES 1>/dev/null 2>&1 || true
     run_on $HOST mkdir -p bin
-    upload_executable $HOST ../bin/docker-ns
-    upload_executable $HOST ../weave
-    rsync -az -e "$SSH" --exclude=tls ./tls/ $HOST:~/tls
+    
+    upload_executable $HOST ../bin/docker-ns &
+    local pids="$pids $!"
+    
+    upload_executable $HOST ../weave &
+    local pids="$pids $!"
+
+    rsync -az -e "$SSH" --exclude=tls ./tls/ $HOST:~/tls &
+    local pids="$pids $!"
+
     for IMG in $TEST_IMAGES ; do
-        docker_on $HOST inspect --format=" " $IMG >/dev/null 2>&1 || docker_on $HOST pull $IMG
+        pull_if_missing "$HOST" "$IMG"
+        local pids="$pids $!"
     done
+    for pid in $pids; do wait $pid; done
 }
 
+ppids=""
 for HOST in $HOSTS; do
     setup_host $HOST &
-    pids="$pids $!"
+    ppids="$ppids $!"
 done
 
 # Wait individually for tasks so we fail-exit on any non-zero return code
 # ('wait' on its own always returns 0)
-for pid in $pids; do
-    wait $pid;
+for ppid in $ppids; do
+    wait $ppid;
 done
+
+echo "Setup completed successfully."


### PR DESCRIPTION
Time spent running the setup steps becomes a blocker when trying to ramp up the number of test servers, given we are currently mainly blocking on I/O -- i.e. many files are uploaded/downloaded, which could easily be done faster.
This is a pre-change refactoring for the #2647 and #2648 work.