### PR TITLE
Remove hard-coded NUM_HOSTS env. var.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,6 @@ machine:
     PATH: $PATH:$HOME/.local/bin
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     STATE: /home/ubuntu/state.env
-    NUM_HOSTS: 16
     # Base name of VMs for integration tests:
     NAME: test-$CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX
     TEST_VMS_SETUP_OUTPUT_FILE: $CIRCLE_ARTIFACTS/test_vms_setup_output.txt


### PR DESCRIPTION
Instead of hardcoding this in the code, this should be passed by CircleCI from: 
```
Settings 
  > weaveworks 
    > weave 
      > Environment Variables.
```