### PR TITLE
Update weave-kube docs and YAML files to leverage Launch Generator

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -1,121 +1,128 @@
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: weave-net
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - namespaces
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
----
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: weave-net
-  namespace: kube-system
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: weave-net
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: weave-net
-subjects:
-- kind: ServiceAccount
-  name: weave-net
-  namespace: kube-system
----
-apiVersion: extensions/v1beta1
-kind: DaemonSet
-metadata:
-  name: weave-net
-  namespace: kube-system
-spec:
-  template:
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
     metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+          - namespaces
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
+    roleRef:
+      kind: ClusterRole
+      name: weave-net
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+  - apiVersion: extensions/v1beta1
+    kind: DaemonSet
+    metadata:
+      name: weave-net
       labels:
         name: weave-net
     spec:
-      hostNetwork: true
-      hostPID: true
-      containers:
-        - name: weave
-          image: weaveworks/weave-kube:latest
-          imagePullPolicy: Always
-          command:
-            - /home/weave/launch.sh
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              host: 127.0.0.1
-              path: /status
-              port: 6784
+      template:
+        metadata:
+          labels:
+            name: weave-net
+        spec:
+          containers:
+            - name: weave
+              command:
+                - /home/weave/launch.sh
+              env: []
+              image: 'weaveworks/weave-kube:latest'
+              imagePullPolicy: Always
+              livenessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+                initialDelaySeconds: 30
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: lib-modules
+                  mountPath: /lib/modules
+            - name: weave-npc
+              image: 'weaveworks/weave-npc:latest'
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+          hostNetwork: true
+          hostPID: true
+          restartPolicy: Always
           securityContext:
-            privileged: true
-          volumeMounts:
+            seLinuxOptions:
+              type: spc_t
+          serviceAccountName: weave-net
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+          volumes:
             - name: weavedb
-              mountPath: /weavedb
+              hostPath:
+                path: /var/lib/weave
             - name: cni-bin
-              mountPath: /host/opt
+              hostPath:
+                path: /opt
             - name: cni-bin2
-              mountPath: /host/home
+              hostPath:
+                path: /home
             - name: cni-conf
-              mountPath: /host/etc
+              hostPath:
+                path: /etc
             - name: dbus
-              mountPath: /host/var/lib/dbus
+              hostPath:
+                path: /var/lib/dbus
             - name: lib-modules
-              mountPath: /lib/modules
-          resources:
-            requests:
-              cpu: 10m
-        - name: weave-npc
-          image: weaveworks/weave-npc:latest
-          imagePullPolicy: Always
-          resources:
-            requests:
-              cpu: 10m
-          securityContext:
-            privileged: true
-      restartPolicy: Always
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      serviceAccountName: weave-net
-      securityContext:
-        seLinuxOptions:
-          type: spc_t
-      volumes:
-        - name: weavedb
-          hostPath:
-            path: /var/lib/weave
-        - name: cni-bin
-          hostPath:
-            path: /opt
-        - name: cni-bin2
-          hostPath:
-            path: /home
-        - name: cni-conf
-          hostPath:
-            path: /etc
-        - name: dbus
-          hostPath:
-            path: /var/lib/dbus
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
+              hostPath:
+                path: /lib/modules

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -1,81 +1,89 @@
-apiVersion: extensions/v1beta1
-kind: DaemonSet
-metadata:
-  name: weave-net
-  namespace: kube-system
-spec:
-  template:
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
     metadata:
+      name: weave-net
       labels:
         name: weave-net
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [
-            {
-              "key": "dedicated",
-              "operator": "Equal",
-              "value": "master",
-              "effect": "NoSchedule"
-            }
-          ]
+  - apiVersion: extensions/v1beta1
+    kind: DaemonSet
+    metadata:
+      name: weave-net
+      labels:
+        name: weave-net
     spec:
-      hostNetwork: true
-      hostPID: true
-      containers:
-        - name: weave
-          image: weaveworks/weave-kube:latest
-          imagePullPolicy: Always
-          command:
-            - /home/weave/launch.sh
-          livenessProbe:
-            initialDelaySeconds: 30
-            httpGet:
-              host: 127.0.0.1
-              path: /status
-              port: 6784
+      template:
+        metadata:
+          annotations:
+            scheduler.alpha.kubernetes.io/tolerations: >-
+              [{"key":"dedicated","operator":"Equal","value":"master","effect":"NoSchedule"}]
+          labels:
+            name: weave-net
+        spec:
+          containers:
+            - name: weave
+              command:
+                - /home/weave/launch.sh
+              env: []
+              image: 'weaveworks/weave-kube:latest'
+              imagePullPolicy: Always
+              livenessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+                initialDelaySeconds: 30
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: lib-modules
+                  mountPath: /lib/modules
+            - name: weave-npc
+              image: 'weaveworks/weave-npc:latest'
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: 10m
+              securityContext:
+                privileged: true
+          hostNetwork: true
+          hostPID: true
+          restartPolicy: Always
           securityContext:
