### PR TITLE
Use a keyserver port that's better for firewalls

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,7 +21,7 @@ ENV GCC_CROSSCOMPILERS \
 # Temporarily add the Ubuntu repositories, because we're going to install gcc cross-compilers from there
 # Install the build-essential and crossbuild-essential-ARCH packages
 RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list.d/cgocrosscompiling.list \
-  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
   && apt-get update \
   && apt-get install -y build-essential \
   && for platform in ${DEB_CROSSPLATFORMS}; do apt-get install -y crossbuild-essential-${platform}; done \


### PR DESCRIPTION
It doesn't really matter if this makes it into master, but it can help improve the contributor experience in some organisations. - so feel free to close it if you're not interested :)

(Our corporate firewall doesn't allow the hkp port out, but does allow 80, so this change lets me run the weave build)