### PR TITLE
Don't fail if only half the system IDs are blank

### DIFF
--- a/net/uuid.go
+++ b/net/uuid.go
@@ -30,7 +30,7 @@ func getSystemUUID(hostRoot string) ([]byte, error) {
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
-	if len(uuid) == 0 {
+	if len(uuid) == 0 && len(machineid) == 0 {
 		return nil, errors.New("All system IDs are blank")
 	}
 	return append(machineid, uuid...), nil


### PR DESCRIPTION
Fix a bug in #2711 
The symptom, on Scaleway, is:

```+ weaveutil unique-id /host//weave /host
All system IDs are blank
```