### PR TITLE
lowercase IP string before trimming in reverse DNS lookup (see #2817)

### DIFF
--- a/nameserver/dns.go
+++ b/nameserver/dns.go
@@ -222,7 +222,7 @@ func (h *handler) handleReverse(w dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 
-	ipStr := strings.TrimSuffix(req.Question[0].Name, "."+reverseDNSdomain)
+	ipStr := strings.TrimSuffix(strings.ToLower(req.Question[0].Name), "."+reverseDNSdomain)
 	ip, err := address.ParseIP(ipStr)
 	if err != nil {
 		h.nameError(w, req)

--- a/test/245_dns_case_insensitive_test.sh
+++ b/test/245_dns_case_insensitive_test.sh
@@ -6,6 +6,9 @@ C1=10.2.0.78
 C2=10.2.0.79
 C3=10.2.0.80
 
+REVERSE_C1_LOWER=78.0.2.10.in-addr.arpa
+REVERSE_C1_UPPER=78.0.2.10.IN-ADDR.ARPA
+
 start_suite "DNS lookup case (in)sensitivity"
 
 weave_on $HOST1 launch
@@ -16,6 +19,9 @@ start_container $HOST1 $C1/24 --name=seeone
 assert_dns_record $HOST1 test seeone.weave.local $C1
 assert_dns_record $HOST1 test SeeOne.weave.local $C1
 assert_dns_record $HOST1 test SEEONE.weave.local $C1
+
+assert_dns_record $HOST1 test $REVERSE_C1_LOWER seeone.weave.local
+assert_dns_record $HOST1 test $REVERSE_C1_UPPER seeone.weave.local
 
 start_container $HOST1 $C2/24 --name=SeEtWo
 assert_dns_record $HOST1 test seetwo.weave.local $C2


### PR DESCRIPTION
Some DNS clients send reverse lookups with uppercase suffixes. This lowercases the request before trimming the lowercase suffix. Problem discovered and discussed here: https://github.com/weaveworks/weave/issues/2817

I could not find any specific reverse dns tests to create/update. The current DNS tests all pass.