### PR TITLE
Removed dependency on jq in test #175.

### DIFF
--- a/test/175_target_peer_persistence_3_test.sh
+++ b/test/175_target_peer_persistence_3_test.sh
@@ -7,7 +7,7 @@ assert_targets() {
     HOST=$1
     shift
     EXPECTED=$(for TARGET in $@; do echo $TARGET; done | sort)
-    assert "weave_on $HOST report | jq -r '.Router.Targets[] | tostring' | sort" "$EXPECTED"
+    assert "weave_on $HOST report -f '{{range .Router.Targets}}{{.}}{{\"\n\"}}{{end}}' | sort" "$EXPECTED"
 }
 
 start_suite "Check Docker restart uses persisted peer list"


### PR DESCRIPTION
If the machine coordinating the test runs does not have `jq`, then test #175 fails with:

```
test #1 "weave_on test-0.lon1.weave-net report | jq -r '.Router.Targets[] | tostring' | sort" failed:
    expected "test-1.lon1.weave-net
test-2.lon1.weave-net"
    got nothing
```

This change completely removes the dependency on `jq` to make the test more robust and avoid potential confusion.