### PR TITLE
Swap HTTP and container checks in wait_for_status.

### DIFF
--- a/weave
+++ b/weave
@@ -994,12 +994,12 @@ wait_for_status() {
     container="$1"
     shift
     while true ; do
-        "$@" GET /status >/dev/null 2>&1 && return 0
         if ! check_running $container >/dev/null 2>&1 ; then
             kill_container $container # stop it restarting
             echo $(death_msg $container) >&2
             return 1
         fi
+        "$@" GET /status >/dev/null 2>&1 && return 0
         fractional_sleep 0.1
     done
 }


### PR DESCRIPTION
Another process may be listening on `6784` and reply incorrectly or with misleading responses, e.g. when both `weave` and `weave-kube` are running and `weave` crashed for some reason.
Swapping the two checks should make things more robust.

Fixes #2709.