### PR TITLE
Upgrade Weave Net to latest version of build-tools, skipping bash scripts when lint-ing.

### DIFF
--- a/.lintignore
+++ b/.lintignore
@@ -1,0 +1,8 @@
+# IMPORTANT: Please only use GLOBs to ignore files and directories.
+
+# Do not lint any bash script in Weave Net, in order to 
+# avoid breaking the build on make lint:
+*.sh
+bin/*
+prog/weaveexec/symlink
+weave

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ exes $(EXES) tests lint: $(BUILD_UPTODATE)
 	$(SUDO) docker run $(RM) $(RUN_FLAGS) \
 	    -v $(shell pwd):/go/src/github.com/weaveworks/weave \
 		-v $(shell pwd)/.pkg:/go/pkg \
-		-e GOARCH=$(ARCH) -e CGO_ENABLED=1 -e GOOS=linux -e CIRCLECI -e CIRCLE_BUILD_NUM -e CIRCLE_NODE_TOTAL -e CIRCLE_NODE_INDEX -e COVERDIR -e SLOW \
+		-e GOARCH=$(ARCH) -e CGO_ENABLED=1 -e GOOS=linux -e CIRCLECI -e CIRCLE_BUILD_NUM -e CIRCLE_NODE_TOTAL -e CIRCLE_NODE_INDEX -e COVERDIR -e SLOW -e DEBUG \
 		$(BUILD_IMAGE) COVERAGE=$(COVERAGE) WEAVE_VERSION=$(WEAVE_VERSION) CC=$(CC) QEMUARCH=$(QEMUARCH) CGO_LDFLAGS=$(CGO_LDFLAGS) $@
 
 else

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ $(SIGPROXY_EXE) $(TEST_TLS_EXE) $(WEAVEWAIT_NOOP_EXE) $(RUNNER_EXE):
 	go build $(BUILD_FLAGS) -o $@ ./$(@D)
 
 tests:
-	./tools/test -no-go-get
+	./tools/test -no-go-get -netgo -timeout 8m
 
 lint:
 	./tools/lint -nocomment -notestpackage .

--- a/bin/circle-test-unit
+++ b/bin/circle-test-unit
@@ -6,6 +6,6 @@ source "$STATE"
 
 if [ -n "$TEST_AND_PUBLISH" ] ; then
     cd $SRCDIR
-    make lint
+    make DEBUG=1 lint
     COVERDIR=test/coverage make RM= tests
 fi


### PR DESCRIPTION
Lint-ing all of Weave Net is currently not desirable because: 

* it would create conflicts on many branches,
* it would pollute the git history, 
* etc. 

and because `lint` currently lints all files except `./vendor`, this breaks Weave Net's build.
As a result, Weave Net is not using the latest commit in `build-tools`'s `master` branch, which is also source of problems:

* it limits standardisation of projects across Weaveworks, 
* it limits the ability to use the latest features of `build-tools`, 
* it complexifies merging changes in `build-tools` (e.g. #53 and weaveworks/weave#2694 for weaveworks/weave#2647), 
* etc.

This change:

* brings Weave Net to the latest version of `build-tools` (which now supports `.lintignore` files),
* adds such a `.lintignore` file to skip all bash scripts (in order to avoid breaking the build).

`GLOB`s in `.lintignore` can then, over time and as scripts are `shfmt`-ed, be relaxed and maybe even removed.