### PR TITLE
Mount /etc under a different path for weave-kube

### DIFF
--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -39,11 +39,11 @@ spec:
             - name: weavedb
               mountPath: /weavedb
             - name: cni-bin
-              mountPath: /opt
+              mountPath: /host/opt
             - name: cni-bin2
-              mountPath: /host_home
+              mountPath: /host/home
             - name: cni-conf
-              mountPath: /etc
+              mountPath: /host/etc
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
So we don't accidentally read or write the hosts's `/etc`.

Also move the other volumes under `/host` to be more consistent with what the weave script expects.