### PR TITLE
Do not segfault if the datapath exists

### DIFF
--- a/common/odp/odp.go
+++ b/common/odp/odp.go
@@ -21,8 +21,13 @@ func CreateDatapath(dpname string) (supported bool, err error) {
 	defer dpif.Close()
 
 	dp, err := dpif.CreateDatapath(dpname)
-	if err != nil && !odp.IsDatapathNameAlreadyExistsError(err) {
-		return true, err
+	if err != nil {
+		if !odp.IsDatapathNameAlreadyExistsError(err) {
+			return true, err
+		}
+		if dp, err = dpif.LookupDatapath(dpname); err != nil {
+			return true, err
+		}
 	}
 
 	// Pick an ephemeral port number to use in probing for vxlan


### PR DESCRIPTION
If the datapath exists when creating it, `dpif.CreateDatapath` will return an empty handle which access causes the segfault.

Fixes segfault in #2638