### PR TITLE
Add prometheus metrics for pending Allocates and Claims

### DIFF
--- a/prog/weaver/metrics.go
+++ b/prog/weaver/metrics.go
@@ -82,6 +82,18 @@ var metrics = []metric{
 				ch <- intGauge(desc, metrics.Flows)
 			}
 		}},
+	{desc("weave_ipam_pending_allocates", "Number of pending allocates."),
+		func(s WeaveStatus, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
+			if s.IPAM != nil {
+				ch <- intGauge(desc, len(s.IPAM.PendingAllocates))
+			}
+		}},
+	{desc("weave_ipam_pending_claims", "Number of pending claims."),
+		func(s WeaveStatus, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
+			if s.IPAM != nil {
+				ch <- intGauge(desc, len(s.IPAM.PendingClaims))
+			}
+		}},
 }
 
 func fastDPMetrics(s WeaveStatus) *weave.FastDPMetrics {

--- a/site/metrics.md
+++ b/site/metrics.md
@@ -19,6 +19,8 @@ exposed:
 * `weave_max_ips` - Size of IP address space used by allocator.
 * `weave_dns_entries` - Number of DNS entries.
 * `weave_flows` - Number of FastDP flows.
+* `weave_ipam_pending_allocates` - Number of pending allocates.
+* `weave_ipam_pending_claims` - Number of pending claims.
 
 #### Publish Router Metrics Endpoint
 


### PR DESCRIPTION
We were bitten by #2797 yesterday (All of our nodes stopped working, because all of the address space was consumed by nodes we'd deleted)

When trying to figure out how to monitor for this situation, none of the existing metrics seemed suitable.

We plan to put alerting on `weave_ipam_pending_claims >0 for >5 minutes`, or something similar