### PR TITLE
Do not reset fastdp heartbeat timer for non-confirmed connections

### DIFF
--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -577,8 +577,8 @@ type fastDatapathForwarder struct {
 	confirmed         bool
 	remoteAddr        *net.UDPAddr
 	heartbeatInterval time.Duration
-	heartbeatTimer    *time.Timer
-	heartbeatTimeout  *time.Timer
+	heartbeatTimer    *time.Timer // for sending
+	heartbeatTimeout  *time.Timer // for receiving
 	ackedHeartbeat    bool
 	stopChan          chan struct{}
 	stopped           bool
@@ -856,7 +856,9 @@ func (fwd *fastDatapathForwarder) handleCryptoInitSARemote(msg []byte) {
 		return
 	}
 
-	if !fwd.isOutboundIPSecEstablished {
+	// FastDatapathCryptoInitSARemote can be received before Confirm'ing
+	// connection, thus before InitSALocal.
+	if fwd.confirmed && !fwd.isOutboundIPSecEstablished {
 		fwd.isOutboundIPSecEstablished = true
 		fwd.heartbeatTimer.Reset(0)
 	}


### PR DESCRIPTION
It is possible to receive `FastDatapathCryptoInitSARemote` control plane message before `Confirm`ing a connection. In such case, the handler for `FastDatapathCryptoInitSARemote` tries to reset `heartbeatTimer` which is nil, thus it makes `weaver` to crash. The timer is initialized in `Confirm`. 

The fix is to skip the reset for such situations, as the timer will be reset in `Confirm` (both handling `<..>InitSARemote` and `Confirm` are mutually exclusive).

Fix #2824 