### PR TITLE
Remove obsolete validation and warning

### DIFF
--- a/weave
+++ b/weave
@@ -1264,11 +1264,6 @@ common_launch_args() {
 launch_router() {
     LAUNCHING_ROUTER=1
     check_forwarding_rules
-    # backward compatibility...
-    if is_cidr "$1" ; then
-        echo "WARNING: $1 parameter ignored; 'weave launch' no longer takes a CIDR as the first parameter" >&2
-        shift 1
-    fi
 
     CONTAINER_PORT=$PORT
     ARGS=


### PR DESCRIPTION
## Context

This logic was added for backward compatibility and to warn users about changes made ~2 years ago.
Given we are planning a 2.0 release for Weave Net, such logic is now irrelevant and can be removed.

## Changelog

Removed obsolete validation, parameters shifting and warning.