### PR TITLE
More help for upgraders who use plugin commands

### DIFF
--- a/weave
+++ b/weave
@@ -266,6 +266,7 @@ IMAGE=$BASE_IMAGE:$IMAGE_VERSION
 CONTAINER_NAME=${WEAVE_CONTAINER_NAME:-weave}
 
 PLUGIN_NAME="$DOCKERHUB_USER/net-plugin"
+OLD_PLUGIN_CONTAINER_NAME=weaveplugin
 CNI_PLUGIN_NAME="weave-plugin-$IMAGE_VERSION"
 CNI_PLUGIN_DIR=${WEAVE_CNI_PLUGIN_DIR:-$HOST_ROOT/opt/cni/bin}
 # Note VOLUMES_CONTAINER which is for weavewait should change when you upgrade Weave
@@ -2119,6 +2120,8 @@ EOF
         [ $# -eq 0 ] || usage
         stop_router
         stop_proxy
+        # In case user has upgraded from <v2.0 and left the old container running
+        docker stop $OLD_PLUGIN_CONTAINER_NAME >/dev/null 2>&1 || true
         ;;
     stop-router)
         [ $# -eq 0 ] || usage
@@ -2148,7 +2151,7 @@ EOF
                 exit 1
                 ;;
         esac
-        for NAME in $CONTAINER_NAME $PROXY_CONTAINER_NAME ; do
+        for NAME in $CONTAINER_NAME $PROXY_CONTAINER_NAME $OLD_PLUGIN_CONTAINER_NAME ; do
             docker stop  $NAME >/dev/null 2>&1 || true
             docker rm -f $NAME >/dev/null 2>&1 || true
         done

--- a/weave
+++ b/weave
@@ -1990,7 +1990,7 @@ EOF
             call_weave GET /report -H 'Accept: application/json'
         fi
         ;;
-    run|start|restart)
+    run|start|restart|launch-plugin|stop-plugin)
         echo "The 'weave $COMMAND' command has been removed as of Weave Net version 2.0" >&2
         echo "Please see release notes for further information" >&2
         exit 1


### PR DESCRIPTION
Print helpful message; also stop and reset old weaveplugin container in case user has upgraded from <v2.0 and left it running.

per https://github.com/weaveworks/weave/pull/2727/files#r109466258, https://github.com/weaveworks/weave/pull/2727/files#r109468485 and https://github.com/weaveworks/weave/pull/2727/files#r109468670