### PR TITLE
Only list active containers in weaveutil/addrs.go#containerAddrs

### DIFF
--- a/prog/weaveutil/addrs.go
+++ b/prog/weaveutil/addrs.go
@@ -30,7 +30,7 @@ func containerAddrs(args []string) error {
 	containerArgs := []string{}
 	for _, cid := range args[1:] {
 		if cid == "weave:allids" { // expand to all container IDs
-			all, err := client.ListContainers(docker.ListContainersOptions{All: true})
+			all, err := client.ListContainers(docker.ListContainersOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
`weaveutil/addrs.go#containerAddrs` previously was using `docker.ListContainersOptions{All: true}`, which is the equivalent of `docker ps -a`, and is not what we want here.
See also: https://weaveworks.slack.com/archives/C0DNGPKLY/p1492080958623977 and following discussion.