### PR TITLE
SIGKILL ulogd on weave-npc exit

### DIFF
--- a/npc/ulogd/ulogd.go
+++ b/npc/ulogd/ulogd.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/weaveworks/weave/common"
 )
@@ -17,6 +18,9 @@ func waitForExit(cmd *exec.Cmd) {
 
 func Start() error {
 	cmd := exec.Command("/usr/sbin/ulogd", "-v")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
 	stdout, err := cmd.StderrPipe()
 	if err != nil {
 		return err


### PR DESCRIPTION
Under certain circumstances (such as containerd-shim being killed) the main weave-npc process can be terminated without ulogd receiving any signals; consequently set PDEATHSIG so that ulogd is killed by the kernel.

Fixes #2653.