### PR TITLE
WIP: DNS entries added/removed on network connect/disconnect

### DIFF
--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -119,12 +119,10 @@ func (c *Client) AddObserver(ob ContainerObserver) error {
 						ob.ContainerDestroyed(event.ID)
 					case "network:connect":
 						if containerID, ok := event.Actor.Attributes["container"]; ok {
-							pending.finish(containerID)
 							ob.ContainerConnected(containerID)
 						}
 					case "network:disconnect":
 						if containerID, ok := event.Actor.Attributes["container"]; ok {
-							pending.finish(containerID)
 							ob.ContainerDisconnected(containerID)
 						}
 					}

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -21,6 +21,8 @@ type ContainerObserver interface {
 	ContainerStarted(ident string)
 	ContainerDied(ident string)
 	ContainerDestroyed(ident string)
+	ContainerConnected(ident string)
+	ContainerDisconnected(ident string)
 }
 
 type Client struct {
@@ -115,6 +117,12 @@ func (c *Client) AddObserver(ob ContainerObserver) error {
 					case "destroy":
 						pending.finish(event.ID)
 						ob.ContainerDestroyed(event.ID)
+					case "network:connect":
+						pending.finish(event.ID)
+						ob.ContainerConnected(event.ID)
+					case "network:disconnect":
+						pending.finish(event.ID)
+						ob.ContainerDisconnected(event.ID)
 					}
 				}
 				if time.Since(start) > retryInterval {

--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -118,11 +118,15 @@ func (c *Client) AddObserver(ob ContainerObserver) error {
 						pending.finish(event.ID)
 						ob.ContainerDestroyed(event.ID)
 					case "network:connect":
-						pending.finish(event.ID)
-						ob.ContainerConnected(event.ID)
+						if containerID, ok := event.Actor.Attributes["container"]; ok {
+							pending.finish(containerID)
+							ob.ContainerConnected(containerID)
+						}
 					case "network:disconnect":
-						pending.finish(event.ID)
-						ob.ContainerDisconnected(event.ID)
+						if containerID, ok := event.Actor.Attributes["container"]; ok {
+							pending.finish(containerID)
+							ob.ContainerDisconnected(containerID)
+						}
 					}
 				}
 				if time.Since(start) > retryInterval {

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -378,6 +378,9 @@ func (alloc *Allocator) ContainerStarted(ident string) {
 	}
 }
 
