### PR TITLE
Ignore modprobe errors in weave-kube/launch.sh

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+modprobe_safe() {
+    modprobe $1 || echo "Ignore the error if \"$1\" is built-in in the kernel"
+}
+
 # Default if not supplied - same as weave net default
 IPALLOC_RANGE=${IPALLOC_RANGE:-10.32.0.0/12}
 HTTP_ADDR=${WEAVE_HTTP_ADDR:-127.0.0.1:6784}
@@ -17,8 +21,8 @@ EXPECT_NPC=${EXPECT_NPC:-1}
 
 # Ensure we have the required modules for NPC
 if [ "${EXPECT_NPC}" != "0" ]; then
-    modprobe br_netfilter
-    modprobe xt_set
+    modprobe_safe br_netfilter
+    modprobe_safe xt_set
 fi
 
 # kube-proxy requires that bridged traffic passes through netfilter

--- a/prog/weaveexec/Dockerfile.template
+++ b/prog/weaveexec/Dockerfile.template
@@ -19,6 +19,7 @@ RUN apk add --update \
     curl \
     ethtool \
     iptables \
+    ipset \
     iproute2 \
     util-linux \
     conntrack-tools \


### PR DESCRIPTION
`weave-kube` is run in `alpine` image which uses busybox. `modprobe` of busybox will return the `"module not found"` error, if a module is built-in, which is an opposite behavior to `modprobe` distributed in mainstream distros (e.g. Ubuntu).

https://bugs.busybox.net/show_bug.cgi?id=5270

Fix #2820 