### PR TITLE
Make /usr/local/go writable to anyone

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -62,6 +62,9 @@ RUN for platform in ${GO_CROSSPLATFORMS}; do \
 		GOOS=${platform%/*} GOARCH=${platform##*/} \
 			go install -tags netgo std; done
 
+# Allow full write access to the Go folders for anyone
+RUN chmod -R a+w /usr/local/go
+
 # The libpcap version from Debian packages is 1.6.2, matching that version here although newer versions of libpcap have been released
 # We have to cross-compile the libpcap library for the new architectures, that's what we're doing here
 ENV LIBPCAP_CROSS_VERSION=1.6.2

--- a/build/build.sh
+++ b/build/build.sh
@@ -25,7 +25,4 @@ echo "weave:x:$uid:$gid::$WEAVE_SRC:/bin/sh" >>/etc/passwd
 echo "weave:*:::::::" >>/etc/shadow
 echo "weave	ALL=(ALL)	NOPASSWD: ALL" >>/etc/sudoers
 
-# Allow full write access to the Go folders for the user Weave
-chown -R $uid:$gid /usr/local/go
-
 su weave -c "PATH=$PATH make -C $WEAVE_SRC BUILD_IN_CONTAINER=false $*"


### PR DESCRIPTION
Previous attempt to chown the dir inside `build.sh` resulted in a significant increase in a build time, and `build.sh` is exec'd once per every build.

Fix #2761 