### PR TITLE
Assert no defunct process is generated as a postcondition of all tests.

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -278,7 +278,16 @@ start_suite() {
     whitely echo "$@"
 }
 
+# Common postconditions to assert on each host, after each test:
+assert_common_postconditions() {
+    # Ensure we do not generate any defunct (a.k.a. zombie) process:
+    assert "run_on $1 ps aux | grep -c '[d]efunct'" "0"
+}
+
 end_suite() {
+    for host in $HOSTS; do
+        assert_common_postconditions "$host"
+    done
     whitely assert_end
     for host in $HOSTS; do
         stop_weave_on $host


### PR DESCRIPTION
## Reason:
Following #2836 / #2845, it appeared some other tests in our suite generated `defunct` processes.
In order to automatically flag such tests, it was decided we could include a similar check as in test 840 as a post condition of all tests.
Full discussion: https://weaveworks.slack.com/archives/C0DNGPKLY/p1489593552762037

## Changelog:
1. Added `assert_common_postconditions` to `config.sh` with a check for `defunct` processes.
2. Added instructions to run `assert_common_postconditions` for all hosts as part of `end_suite`.