### PR TITLE
Update weave-kube docs and YAML files to leverage Launch Generator

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -1,120 +1,167 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: weave-net
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - namespaces
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
----
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: weave-net
-  namespace: kube-system
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: weave-net
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: weave-net
-subjects:
-- kind: ServiceAccount
-  name: weave-net
-  namespace: kube-system
----
-apiVersion: extensions/v1beta1
-kind: DaemonSet
-metadata:
-  name: weave-net
-  namespace: kube-system
-spec:
-  template:
-    metadata:
+kind: List
+items:
+  - metadata:
       labels:
         name: weave-net
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "server-version": "master-c1f3803",
+            "original-request": {
+              "url": "/k8s/v1.6/net?v=latest",
+              "date": "Tue Apr 18 2017 15:00:03 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+    apiVersion: v1
+    kind: ServiceAccount
+  - metadata:
+      labels:
+        name: weave-net
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "server-version": "master-c1f3803",
+            "original-request": {
+              "url": "/k8s/v1.6/net?v=latest",
+              "date": "Tue Apr 18 2017 15:00:03 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
     spec:
-      hostNetwork: true
-      hostPID: true
-      containers:
-        - name: weave
-          image: weaveworks/weave-kube:latest
-          imagePullPolicy: Always
-          command:
-            - /home/weave/launch.sh
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              host: 127.0.0.1
-              path: /status
-              port: 6784
-          securityContext:
-            privileged: true
-          volumeMounts:
+      template:
+        metadata:
+          labels:
+            name: weave-net
+        spec:
+          tolerations:
+            - key: node-role.kubernetes.io/master
+              effect: NoSchedule
+          containers:
+            - name: weave
+              image: 'weaveworks/weave-kube:latest'
+              imagePullPolicy: Always
+              command:
+                - /home/weave/launch.sh
+              env: []
+              livenessProbe:
+                initialDelaySeconds: 30
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: lib-modules
+                  mountPath: /lib/modules
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+            - name: weave-npc
+              image: 'weaveworks/weave-npc:latest'
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+          volumes:
             - name: weavedb
-              mountPath: /weavedb
+              emptyDir: {}
             - name: cni-bin
-              mountPath: /host/opt
+              hostPath:
+                path: /opt
             - name: cni-bin2
-              mountPath: /host/home
+              hostPath:
+                path: /home
             - name: cni-conf
-              mountPath: /host/etc
+              hostPath:
+                path: /etc
             - name: dbus
-              mountPath: /host/var/lib/dbus
+              hostPath:
+                path: /var/lib/dbus
             - name: lib-modules
-              mountPath: /lib/modules
-          resources:
-            requests:
-              cpu: 10m
-        - name: weave-npc
-          image: weaveworks/weave-npc:latest
-          imagePullPolicy: Always
-          resources:
-            requests:
-              cpu: 10m
+              hostPath:
+                path: /lib/modules
+          hostPID: true
+          hostNetwork: true
+          serviceAccountName: weave-net
+          restartPolicy: Always
           securityContext:
-            privileged: true
-      restartPolicy: Always
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      serviceAccountName: weave-net
-      securityContext:
-        seLinuxOptions:
-          type: spc_t
-      volumes:
-        - name: weavedb
-          emptyDir: {}
-        - name: cni-bin
-          hostPath:
-            path: /opt
-        - name: cni-bin2
-          hostPath:
-            path: /home
-        - name: cni-conf
-          hostPath:
-            path: /etc
-        - name: dbus
-          hostPath:
-            path: /var/lib/dbus
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
+            seLinuxOptions:
+              type: spc_t
+    apiVersion: extensions/v1beta1
+    kind: DaemonSet
+  - metadata:
+      labels:
+        name: weave-net
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "server-version": "master-c1f3803",
+            "original-request": {
+              "url": "/k8s/v1.6/net?v=latest",
+              "date": "Tue Apr 18 2017 15:00:03 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+          - namespaces
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+  - metadata:
+      labels:
+        name: weave-net
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "server-version": "master-c1f3803",
+            "original-request": {
+              "url": "/k8s/v1.6/net?v=latest",
+              "date": "Tue Apr 18 2017 15:00:03 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: weave-net
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -1,80 +1,108 @@
-apiVersion: extensions/v1beta1
-kind: DaemonSet
-metadata:
-  name: weave-net
-  namespace: kube-system
-spec:
-  template:
-    metadata:
+apiVersion: v1
+kind: List
+items:
+  - metadata:
       labels:
         name: weave-net
+      name: weave-net
       annotations:
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [
-            {
-              "key": "dedicated",
-              "operator": "Equal",
-              "value": "master",
-              "effect": "NoSchedule"
-            }
-          ]
+        cloud.weave.works/launcher-info: |-
+          {
+            "server-version": "master-c1f3803",
+            "original-request": {
+              "url": "/k8s/v1.5/net?v=latest",
+              "date": "Tue Apr 18 2017 14:59:54 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+    apiVersion: v1
+    kind: ServiceAccount
+  - metadata:
+      labels:
+        name: weave-net
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "server-version": "master-c1f3803",
+            "original-request": {
+              "url": "/k8s/v1.5/net?v=latest",
+              "date": "Tue Apr 18 2017 14:59:54 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
     spec:
-      hostNetwork: true
-      hostPID: true
-      containers:
-        - name: weave
-          image: weaveworks/weave-kube:latest
-          imagePullPolicy: Always
-          command:
-            - /home/weave/launch.sh
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              host: 127.0.0.1
-              path: /status
-              port: 6784
-          securityContext:
-            privileged: true
-          volumeMounts:
+      template:
+        metadata:
+          labels:
+            name: weave-net
+          annotations:
+            scheduler.alpha.kubernetes.io/tolerations: >-
+              [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+        spec:
+          containers:
+            - name: weave
+              image: 'weaveworks/weave-kube:latest'
+              imagePullPolicy: Always
+              command:
+                - /home/weave/launch.sh
+              env: []
+              livenessProbe:
+                initialDelaySeconds: 30
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: lib-modules
+                  mountPath: /lib/modules
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+            - name: weave-npc
+              image: 'weaveworks/weave-npc:latest'
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+          volumes:
             - name: weavedb
-              mountPath: /weavedb
+              emptyDir: {}
             - name: cni-bin
-              mountPath: /host/opt
+              hostPath:
+                path: /opt
             - name: cni-bin2
-              mountPath: /host/home
+              hostPath:
+                path: /home
             - name: cni-conf
-              mountPath: /host/etc
+              hostPath:
+                path: /etc
             - name: dbus
-              mountPath: /host/var/lib/dbus
+              hostPath:
+                path: /var/lib/dbus
             - name: lib-modules
-              mountPath: /lib/modules
-          resources:
-            requests:
-              cpu: 10m
-        - name: weave-npc
-          image: weaveworks/weave-npc:latest
-          imagePullPolicy: Always
-          resources:
-            requests:
-              cpu: 10m
+              hostPath:
+                path: /lib/modules
+          hostPID: true
+          hostNetwork: true
+          serviceAccountName: weave-net
+          restartPolicy: Always
           securityContext:
-            privileged: true
-      restartPolicy: Always
-      volumes:
-        - name: weavedb
-          emptyDir: {}
-        - name: cni-bin
-          hostPath:
-            path: /opt
-        - name: cni-bin2
-          hostPath:
-            path: /home
-        - name: cni-conf
-          hostPath:
-            path: /etc
-        - name: dbus
-          hostPath:
-            path: /var/lib/dbus
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
+            seLinuxOptions:
+              type: spc_t
+    apiVersion: extensions/v1beta1
+    kind: DaemonSet

--- a/site/kube-addon.md
+++ b/site/kube-addon.md
@@ -18,21 +18,20 @@ The following topics are discussed:
 Weave Net can be installed onto your CNI-enabled Kubernetes cluster
 with a single command:
 
-* Kubernetes versions `1.6` and above:
-
 ```
-$ kubectl apply -f https://git.io/weave-kube-1.6
-```
-
-* Kubernetes versions up to `1.5`:
-
-```
-$ kubectl apply -f https://git.io/weave-kube
+$ kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
 ```
 
 After a few seconds, a Weave Net pod should be running on each
 Node and any further pods you create will be automatically attached to the Weave
 network.
+
+**Note:** In Kubernetes versions `1.6` and above, depending on how your cluster is configured, you may need to:
+
+- add `sudo`,
+- add `--kubeconfig /etc/kubernetes/admin.conf` (or equivalent),
+
+to the above `kubectl version` command.
 
 **Note:** This command requires Kubernetes 1.4 or later.
 
@@ -59,10 +58,9 @@ Shut down Kubernetes, and _on all nodes_ perform the following:
 Then relaunch Kubernetes and install the addon as described
 above.
 
-The URLs [https://git.io/weave-kube](https://git.io/weave-kube) and [https://git.io/weave-kube-1.6](https://git.io/weave-kube-1.6) point
-to the YAML file for the [latest release](https://github.com/weaveworks/weave/releases/tag/latest_release) of the Weave Net addon.
-Historic versions are archived on our [GitHub release
-page](https://github.com/weaveworks/weave/releases).
+**Note:** URLs [git.io/weave-kube](https://git.io/weave-kube) and [git.io/weave-kube-1.6](https://git.io/weave-kube-1.6) point respectively to [cloud.weave.works/k8s/v1.5/net](https://cloud.weave.works/k8s/v1.5/net) and [cloud.weave.works/k8s/v1.6/net](https://cloud.weave.works/k8s/v1.6/net).
+In the past, these URLs were pointing to static YAML files for the [latest release](https://github.com/weaveworks/weave/releases/tag/latest_release) of the Weave Net addon, respectively [`latest_release/weave-daemonset.yaml`](https://github.com/weaveworks/weave/releases/download/latest_release/weave-daemonset.yaml) and [`latest_release/weave-daemonset-k8s-1.6.yaml`](https://github.com/weaveworks/weave/releases/download/latest_release/weave-daemonset-k8s-1.6.yaml)
+Historic versions of these static YAML files are archived on our [GitHub release page](https://github.com/weaveworks/weave/releases).
 
 ## <a name="kube-1.6-upgrade"></a> Upgrading Kubernetes to version 1.6
 

--- a/site/kube-addon.md
+++ b/site/kube-addon.md
@@ -31,7 +31,6 @@ network.
 - add `sudo`,
 - add `--kubeconfig /etc/kubernetes/admin.conf` (or equivalent),
 
-to the above `kubectl version` command.
 
 **Note:** This command requires Kubernetes 1.4 or later.
 
@@ -57,6 +56,31 @@ Shut down Kubernetes, and _on all nodes_ perform the following:
 
 Then relaunch Kubernetes and install the addon as described
 above.
+
+**Note:** You can customise the generated YAML file by passing Weave-Kube options, arguments and environment variables as query parameters:
+  - `version`: Weave-Kube's version. Default: latest release.
+  - `known-peers`: comma-separated list of hosts. Default: empty.
+  - `trusted-subnets`: comma-separated list of CIDRs. Default: empty.
+  - `disable-npc`: boolean (`true|false`). Default: `false`.
+  - `enable-encryption`: boolean (`true|false`). Default: `false`.
+  - `env.NAME=VALUE`: add environment variable `NAME` and set it to `VALUE`.
+
+Example:
+```
+$ kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&env.MTU=1337"
+```
+This command generates a YAML file containing, among others:
+
+```
+[...]
+          containers:
+            - name: weave
+[...]
+              env:
+                - name: MTU
+                  value: '1337'
+[...]
+```
 
 **Note:** URLs [git.io/weave-kube](https://git.io/weave-kube) and [git.io/weave-kube-1.6](https://git.io/weave-kube-1.6) point respectively to [cloud.weave.works/k8s/v1.5/net](https://cloud.weave.works/k8s/v1.5/net) and [cloud.weave.works/k8s/v1.6/net](https://cloud.weave.works/k8s/v1.6/net).
 In the past, these URLs were pointing to static YAML files for the [latest release](https://github.com/weaveworks/weave/releases/tag/latest_release) of the Weave Net addon, respectively [`latest_release/weave-daemonset.yaml`](https://github.com/weaveworks/weave/releases/download/latest_release/weave-daemonset.yaml) and [`latest_release/weave-daemonset-k8s-1.6.yaml`](https://github.com/weaveworks/weave/releases/download/latest_release/weave-daemonset-k8s-1.6.yaml)


### PR DESCRIPTION
### Context:

The current Kubernetes YAML for `weave-kube`

1. is static, which forces people to manually edit the file in order to customise it, to add environment variables, etc. and
2. exists in two versions, one for Kubernetes `v1.5`, and one for `v1.6` and above, which forces users to make choices about how they install `weave-kube`, hence increasing mental burden.

The latest version of the Launch Generator supports, among others: 
- passing additional options, arguments, and environment variables (weaveworks/launch-generator#66), which addresses 1. above;
- passing the output of `kubectl version` to automatically extract Kubernetes' "server version" and return appropriate YAML configuration (weaveworks/launch-generator#79) without having users to care about it, which addresses 2. above.

### Changelog:

1. Update documentation to cover point 1. from the above "Context" section.
2. Update documentation to cover point 2. from the above "Context" section.
3. Update Weave-Kube daemonset YAML files to standardise configuration.

### Related work:
- weaveworks/launch-generator#66
- weaveworks/launch-generator#79
- weaveworks/launch-generator#88
- weaveworks/launch-generator#91

This PR and the above ones:
- fix weaveworks/launch-generator#43
- fix #2754