### PR TITLE
Update vishvananda/netlink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/weaveworks/build-tools
 [submodule "vendor/github.com/vishvananda/netlink"]
 	path = vendor/github.com/vishvananda/netlink
-	url = https://github.com/weaveworks/netlink.git
+	url = https://github.com/vishvananda/netlink.git
 [submodule "vendor/github.com/gorilla/mux"]
 	path = vendor/github.com/gorilla/mux
 	url = https://github.com/gorilla/mux.git


### PR DESCRIPTION
Changes the origin to `vishvananda/netlink` from `weaveworks/netlink` as the required PRs got merged.