-            privileged: true
-          volumeMounts:
+            seLinuxOptions:
+              type: spc_t
+          serviceAccountName: weave-net
+          volumes:
             - name: weavedb
-              mountPath: /weavedb
+              hostPath:
+                path: /var/lib/weave
             - name: cni-bin
-              mountPath: /host/opt
+              hostPath:
+                path: /opt
             - name: cni-bin2
-              mountPath: /host/home
+              hostPath:
+                path: /home
             - name: cni-conf
-              mountPath: /host/etc
+              hostPath:
+                path: /etc
             - name: dbus
-              mountPath: /host/var/lib/dbus
+              hostPath:
+                path: /var/lib/dbus
             - name: lib-modules
-              mountPath: /lib/modules
-          resources:
-            requests:
-              cpu: 10m
-        - name: weave-npc
-          image: weaveworks/weave-npc:latest
-          imagePullPolicy: Always
-          resources:
-            requests:
-              cpu: 10m
-          securityContext:
-            privileged: true
-      restartPolicy: Always
-      volumes:
-        - name: weavedb
-          hostPath:
-            path: /var/lib/weave
-        - name: cni-bin
-          hostPath:
-            path: /opt
-        - name: cni-bin2
-          hostPath:
-            path: /home
-        - name: cni-conf
-          hostPath:
-            path: /etc
-        - name: dbus
-          hostPath:
-            path: /var/lib/dbus
-        - name: lib-modules
-          hostPath:
-            path: /lib/modules
+              hostPath:
+                path: /lib/modules

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -38,10 +38,16 @@ for host in $HOSTS; do
     fi
 done
 
-[ -n "$COVERAGE" ] && COVERAGE_ARGS="\\n          env:\\n            - name: EXTRA_ARGS\\n              value: \"-test.coverprofile=/home/weave/cover.prof --\""
+if [ -n "$COVERAGE" ]; then
+    COVERAGE_ARGS="env:\\n                - name: EXTRA_ARGS\\n                  value: \"-test.coverprofile=/home/weave/cover.prof --\""
+else
+    COVERAGE_ARGS="env: []"
+fi
 
-sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never$COVERAGE_ARGS%" "$(dirname "$0")/../prog/weave-kube/weave-daemonset-k8s-1.6.yaml" \
-	| run_on $HOST1 "$KUBECTL apply -f -"
+# Ensure Kubernetes uses locally built container images and inject code coverage environment variable (or do nothing depending on $COVERAGE):
+sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never%" \
+    -e "s%env: \[\]%$COVERAGE_ARGS%" \
+    "$(dirname "$0")/../prog/weave-kube/weave-daemonset-k8s-1.6.yaml" | run_on "$HOST1" "$KUBECTL apply -n kube-system -f -"
 
 sleep 5
 


### PR DESCRIPTION
### Context:

The current Kubernetes YAML for `weave-kube`

1. is static, which forces people to manually edit the file in order to customise it, to add environment variables, etc. and
2. exists in two versions, one for Kubernetes `v1.5`, and one for `v1.6` and above, which forces users to make choices about how they install `weave-kube`, hence increasing mental burden.

The latest version of the Launch Generator supports, among others: 
- passing additional options, arguments, and environment variables (weaveworks/launch-generator#66), which addresses 1. above;
- passing the output of `kubectl version` to automatically extract Kubernetes' "server version" and return appropriate YAML configuration (weaveworks/launch-generator#79) without having users to care about it, which addresses 2. above.

### Changelog:

1. Update documentation to cover point 1. from the above "Context" section.
2. Update documentation to cover point 2. from the above "Context" section.
3. Update Weave-Kube daemonset YAML files to standardise configuration based on Launch Generator's output.

### Related work:
- weaveworks/launch-generator#66
- weaveworks/launch-generator#79
- weaveworks/launch-generator#88
- weaveworks/launch-generator#91

This PR and the above ones:
- fix weaveworks/launch-generator#43
- fix #2754

cc: @errordeveloper 