### PR TITLE
Destroy ipsets prefixed `weave-` only (fixes issue #2751)

### DIFF
--- a/npc/constants.go
+++ b/npc/constants.go
@@ -6,4 +6,6 @@ const (
 	MainChain    = "WEAVE-NPC"
 	DefaultChain = "WEAVE-NPC-DEFAULT"
 	IngressChain = "WEAVE-NPC-INGRESS"
+
+	IpsetNamePrefix = "weave-"
 )

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -29,7 +29,7 @@ func newSelectorSpec(json *unversioned.LabelSelector, nsName string, ipsetType i
 		// We prefix the selector string with the namespace name when generating
 		// the shortname because you can specify the same selector in multiple
 		// namespaces - we need those to map to distinct ipsets
-		ipsetName: ipset.Name("weave-" + shortName(nsName+":"+key)),
+		ipsetName: ipset.Name(IpsetNamePrefix + shortName(nsName+":"+key)),
 		ipsetType: ipsetType}, nil
 }
 

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -80,14 +80,22 @@ func resetIPTables(ipt *iptables.IPTables) error {
 }
 
 func resetIPSets(ips ipset.Interface) error {
-	// TODO should restrict ipset operations to the `weave-` prefix:
+	// Remove ipsets prefixed `weave-` only
 
-	if err := ips.FlushAll(); err != nil {
+	sets, err := ips.List(npc.IpsetNamePrefix)
+	if (err != nil) {
+		common.Log.Errorf("Failed to retrieve list of ipsets")
 		return err
 	}
 
-	if err := ips.DestroyAll(); err != nil {
-		return err
+	 common.Log.Debugf("Got list of ipsets: %v", sets)
+
+	for _, s := range sets {
+		common.Log.Debugf("Destroying ipsets '%s'", string(s))
+		if err := ips.Destroy(s); err != nil {
+			common.Log.Errorf("Failed to destroy ipset '%s'", string(s))
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Changes to destroy weave's ipsets only so that it can co-exist with other tools that use ipsets (e.g., keepalived-vip).