### PR TITLE
Fetch list of container IDs inside weaveutil

### DIFF
--- a/prog/weaveutil/addrs.go
+++ b/prog/weaveutil/addrs.go
@@ -27,10 +27,25 @@ func containerAddrs(args []string) error {
 		return err
 	}
 
+	containerArgs := []string{}
+	for _, cid := range args[1:] {
+		if cid == "weave:allids" { // expand to all container IDs
+			all, err := client.ListContainers(docker.ListContainersOptions{All: true})
+			if err != nil {
+				return err
+			}
+			for _, c := range all {
+				containerArgs = append(containerArgs, c.ID)
+			}
+		} else {
+			containerArgs = append(containerArgs, cid)
+		}
+	}
+
 	var containerIDs []string
 	containers := make(map[string]*docker.Container)
 
-	for _, cid := range args[1:] {
+	for _, cid := range containerArgs {
 		if cid == "weave:expose" {
 			netDev, err := weavenet.GetBridgeNetDev(bridgeName)
 			if err != nil {

--- a/weave
+++ b/weave
@@ -999,12 +999,12 @@ wait_for_status() {
 
 # Call $1 for all containers, passing container ID, all MACs and all IPs
 with_container_addresses() {
-    COMMAND=$1
+    COMMAND_WCA=$1
     shift 1
 
     CONTAINER_ADDRS=$(util_op container-addrs $BRIDGE "$@") || return 1
     echo "$CONTAINER_ADDRS" |  while read CONTAINER_ID CONTAINER_IFACE CONTAINER_MAC CONTAINER_IPS; do
-        $COMMAND "$CONTAINER_ID" "$CONTAINER_IFACE" "$CONTAINER_MAC" "$CONTAINER_IPS"
+        $COMMAND_WCA "$CONTAINER_ID" "$CONTAINER_IFACE" "$CONTAINER_MAC" "$CONTAINER_IPS"
     done
 }
 
@@ -1218,12 +1218,12 @@ when_weave_running() {
 # and $3.. as additional arguments
 with_container_fqdn() {
     CONT="$1"
-    COMMAND="$2"
+    COMMAND_WCF="$2"
     shift 2
 
     CONT_FQDN=$(docker inspect --format='{{.Config.Hostname}}.{{.Config.Domainname}}' $CONT 2>/dev/null) || return 0
     CONT_NAME=${CONT_FQDN%%.*}
-    [ "$CONT_NAME" = "$CONT_FQDN" -o "$CONT_NAME." = "$CONT_FQDN" ] || $COMMAND "$CONT" "$CONT_FQDN" "$@"
+    [ "$CONT_NAME" = "$CONT_FQDN" -o "$CONT_NAME." = "$CONT_FQDN" ] || $COMMAND_WCF "$CONT" "$CONT_FQDN" "$@"
 }
 
 # Register FQDN in $2 as names for addresses $3.. under full container ID $1

--- a/weave
+++ b/weave
@@ -1009,7 +1009,7 @@ with_container_addresses() {
 }
 
 echo_addresses() {
-    echo $1 $3 $4
+    echo $(printf "%.12s" $1) $3 $4
 }
 
 echo_ips() {
@@ -2246,7 +2246,7 @@ EOF
         show_addrs $ALL_CIDRS
         ;;
     ps)
-        [ $# -eq 0 ] && CONTAINERS="weave:expose $(docker ps -q)" || CONTAINERS="$@"
+        [ $# -eq 0 ] && CONTAINERS="weave:expose weave:allids" || CONTAINERS="$@"
         with_container_addresses echo_addresses $CONTAINERS
         ;;
     stop)

--- a/weave
+++ b/weave
@@ -1713,14 +1713,14 @@ fetch_router_args() {
     NO_DNS_OPT=$(echo $CONTAINER_ARGS | grep -o -e '--no-dns') || true
 }
 
+populate_dns_for_one_container() {
+    [ -z "$4" ] || with_container_fqdn $1 put_dns_fqdn $4
+}
+
 populate_router() {
     if [ -z "$NO_DNS_OPT" ] ; then
         # Tell the newly-started weaveDNS about existing weave IPs
-        for CONTAINER in $(docker ps -q --no-trunc) ; do
-            if CONTAINER_IPS=$(with_container_addresses echo_ips $CONTAINER) && [ -n "$CONTAINER_IPS" ] ; then
-                with_container_fqdn $CONTAINER put_dns_fqdn $CONTAINER_IPS
-            fi
-        done
+        with_container_addresses populate_dns_for_one_container weave:allids
     fi
 }
 


### PR DESCRIPTION
This makes `weave ps` slightly cheaper, and will help Weave Scope to stop embedding the docker binary.