### PR TITLE
Add CONN_LIMIT environment var for running container

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -7,6 +7,7 @@ IPALLOC_RANGE=${IPALLOC_RANGE:-10.32.0.0/12}
 HTTP_ADDR=${WEAVE_HTTP_ADDR:-127.0.0.1:6784}
 STATUS_ADDR=${WEAVE_STATUS_ADDR:-0.0.0.0:6782}
 HOST_ROOT=${HOST_ROOT:-/host}
+CONN_LIMIT=${CONN_LIMIT:-30}
 
 # Check if the IP range overlaps anything existing on the host
 /usr/bin/weaveutil netcheck $IPALLOC_RANGE weave
@@ -113,5 +114,6 @@ exec /home/weave/weaver $EXTRA_ARGS --port=6783 $BRIDGE_OPTIONS \
      --http-addr=$HTTP_ADDR --status-addr=$STATUS_ADDR --docker-api='' --no-dns \
      --ipalloc-range=$IPALLOC_RANGE $NICKNAME_ARG \
      --ipalloc-init $IPALLOC_INIT \
+     --conn-limit=$CONN_LIMIT \
      "$@" \
      $KUBE_PEERS


### PR DESCRIPTION
Once the number of cluster nodes is more than 30, then i need to build a new image. So, i think we should add an environment var for running weave container in a large cluster.