### PR TITLE
Claim existing IP addresses at startup with no race condition

### DIFF
--- a/ipam/allocate.go
+++ b/ipam/allocate.go
@@ -14,9 +14,9 @@ type allocateResult struct {
 
 type allocate struct {
 	resultChan       chan<- allocateResult
-	ident            string
+	ident            string       // a container ID, something like "weave:expose", or api.NoContainerID
 	r                address.CIDR // Subnet we are trying to allocate within
-	isContainer      bool
+	isContainer      bool         // true if ident is a container ID
 	hasBeenCancelled func() bool
 }
 

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -77,8 +77,9 @@ type Allocator struct {
 }
 
 type PreClaim struct {
-	Ident string
-	Cidr  address.CIDR
+	Ident       string
+	IsContainer bool
+	Cidr        address.CIDR
 }
 
 type Config struct {

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -76,9 +76,10 @@ type Allocator struct {
 	now               func() time.Time
 }
 
+// PreClaims are IP addresses discovered before we could initialize IPAM
 type PreClaim struct {
-	Ident       string
-	IsContainer bool
+	Ident       string // a container ID, something like "weave:expose", or api.NoContainerID
+	IsContainer bool   // true if Ident is a container ID
 	Cidr        address.CIDR
 }
 

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -76,6 +76,11 @@ type Allocator struct {
 	now               func() time.Time
 }
 
+type PreClaim struct {
+	Ident string
+	Cidr  address.CIDR
+}
+
 type Config struct {
 	OurName     mesh.PeerName
 	OurUID      mesh.PeerUID
@@ -83,6 +88,7 @@ type Config struct {
 	Seed        []mesh.PeerName
 	Universe    address.CIDR
 	IsObserver  bool
+	PreClaims   []PreClaim
 	Quorum      func() uint
 	Db          db.DB
 	IsKnownPeer func(name mesh.PeerName) bool
@@ -123,6 +129,12 @@ func NewAllocator(config Config) *Allocator {
 		dead:        make(map[string]time.Time),
 		now:         time.Now,
 	}
+
+	alloc.pendingClaims = make([]operation, len(config.PreClaims))
+	for i, c := range config.PreClaims {
+		alloc.pendingClaims[i] = &claim{ident: c.Ident, cidr: c.Cidr}
+	}
+
 	return alloc
 }
 
@@ -155,6 +167,9 @@ func (alloc *Allocator) Start() {
 		alloc.infof("Initialising via deferred consensus")
 	default:
 		alloc.infof("Initialising as observer - awaiting IPAM data from another peer")
+	}
+	if loadedPersistedData { // do any pre-claims right away
+		alloc.tryOps(&alloc.pendingClaims)
 	}
 	actionChan := make(chan func(), mesh.ChannelSize)
 	stopChan := make(chan struct{})

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -174,7 +174,7 @@ func TestAllocatorClaim(t *testing.T) {
 	)
 
 	preAddr, _ := address.ParseCIDR(testPre)
-	allocs, router, subnet := makeNetworkOfAllocators(2, universe, []PreClaim{{container1, preAddr}})
+	allocs, router, subnet := makeNetworkOfAllocators(2, universe, []PreClaim{{container1, true, preAddr}})
 	defer stopNetworkOfAllocators(allocs, router)
 	alloc := allocs[1]
 	addr1, _ := address.ParseCIDR(testAddr1)

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -12,10 +12,10 @@ import (
 
 type claim struct {
 	resultChan       chan<- error
-	ident            string
-	cidr             address.CIDR
-	isContainer      bool
-	noErrorOnUnknown bool
+	ident            string       // a container ID, something like "weave:expose", or api.NoContainerID
+	cidr             address.CIDR // single address being claimed
+	isContainer      bool         // true if ident is a container ID
+	noErrorOnUnknown bool         // if false, error or block if we don't know; if true return ok but keep trying
 	hasBeenCancelled func() bool
 }
 

--- a/ipam/claim.go
+++ b/ipam/claim.go
@@ -35,7 +35,7 @@ func (c *claim) sendResult(result error) {
 
 // Try returns true for success (or failure), false if we need to try again later
 func (c *claim) Try(alloc *Allocator) bool {
-	if c.hasBeenCancelled() {
+	if c.hasBeenCancelled != nil && c.hasBeenCancelled() {
 		c.Cancel()
 		return true
 	}

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -66,28 +66,11 @@ if [ -z "$IPALLOC_INIT" ]; then
     IPALLOC_INIT="consensus=$(peer_count $KUBE_PEERS)"
 fi
 
-reclaim_ips() {
-    ID=$1
-    shift
-    for CIDR in "$@" ; do
-        curl -s -S -X PUT "$HTTP_ADDR/ip/$ID/$CIDR" || true
-    done
-}
-
 post_start_actions() {
     # Wait for weave process to become responsive
     while true ; do
         curl $HTTP_ADDR/status >/dev/null 2>&1 && break
         sleep 1
-    done
-
-    # Tell the newly-started weave about existing weave bridge IPs
-    /usr/bin/weaveutil container-addrs weave weave:expose | while read ID IFACE MAC IPS; do
-        reclaim_ips "weave:expose" $IPS
-    done
-    # Tell weave about existing weave process IPs
-    /usr/bin/weaveutil process-addrs weave | while read ID IFACE MAC IPS; do
-        reclaim_ips "_" $IPS
     done
 
     # Install CNI plugin binary to typical CNI bin location

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -306,15 +306,16 @@ func main() {
 			}
 			trackerName = "awsvpc"
 		}
-		preClaims, err := findExistingAddresses(weavenet.WeaveBridgeName)
+		var allContainerIDs []string
+		if dockerCli != nil {
+			allContainerIDs, err = dockerCli.AllContainerIDs()
+			checkFatal(err)
+		}
+		preClaims, err := findExistingAddresses(dockerCli, allContainerIDs, weavenet.WeaveBridgeName)
 		checkFatal(err)
 		allocator, defaultSubnet = createAllocator(router, ipamConfig, preClaims, db, t, isKnownPeer)
 		observeContainers(allocator)
-		if dockerCli != nil {
-			ids, err := dockerCli.AllContainerIDs()
-			checkFatal(err)
-			allocator.PruneOwned(ids)
-		}
+		allocator.PruneOwned(allContainerIDs)
 	}
 
 	var (

--- a/prog/weaver/reclaim.go
+++ b/prog/weaver/reclaim.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"net"
+
+	"github.com/weaveworks/weave/api"
+	"github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/ipam"
+	weavenet "github.com/weaveworks/weave/net"
+	"github.com/weaveworks/weave/net/address"
+)
+
+func a(cidr *net.IPNet) address.CIDR {
+	prefixLength, _ := cidr.Mask.Size()
+	return address.CIDR{Addr: address.FromIP4(cidr.IP), PrefixLen: prefixLength}
+}
+
+// Get all the existing Weave IPs at startup, so we can stop IPAM
+// giving out any as duplicates
+func findExistingAddresses(bridgeName string) (addrs []ipam.PreClaim, err error) {
+	// First get the address for the bridge
+	bridgeNetDev, err := weavenet.GetBridgeNetDev(bridgeName)
+	if err != nil {
+		return nil, err
+	}
+	for _, cidr := range bridgeNetDev.CIDRs {
+		addrs = append(addrs, ipam.PreClaim{Ident: "weave:expose", Cidr: a(cidr)})
+	}
+
+	// Then find all veths connected to the bridge
+	peerIDs, err := weavenet.ConnectedToBridgeVethPeerIds(bridgeName)
+	if err != nil {
+		return nil, err
+	}
+
+	pids, err := common.AllPids("/proc")
+	if err != nil {
+		return nil, err
+	}
+
+	// Now iterate over all processes to see if they have a network namespace with an attached interface
+	for _, pid := range pids {
+		netDevs, err := weavenet.GetNetDevsByVethPeerIds(pid, peerIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, netDev := range netDevs {
+			for _, cidr := range netDev.CIDRs {
+				// We don't know the container ID, so use special magic string
+				addrs = append(addrs, ipam.PreClaim{Ident: api.NoContainerID, Cidr: a(cidr)})
+			}
+		}
+	}
+	return addrs, nil
+}

--- a/prog/weaver/reclaim.go
+++ b/prog/weaver/reclaim.go
@@ -3,8 +3,11 @@ package main
 import (
 	"net"
 
+	docker "github.com/fsouza/go-dockerclient"
+
 	"github.com/weaveworks/weave/api"
 	"github.com/weaveworks/weave/common"
+	weavedocker "github.com/weaveworks/weave/common/docker"
 	"github.com/weaveworks/weave/ipam"
 	weavenet "github.com/weaveworks/weave/net"
 	"github.com/weaveworks/weave/net/address"
@@ -17,14 +20,25 @@ func a(cidr *net.IPNet) address.CIDR {
 
 // Get all the existing Weave IPs at startup, so we can stop IPAM
 // giving out any as duplicates
-func findExistingAddresses(bridgeName string) (addrs []ipam.PreClaim, err error) {
+func findExistingAddresses(dockerCli *weavedocker.Client, containerIDs []string, bridgeName string) (addrs []ipam.PreClaim, err error) {
+	Log.Infof("Checking for pre-existing addresses on %s bridge", bridgeName)
 	// First get the address for the bridge
 	bridgeNetDev, err := weavenet.GetBridgeNetDev(bridgeName)
 	if err != nil {
 		return nil, err
 	}
 	for _, cidr := range bridgeNetDev.CIDRs {
+		Log.Infof("%s bridge has address %v", bridgeName, cidr)
 		addrs = append(addrs, ipam.PreClaim{Ident: "weave:expose", Cidr: a(cidr)})
+	}
+
+	add := func(cid string, isContainer bool, netDevs []weavenet.Dev) {
+		for _, netDev := range netDevs {
+			for _, cidr := range netDev.CIDRs {
+				Log.Infof("Found address %v for ID %s", cidr, cid)
+				addrs = append(addrs, ipam.PreClaim{Ident: cid, IsContainer: isContainer, Cidr: a(cidr)})
+			}
+		}
 	}
 
 	// Then find all veths connected to the bridge
@@ -33,22 +47,37 @@ func findExistingAddresses(bridgeName string) (addrs []ipam.PreClaim, err error)
 		return nil, err
 	}
 
-	pids, err := common.AllPids("/proc")
-	if err != nil {
-		return nil, err
-	}
-
-	// Now iterate over all processes to see if they have a network namespace with an attached interface
-	for _, pid := range pids {
-		netDevs, err := weavenet.GetNetDevsByVethPeerIds(pid, peerIDs)
+	// Now iterate over all containers to see if they have a network
+	// namespace with an attached interface
+	if dockerCli != nil {
+		for _, cid := range containerIDs {
+			container, err := dockerCli.InspectContainer(cid)
+			if err != nil {
+				if _, ok := err.(*docker.NoSuchContainer); ok {
+					continue
+				}
+				return nil, err
+			}
+			if container.State.Pid != 0 {
+				netDevs, err := weavenet.GetNetDevsByVethPeerIds(container.State.Pid, peerIDs)
+				if err != nil {
+					return nil, err
+				}
+				add(cid, true, netDevs)
+			}
+		}
+	} else {
+		// If we don't have a Docker connection, iterate over all processes
+		pids, err := common.AllPids("/proc")
 		if err != nil {
 			return nil, err
 		}
-		for _, netDev := range netDevs {
-			for _, cidr := range netDev.CIDRs {
-				// We don't know the container ID, so use special magic string
-				addrs = append(addrs, ipam.PreClaim{Ident: api.NoContainerID, Cidr: a(cidr)})
+		for _, pid := range pids {
+			netDevs, err := weavenet.GetNetDevsByVethPeerIds(pid, peerIDs)
+			if err != nil {
+				return nil, err
 			}
+			add(api.NoContainerID, false, netDevs)
 		}
 	}
 	return addrs, nil

--- a/test/320_claim_3_test.sh
+++ b/test/320_claim_3_test.sh
@@ -49,6 +49,7 @@ delete_persistence $HOST1 $HOST2
 # Now make host1 attempt to claim from host2, when host2 is stopped
 # the point being to check whether host1 will hang trying to talk to host2
 weave_on $HOST2 launch-router --ipalloc-range $UNIVERSE
+weave_on $HOST2 prime
 # Introduce host3 to remember the IPAM CRDT when we stop host2
 weave_on $HOST3 launch-router --ipalloc-range $UNIVERSE $HOST2
 weave_on $HOST3 prime

--- a/weave
+++ b/weave
@@ -1304,25 +1304,6 @@ check_overlap() {
     util_op netcheck $1 $BRIDGE
 }
 
-# Claim addresses for a container in IPAM.  Expects to be called from
-# with_container_addresses.
-ipam_reclaim() {
-    CONTAINER_ID="$1"
-    # The weave IP addresses of containers attached by the plugin are
-    # recorded specially in IPAM, since the container id is not know
-    # at the time.
-    [ "$2" = "$CONTAINER_IFNAME" ] || CONTAINER_ID="_"
-    for CIDR in $4 ; do
-        http_call $HTTP_ADDR PUT "/ip/$CONTAINER_ID/$CIDR?noErrorOnUnknown=true&?check-alive=true" || true
-    done
-}
-
-ipam_reclaim_no_check_alive() {
-    for CIDR in $4 ; do
-        http_call $HTTP_ADDR PUT /ip/$1/$CIDR?noErrorOnUnknown=true || true
-    done
-}
-
 detect_awsvpc() {
     # Ignoring errors here: if we cannot detect AWSVPC we will skip the relevant
     # steps, because "attach" should work without the weave router running.
@@ -1729,17 +1710,10 @@ setup_awsvpc() {
 # Recreate the parameter values that are set when the router is first launched
 fetch_router_args() {
     CONTAINER_ARGS=$(docker inspect -f '{{.Args}}' $CONTAINER_NAME) || return 1
-    IPRANGE=$(echo $CONTAINER_ARGS | grep -o -E -e '-ipalloc-range [0-9/.]+') || true
     NO_DNS_OPT=$(echo $CONTAINER_ARGS | grep -o -e '--no-dns') || true
 }
 
 populate_router() {
-    if [ -n "$IPRANGE" ] ; then
-        # Tell the newly-started weave IP allocator about existing weave IPs
-        # In the case of AWSVPC, we do expose before calling populate_router
-        [ -n "$AWSVPC" ] || with_container_addresses ipam_reclaim_no_check_alive weave:expose
-        with_container_addresses ipam_reclaim $(docker ps -q --no-trunc)
-    fi
     if [ -z "$NO_DNS_OPT" ] ; then
         # Tell the newly-started weaveDNS about existing weave IPs
         for CONTAINER in $(docker ps -q --no-trunc) ; do

--- a/weave
+++ b/weave
@@ -1691,6 +1691,7 @@ launch_router() {
     ROUTER_CONTAINER=$(docker run -d --name=$CONTAINER_NAME \
         $(docker_run_options) \
         $RESTART_POLICY \
+        --pid=host \
         --volumes-from $DB_CONTAINER_NAME \
         -v $RESOLV_CONF_DIR:/var/run/weave/etc \
         -e WEAVE_PASSWORD \


### PR DESCRIPTION
Fixes #2784 

`reclaim.go` is a re-implementation of the `launch.sh` code to claim addresses in Go.
We already had a `pendingClaims` list in IPAM, so we simply pre-populate this with entries for each existing address.  The claims will be processed as soon as the ring is known.

As it stands, this code is only good enough for `weave-kube`, not for `weave launch`
The code to find existing IPs works through the process table, and thus we do not have the Docker container ID.  To resolve that I propose to add another loop to go through Docker container IDs if we have a Docker API connection.