### PR TITLE
Fix ordering bug in test #150.

### DIFF
--- a/test/150_connect_forget_2_test.sh
+++ b/test/150_connect_forget_2_test.sh
@@ -11,7 +11,7 @@ direct_peers() {
 }
 
 assert_peers() {
-  assert "direct_peers $1 | sort" "$(echo "$2" | sort)"
+  assert "direct_peers $1 | sort" "$(echo -e "$2" | sort)"
 }
 
 start_suite "Connecting and forgetting routers after launch"


### PR DESCRIPTION
Fixes flaky test runs like the below:

```
>>> Running /root/src/github.com/weaveworks/weave/test/150_connect_forget_2_test.sh on [138.68.153.213 138.68.149.186]
>>> Test /root/src/github.com/weaveworks/weave/test/150_connect_forget_2_test.sh finished after 12.4 secs with error: exit status 1
test #5 "direct_peers 138.68.149.186 | sort" failed:
  expected "138.68.153.213\n138.68.149.186"
  got "138.68.149.186\n138.68.153.213"
```

Test:
```
#!/bin/bash
assert_peers() {
  printf "$(echo "$1" | sort)"
}

fix() {
  printf "$(echo -e "$1" | sort)"
}

echo "Current state (broken):"
assert_peers "138.68.153.213\n138.68.149.186"
echo
assert_peers "138.68.149.186\n138.68.153.213"
echo

echo "Target state (fixed):"
fix "138.68.153.213\n138.68.149.186"
echo
fix "138.68.149.186\n138.68.153.213"
echo
```

Output:
```
$ ./test.sh 
Current state (broken):
138.68.153.213
138.68.149.186
138.68.149.186
138.68.153.213
Target state (fixed):
138.68.149.186
138.68.153.213
138.68.149.186
138.68.153.213
```
