### PR TITLE
Ensure we have the right modules loaded for weave-npc

### DIFF
--- a/docs/weavenpc-design.md
+++ b/docs/weavenpc-design.md
@@ -19,6 +19,9 @@ NetworkPolicy object updates from the k8s API server:
   network policy, containing the IP addresses of all pods in the
   namespace whose labels match that selector
 
+IPsets are implemented by the kernel module `xt_set`, without which
+weave-npc will not work.
+
 ipset names are generated deterministically from a string
 representation of the corresponding label selector. Because ipset
 names are limited to 31 characters in length, this is done by taking a
@@ -93,6 +96,9 @@ The following traffic is NOT affected:
 * Traffic originating from processes in the host network namespace
   (e.g. kubelet health checks)
 * Traffic routed from an application container to the internet
+
+The above mechanism relies on the kernel module `br_netfilter` being
+loaded and enabled via `/proc/sys/net/bridge/bridge-nf-call-iptables`.
 
 See these resources for helpful context:
 

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -15,6 +15,12 @@ CONN_LIMIT=${CONN_LIMIT:-30}
 # Default for network policy
 EXPECT_NPC=${EXPECT_NPC:-1}
 
+# Ensure we have the required modules for NPC
+if [ "${EXPECT_NPC}" != "0" ]; then
+    modprobe br_netfilter
+    modprobe xt_set
+fi
+
 # kube-proxy requires that bridged traffic passes through netfilter
 if ! BRIDGE_NF_ENABLED=$(cat /proc/sys/net/bridge/bridge-nf-call-iptables); then
     echo "Cannot detect bridge-nf support - network policy and iptables mode kubeproxy may not work reliably" >&2

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -46,6 +46,8 @@ spec:
               mountPath: /host/etc
             - name: dbus
               mountPath: /host/var/lib/dbus
+            - name: lib-modules
+              mountPath: /lib/modules
           resources:
             requests:
               cpu: 10m
@@ -73,3 +75,6 @@ spec:
         - name: dbus
           hostPath:
             path: /var/lib/dbus
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules


### PR DESCRIPTION
Fixes #2726 

At least when `weave-npc` is executed via the `weave-kube` daemonset.  It would be nicer to separate those two concerns, but we already need to know that `weave-npc` is in use when creating the bridge.