### PR TITLE
Reference-count ipset entries

### DIFF
--- a/npc/ipset/ipset.go
+++ b/npc/ipset/ipset.go
@@ -53,18 +53,22 @@ func (i *ipset) DelEntry(ipsetName Name, entry string) error {
 }
 
 func (i *ipset) Flush(ipsetName Name) error {
+	i.removeSet(ipsetName)
 	return doExec("flush", string(ipsetName))
 }
 
 func (i *ipset) FlushAll() error {
+	i.refCount = newRefCount()
 	return doExec("flush")
 }
 
 func (i *ipset) Destroy(ipsetName Name) error {
+	i.removeSet(ipsetName)
 	return doExec("destroy", string(ipsetName))
 }
 
 func (i *ipset) DestroyAll() error {
+	i.refCount = newRefCount()
 	return doExec("destroy")
 }
 
@@ -100,4 +104,12 @@ func (rc *refCount) dec(ipsetName Name, entry string) int {
 	k := key{ipsetName, entry}
 	rc.ref[k]--
 	return rc.ref[k]
+}
+
+func (rc *refCount) removeSet(ipsetName Name) {
+	for k := range rc.ref {
+		if k.ipsetName == ipsetName {
+			delete(rc.ref, k)
+		}
+	}
 }


### PR DESCRIPTION
To avoid crashing on error from `ipset` when we receive an Add before a Delete; fixes #2792 

Note that a real, long-lasting, IP duplication is a real problem, and this change makes it much less likely that we would spot that.