+func (allow *Allocator) ContainerConnected(ident string)    {}
+func (allow *Allocator) ContainerDisconnected(ident string) {}
+
 func (alloc *Allocator) PruneOwned(ids []string) {
 	idmap := make(map[string]struct{}, len(ids))
 	for _, id := range ids {

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -24,9 +24,10 @@ const (
 	msgRingUpdate
 	msgSpaceRequestDenied
 
-	tickInterval         = time.Second * 5
-	MinSubnetSize        = 4 // first and last addresses are excluded, so 2 would be too small
-	containerDiedTimeout = time.Second * 30
+	tickInterval                 = time.Second * 5
+	MinSubnetSize                = 4 // first and last addresses are excluded, so 2 would be too small
+	containerDiedTimeout         = time.Second * 30
+	containerDisconnectedTimeout = time.Second * 30
 )
 
 // operation represents something which Allocator wants to do, but
@@ -65,6 +66,7 @@ type Allocator struct {
 	pendingClaims     []operation              // held until we know who owns the space
 	pendingPrimes     []operation              // held while our ring is empty
 	dead              map[string]time.Time     // containers we heard were dead, and when
+	disconnected      map[string]time.Time     // containers we heard were disconnected, and when
 	db                db.DB                    // persistence
 	gossip            mesh.Gossip              // our link to the outside world for sending messages
 	paxos             paxos.Participant
@@ -118,18 +120,19 @@ func NewAllocator(config Config) *Allocator {
 	}
 
 	alloc = &Allocator{
-		ourName:     config.OurName,
-		seed:        config.Seed,
-		universe:    config.Universe,
-		ring:        ring.New(config.Universe.Range().Start, config.Universe.Range().End, config.OurName, onUpdate),
-		owned:       make(map[string]ownedData),
-		db:          config.Db,
-		paxos:       participant,
-		nicknames:   map[mesh.PeerName]string{config.OurName: config.OurNickname},
-		isKnownPeer: config.IsKnownPeer,
-		quorum:      config.Quorum,
-		dead:        make(map[string]time.Time),
-		now:         time.Now,
+		ourName:      config.OurName,
+		seed:         config.Seed,
+		universe:     config.Universe,
+		ring:         ring.New(config.Universe.Range().Start, config.Universe.Range().End, config.OurName, onUpdate),
+		owned:        make(map[string]ownedData),
+		db:           config.Db,
+		paxos:        participant,
+		nicknames:    map[mesh.PeerName]string{config.OurName: config.OurNickname},
+		isKnownPeer:  config.IsKnownPeer,
+		quorum:       config.Quorum,
+		dead:         make(map[string]time.Time),
+		disconnected: make(map[string]time.Time),
+		now:          time.Now,
 	}
 
 	alloc.pendingClaims = make([]operation, len(config.PreClaims))
@@ -378,8 +381,35 @@ func (alloc *Allocator) ContainerStarted(ident string) {
 	}
 }
 
-func (allow *Allocator) ContainerConnected(ident string)    {}
-func (allow *Allocator) ContainerDisconnected(ident string) {}
+func (alloc *Allocator) ContainerConnected(ident string) {
+	alloc.actionChan <- func() {
+		delete(alloc.disconnected, ident) // delete is no-op if key not in map
+	}
+}
+
+func (alloc *Allocator) ContainerDisconnected(ident string) {
+	alloc.actionChan <- func() {
+		if alloc.hasOwnedByContainer(ident) {
+			alloc.debugln("Container", ident, "disconnected; noting to remove later")
+			alloc.disconnected[ident] = alloc.now()
+		}
+		// Also remove any pending ops
+		alloc.cancelOpsFor(&alloc.pendingAllocates, ident)
+		alloc.cancelOpsFor(&alloc.pendingClaims, ident)
+	}
+}
+
+func (alloc *Allocator) removeDisconnectedContainers() {
+	cutoff := alloc.now().Add(-containerDisconnectedTimeout)
+	for ident, timeOfDisconnect := range alloc.disconnected {
+		if timeOfDisconnect.Before(cutoff) {
+			if err := alloc.delete(ident); err == nil {
+				alloc.debugln("Removed addresses for container", ident)
+			}
+			delete(alloc.disconnected, ident)
+		}
+	}
+}
 
 func (alloc *Allocator) PruneOwned(ids []string) {
 	idmap := make(map[string]struct{}, len(ids))
@@ -703,6 +733,7 @@ func (alloc *Allocator) actorLoop(actionChan <-chan func(), stopChan <-chan stru
 				alloc.tryPendingOps()
 			}
 			alloc.removeDeadContainers()
+			alloc.removeDisconnectedContainers()
 		}
 
 		alloc.assertInvariants()

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -137,6 +137,9 @@ func (n *Nameserver) ContainerDied(ident string) {
 	n.broadcastEntries(entries...)
 }
 
+func (n *Nameserver) ContainerConnected(ident string)    {}
+func (n *Nameserver) ContainerDisconnected(ident string) {}
+
 func (n *Nameserver) PeerGone(peer mesh.PeerName) {
 	n.infof("peer %s gone", peer.String())
 	n.Lock()

--- a/nameserver/nameserver_test.go
+++ b/nameserver/nameserver_test.go
@@ -232,6 +232,12 @@ func TestContainerAndPeerDeath(t *testing.T) {
 	nameserver.AddEntry("hostname", "containerid", peername, address.Address(0))
 	require.Equal(t, []address.Address{0}, nameserver.Lookup("hostname"))
 
+	nameserver.ContainerDisconnected("containerid")
+	require.Equal(t, []address.Address{}, nameserver.Lookup("hostname"))
+
+	nameserver.AddEntry("hostname", "containerid", peername, address.Address(0))
+	require.Equal(t, []address.Address{0}, nameserver.Lookup("hostname"))
+
 	nameserver.PeerGone(peername)
 	require.Equal(t, []address.Address{}, nameserver.Lookup("hostname"))
 }

--- a/plugin/net/watcher.go
+++ b/plugin/net/watcher.go
@@ -58,3 +58,6 @@ func (w *watcher) ContainerDied(id string) {
 }
 
 func (w *watcher) ContainerDestroyed(id string) {}
+
+func (w *watcher) ContainerConnected(id string)    {}
+func (w *watcher) ContainerDisconnected(id string) {}

--- a/plugin/net/watcher.go
+++ b/plugin/net/watcher.go
@@ -59,5 +59,30 @@ func (w *watcher) ContainerDied(id string) {
 
 func (w *watcher) ContainerDestroyed(id string) {}
 
-func (w *watcher) ContainerConnected(id string)    {}
+func (w *watcher) ContainerConnected(id string) {
+	w.driver.debug("ContainerConnected", "%s", id)
+	info, err := w.client.InspectContainer(id)
+	if err != nil {
+		w.driver.warn("ContainerConnected", "error inspecting container %s: %s", id, err)
+		return
+	}
+	// check that it's on our network
+	for _, net := range info.NetworkSettings.Networks {
+		network, err := w.driver.findNetworkInfo(net.NetworkID)
+		if err != nil {
+			w.driver.warn("ContainerConnected", "unable to find network %s info: %s", net.NetworkID, err)
+			continue
+		}
+		if network.isOurs {
+			fqdn := fmt.Sprintf("%s.%s", info.Config.Hostname, info.Config.Domainname)
+			if err := w.weave.RegisterWithDNS(id, fqdn, net.IPAddress); err != nil {
+				w.driver.warn("ContainerConnected", "unable to register %s with weaveDNS: %s", id, err)
+			}
+			if _, err := weavenet.WithNetNSByPid(info.State.Pid, "configure-arp", weavenet.VethName); err != nil {
+				w.driver.warn("ContainerConnected", "unable to configure interfaces: %s", err)
+			}
+		}
+	}
+}
+
 func (w *watcher) ContainerDisconnected(id string) {}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -404,14 +404,6 @@ func (proxy *Proxy) ContainerStarted(ident string) {
 	proxy.notifyWaiters(ident, err)
 }
 
-func (proxy *Proxy) ContainerConnected(ident string) {
-	err := proxy.attach(ident)
-	// if err != nil {
-	// TODO: Not sure what is needed here.
-	// }
-	proxy.notifyWaiters(ident, err)
-}
-
 func containerShouldAttach(container *docker.Container) bool {
 	return len(container.Config.Entrypoint) > 0 && container.Config.Entrypoint[0] == weaveWaitEntrypoint[0]
 }
@@ -486,6 +478,7 @@ func (proxy *Proxy) waitForStartByIdent(ident string) error {
 
 func (proxy *Proxy) ContainerDied(ident string)         {}
 func (proxy *Proxy) ContainerDestroyed(ident string)    {}
+func (proxy *Proxy) ContainerConnected(ident string)    {}
 func (proxy *Proxy) ContainerDisconnected(ident string) {}
 
 // Check if this container needs to be attached, if so then attach it,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -476,8 +476,10 @@ func (proxy *Proxy) waitForStartByIdent(ident string) error {
 	return nil
 }
 
-func (proxy *Proxy) ContainerDied(ident string)      {}
-func (proxy *Proxy) ContainerDestroyed(ident string) {}
+func (proxy *Proxy) ContainerDied(ident string)         {}
+func (proxy *Proxy) ContainerDestroyed(ident string)    {}
+func (proxy *Proxy) ContainerConnected(ident string)    {}
+func (proxy *Proxy) ContainerDisconnected(ident string) {}
 
 // Check if this container needs to be attached, if so then attach it,
 // and return nil on success or not needed.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -404,6 +404,14 @@ func (proxy *Proxy) ContainerStarted(ident string) {
 	proxy.notifyWaiters(ident, err)
 }
 
+func (proxy *Proxy) ContainerConnected(ident string) {
+	err := proxy.attach(ident)
+	// if err != nil {
+	// TODO: Not sure what is needed here.
+	// }
+	proxy.notifyWaiters(ident, err)
+}
+
 func containerShouldAttach(container *docker.Container) bool {
 	return len(container.Config.Entrypoint) > 0 && container.Config.Entrypoint[0] == weaveWaitEntrypoint[0]
 }
@@ -478,7 +486,6 @@ func (proxy *Proxy) waitForStartByIdent(ident string) error {
 
 func (proxy *Proxy) ContainerDied(ident string)         {}
 func (proxy *Proxy) ContainerDestroyed(ident string)    {}
-func (proxy *Proxy) ContainerConnected(ident string)    {}
 func (proxy *Proxy) ContainerDisconnected(ident string) {}
 
 // Check if this container needs to be attached, if so then attach it,


### PR DESCRIPTION
This is an initial PR, to get feedback.

@bboreham I'm not sure what should happen in the Proxy ContainerDisconnect method if there is an error attaching the container.

Also, in the allocator, I added a new map for disconnected containers, instead of treating them as dead. I guess one issue is (`disconnect -> died -> start with --net`) will leave the container in the disconnected map, even though it is connected.

TODO:
- [x] Proxy ContainerDisconnect Implementation
- [x] Improve tests
- [ ] Support for `docker network connect --alias`

Fixes #1914 