### PR TITLE
Remove the deprecated MAINTAINER field in Dockerfiles for "LABEL maintainer" instead

### DIFF
--- a/prog/weave-npc/Dockerfile
+++ b/prog/weave-npc/Dockerfile
@@ -1,4 +1,13 @@
 FROM alpine
+
+LABEL maintainer "Weaveworks Inc <help@weave.works>"
+LABEL works.weave.role=system \
+      org.label-schema.name="Weave Net" \
+      org.label-schema.description="Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery" \
+      org.label-schema.url="https://weave.works" \
+      org.label-schema.vcs-url="https://github.com/weaveworks/weave" \
+      org.label-schema.vendor="Weaveworks"
+
 RUN apk add --update \
     iptables \
     ipset \

--- a/prog/weavedb/Dockerfile
+++ b/prog/weavedb/Dockerfile
@@ -1,6 +1,6 @@
 # This is a nearly-empty image that we use to create a data-only container for persistence
 FROM scratch
-MAINTAINER Weaveworks Inc <help@weave.works>
+LABEL maintainer "Weaveworks Inc <help@weave.works>"
 ENTRYPOINT ["data-only"]
 # Work round Docker refusing to save an empty image
 COPY Dockerfile /

--- a/prog/weaveexec/Dockerfile
+++ b/prog/weaveexec/Dockerfile
@@ -1,7 +1,12 @@
 FROM alpine
 
-MAINTAINER Weaveworks Inc <help@weave.works>
-LABEL works.weave.role=system
+LABEL maintainer "Weaveworks Inc <help@weave.works>"
+LABEL works.weave.role=system \
+      org.label-schema.name="Weave Net" \
+      org.label-schema.description="Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery" \
+      org.label-schema.url="https://weave.works" \
+      org.label-schema.vcs-url="https://github.com/weaveworks/weave" \
+      org.label-schema.vendor="Weaveworks"
 
 WORKDIR /home/weave
 ENTRYPOINT ["/home/weave/sigproxy", "/home/weave/weave"]

--- a/prog/weaver/Dockerfile.template
+++ b/prog/weaver/Dockerfile.template
@@ -1,6 +1,4 @@
 FROM DOCKERHUB_USER/weaveexec
-MAINTAINER Weaveworks Inc <help@weave.works>
-LABEL works.weave.role=system
 WORKDIR /home/weave
 ADD ./weaver /home/weave/
 ADD weavedata.db /weavedb/


### PR DESCRIPTION
Fixes https://github.com/weaveworks/weave/issues/2705

This is more of a test PR for me to see if everything works as it should.
I've now used the lucas@weave.works address.

cc @bboreham 