### PR TITLE
Remove deprecation warnings for `launch-dns` and `stop-dns` commands

### DIFF
--- a/weave
+++ b/weave
@@ -2103,14 +2103,6 @@ EOF
         done
         [ $res -eq 0 ]
         ;;
-    launch-dns)
-        echo "The 'launch-dns' command has been removed; DNS is launched as part of 'launch' and 'launch-router'." >&2
-        exit 0
-        ;;
-    stop-dns)
-        echo "The 'stop-dns command has been removed; DNS is stopped as part of 'stop' and 'stop-router'." >&2
-        exit 0
-        ;;
     prime)
         call_weave GET /ring
         ;;


### PR DESCRIPTION
## Context

The `launch-dns` and `stop-dns` commands have been deprecated ~2 years ago.
Given we are planning a 2.0 release for Weave Net, now is a good time to fully remove these.

## Changelog

1. Removed `launch-dns` command.
2. Removed `stop-dns` command.

N.B.: I couldn't find any mention of these commands in `docs` and `site` by `grep -R`-ing these, so that should be it.