### PR TITLE
Wrap weave-kube/launch.sh within tini

### DIFF
--- a/prog/weave-kube/Dockerfile.template
+++ b/prog/weave-kube/Dockerfile.template
@@ -1,3 +1,7 @@
 FROM DOCKERHUB_USER/weaveARCH_EXT
 ADD ./launch.sh ./kube-peers /home/weave/
-ENTRYPOINT ["/home/weave/launch.sh"]
+
+# Add tini for signal processing and zombie killing:
+RUN apk add --update tini
+# Run launch.sh script under tini:
+ENTRYPOINT ["/sbin/tini", "--", "/home/weave/launch.sh"]

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -115,8 +115,10 @@ post_start_actions() {
     /home/weave/weave --local expose $WEAVE_EXPOSE_IP
 }
 
-post_start_actions &
+# Double-forks so that post_start_actions' process gets adopted by tini as the subshell () process immediately dies:
+( post_start_actions & )
 
+# Replaces the current shell with weaver. No new process is created.
 exec /home/weave/weaver $EXTRA_ARGS --port=6783 $BRIDGE_OPTIONS \
      --http-addr=$HTTP_ADDR --status-addr=$STATUS_ADDR --docker-api='' --no-dns \
      --ipalloc-range=$IPALLOC_RANGE $NICKNAME_ARG \

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -25,8 +25,7 @@ spec:
         - name: weave
           image: weaveworks/weave-kube:latest
           imagePullPolicy: Always
-          command:
-            - /home/weave/launch.sh
+          command: ["/sbin/tini", "-s", "--", "/home/weave/launch.sh"]
           livenessProbe:
             initialDelaySeconds: 30
             httpGet:

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -52,6 +52,11 @@ assert_raises "run_on $HOST1 $PING $HOST2EXPIP"
 assert_raises "run_on $HOST2 $PING $HOST1EXPIP"
 assert_raises "run_on $HOST3 $PING $HOST2EXPIP"
 
+# Ensure we do not generate any defunct process (e.g. launch.sh) after starting weaver:
+assert "run_on $HOST1 ps aux | grep -c '[d]efunct'" "0"
+assert "run_on $HOST2 ps aux | grep -c '[d]efunct'" "0"
+assert "run_on $HOST3 ps aux | grep -c '[d]efunct'" "0"
+
 # See if we can get some pods running that connect to the network
 run_on $HOST1 "kubectl run hello --image=weaveworks/hello-world --replicas=3"
 


### PR DESCRIPTION
Fixes #2836.

**Changelog**:
- Add test to catch `defunct` `launch.sh` processes.
- Wrap `launch.sh` within `tini`:
  - prevents from generating defunct (a.k.a. zombie) launch.sh processes;
  - propagates signals from Docker to our processes (i.e. does not reopen #2684).

**Why**: In Docker, `ENTRYPOINT` is `PID 1` and therefore has the responsibility of reaping processes and forwarding signals to child processes, which `launch.sh` currently does not do.
This change leverages `tini` to bake such behaviour in, as recommended by Docker.

**See also**:
- github.com/docker-library/official-images#init
- github.com/krallin/tini/issues/8

**Sample output**:

- During initialisation:

```
$ ps auxf
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
[...]
root      1380  0.5  1.9 879660 74864 ?        Ssl  Mar13   5:42 /usr/bin/docker daemon -H fd:// -H unix:///
root      1664  0.0  0.4 502116 18644 ?        Ssl  Mar13   0:05  \_ docker-containerd -l /var/run/docker/li
root      9716  0.0  0.1 134960  5412 ?        Sl   11:00   0:00      \_ docker-containerd-shim 4946a0467c5a
root      9734  0.0  0.0    736     4 ?        Ss   11:00   0:00      |   \_ /sbin/tini -s -- /home/weave/la
root      9738  6.0  1.5 483756 59948 ?        Sl   11:00   0:00      |       \_ /home/weave/weaver --port=6
root     10020  0.0  0.0   1524    64 ?        S    11:00   0:00      |       \_ /bin/sh /home/weave/launch.
root     10110  0.0  0.0   1772  1264 ?        S    11:00   0:00      |           \_ /bin/sh /home/weave/wea
root     10135  0.0  0.0   1772   324 ?        S    11:00   0:00      |               \_ /bin/sh /home/weave
root     10136  0.0  0.0  14656  2912 ?        S    11:00   0:00      |                   \_ curl -o /tmp/we
[...]
```

- Once initialised successfully:

```
$ ps auxf
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
[...]
root      1380  0.5  1.9 879660 74864 ?        Ssl  Mar13   5:42 /usr/bin/docker daemon -H fd:// -H unix:///
root      1664  0.0  0.4 502116 18644 ?        Ssl  Mar13   0:05  \_ docker-containerd -l /var/run/docker/li
root      9716  0.0  0.1 134960  5412 ?        Sl   11:00   0:00      \_ docker-containerd-shim 4946a0467c5a
root      9734  0.0  0.0    736     4 ?        Ss   11:00   0:00      |   \_ /sbin/tini -s -- /home/weave/la
root      9738  4.2  1.5 491952 59948 ?        Sl   11:00   0:00      |       \_ /home/weave/weaver --port=6
[...]
```