### PR TITLE
README: Drop Slack Status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Integration Tests](https://circleci.com/gh/weaveworks/weave/tree/master.svg?style=shield)](https://circleci.com/gh/weaveworks/weave)
 [![Coverage Status](https://coveralls.io/repos/weaveworks/weave/badge.svg)](https://coveralls.io/r/weaveworks/weave)
 [![Go Report Card](https://goreportcard.com/badge/github.com/weaveworks/weave)](https://goreportcard.com/report/github.com/weaveworks/weave)
-[![Slack Status](https://slack.weave.works/badge.svg)](https://slack.weave.works)
 [![Docker Pulls](https://img.shields.io/docker/pulls/weaveworks/weave.svg?maxAge=604800)](https://hub.docker.com/r/weaveworks/weave/)
 
 # About Weaveworks


### PR DESCRIPTION
The Slack Status badge doesn't work, at least for
non-signed-in users.  This gives a bad impression
as to the quality of the project.

Here's what it looks like for me, for example:

![image](https://cloud.githubusercontent.com/assets/152014/24127699/f3c4ae46-0d93-11e7-89a3-fb1a115b499d.png)
