### PR TITLE
Rename router.Bridge to router.InjectorConsumer

### DIFF
--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -209,25 +209,25 @@ func (lock *fastDatapathLock) relock() {
 	}
 }
 
-// Bridge bits
+// InjectorConsumer bits
 
-type fastDatapathBridge struct {
+type fastDatapathInjectorConsumer struct {
 	*FastDatapath
 }
 
-func (fastdp *FastDatapath) Bridge() Bridge {
-	return fastDatapathBridge{fastdp}
+func (fastdp *FastDatapath) InjectorConsumer() InjectorConsumer {
+	return fastDatapathInjectorConsumer{fastdp}
 }
 
-func (fastdp fastDatapathBridge) Interface() *net.Interface {
+func (fastdp fastDatapathInjectorConsumer) Interface() *net.Interface {
 	return fastdp.iface
 }
 
-func (fastdp fastDatapathBridge) String() string {
+func (fastdp fastDatapathInjectorConsumer) String() string {
 	return fmt.Sprint(fastdp.iface.Name, " (via ODP)")
 }
 
-func (fastdp fastDatapathBridge) Stats() map[string]int {
+func (fastdp fastDatapathInjectorConsumer) Stats() map[string]int {
 	lock := fastdp.startLock()
 	defer lock.unlock()
 
@@ -238,12 +238,12 @@ func (fastdp fastDatapathBridge) Stats() map[string]int {
 
 var routerBridgePortID = bridgePortID{router: true}
 
-func (fastdp fastDatapathBridge) StartConsumingPackets(consumer BridgeConsumer) error {
+func (fastdp fastDatapathInjectorConsumer) StartConsumingPackets(consumer Consumer) error {
 	fastdp.lock.Lock()
 	defer fastdp.lock.Unlock()
 
 	if fastdp.sendToPort[routerBridgePortID] != nil {
-		return fmt.Errorf("FastDatapath already has a BridgeConsumer")
+		return fmt.Errorf("FastDatapath already has a Consumer")
 	}
 
 	// set up delivery to the weave router port on the bridge
@@ -257,7 +257,7 @@ func (fastdp fastDatapathBridge) StartConsumingPackets(consumer BridgeConsumer) 
 	return nil
 }
 
-func (fastdp fastDatapathBridge) InjectPacket(key PacketKey) FlowOp {
+func (fastdp fastDatapathInjectorConsumer) InjectPacket(key PacketKey) FlowOp {
 	lock := fastdp.startLock()
 	defer lock.unlock()
 	return fastdp.bridge(routerBridgePortID, key, &lock)

--- a/router/injector_consumer.go
+++ b/router/injector_consumer.go
@@ -5,13 +5,13 @@ import (
 )
 
 // Interface to packet handling on the local virtual bridge
-type Bridge interface {
+type InjectorConsumer interface {
 	// Inject a packet to be delivered locally
 	InjectPacket(PacketKey) FlowOp
 
 	// Start consuming packets from the bridge.  Injected packets
 	// should not be included.
-	StartConsumingPackets(BridgeConsumer) error
+	StartConsumingPackets(Consumer) error
 
 	Interface() *net.Interface
 	String() string
@@ -19,26 +19,26 @@ type Bridge interface {
 }
 
 // A function that determines how to handle locally captured packets.
-type BridgeConsumer func(PacketKey) FlowOp
+type Consumer func(PacketKey) FlowOp
 
-type NullBridge struct{}
+type NullInjectorConsumer struct{}
 
-func (NullBridge) InjectPacket(PacketKey) FlowOp {
+func (NullInjectorConsumer) InjectPacket(PacketKey) FlowOp {
 	return nil
 }
 
-func (NullBridge) StartConsumingPackets(BridgeConsumer) error {
+func (NullInjectorConsumer) StartConsumingPackets(Consumer) error {
 	return nil
 }
 
-func (NullBridge) Interface() *net.Interface {
+func (NullInjectorConsumer) Interface() *net.Interface {
 	return nil
 }
 
-func (NullBridge) String() string {
+func (NullInjectorConsumer) String() string {
 	return "no overlay bridge"
 }
 
-func (NullBridge) Stats() map[string]int {
+func (NullInjectorConsumer) Stats() map[string]int {
 	return nil
 }

--- a/router/network_router_status.go
+++ b/router/network_router_status.go
@@ -23,8 +23,8 @@ type MACStatus struct {
 func NewNetworkRouterStatus(router *NetworkRouter) *NetworkRouterStatus {
 	return &NetworkRouterStatus{
 		mesh.NewStatus(router.Router),
-		router.Bridge.String(),
-		router.Bridge.Stats(),
+		router.InjectorConsumer.String(),
+		router.InjectorConsumer.Stats(),
 		NewMACStatusSlice(router.Macs)}
 }
 

--- a/router/pcap.go
+++ b/router/pcap.go
@@ -27,7 +27,7 @@ type Pcap struct {
 	readHandle *pcap.Handle
 }
 
-func NewPcap(iface *net.Interface, bufSz int) (Bridge, error) {
+func NewPcap(iface *net.Interface, bufSz int) (InjectorConsumer, error) {
 	wh, err := newPcapHandle(iface.Name, false, 0, 0)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func NewPcap(iface *net.Interface, bufSz int) (Bridge, error) {
 	return &Pcap{iface: iface, bufSz: bufSz, writeHandle: wh}, nil
 }
 
-func (p *Pcap) StartConsumingPackets(consumer BridgeConsumer) error {
+func (p *Pcap) StartConsumingPackets(consumer Consumer) error {
 	rh, err := newPcapHandle(p.iface.Name, true, 65535, p.bufSz)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func (p *Pcap) Process(frame []byte, dec *EthernetDecoder, broadcast bool) {
 	checkWarn(p.writeHandle.WritePacketData(frame))
 }
 
-func (p *Pcap) sniff(readHandle *pcap.Handle, consumer BridgeConsumer) {
+func (p *Pcap) sniff(readHandle *pcap.Handle, consumer Consumer) {
 	dec := NewEthernetDecoder()
 
 	for {


### PR DESCRIPTION
Since what it does it injects and consumes packets, and something else entirely does bridging.

The name seems to come from https://github.com/weaveworks/weave/pull/991#issuecomment-120427085; previously it was `IntraHost`.  But that wasn't right either, for what it does.