### PR TITLE
Move plugin network creation from shell script to Go

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,9 +1,7 @@
 package plugin
 
 import (
-	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -18,7 +16,10 @@ import (
 	"github.com/weaveworks/weave/plugin/skel"
 )
 
-const pluginV2Name = "net-plugin"
+const (
+	pluginV2Name    = "net-plugin"
+	MulticastOption = netplugin.MulticastOption
+)
 
 var Log = common.Log
 
@@ -53,12 +54,6 @@ func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddre
 		defer os.Remove(meshAddress)
 		defer meshListener.Close()
 	}
-
-	statusListener, err := weavenet.ListenUnixSocket("/home/weave/plugin-status.sock")
-	if err != nil {
-		return err
-	}
-	go serveStatus(statusListener)
 
 	return <-endChan
 }
@@ -97,13 +92,4 @@ func listenAndServe(dockerClient *docker.Client, weave *weaveapi.Client, address
 	}()
 
 	return listener, nil
-}
-
-func serveStatus(listener net.Listener) {
-	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "ok")
-	})}
-	if err := server.Serve(listener); err != nil {
-		Log.Fatalf("ListenAndServeStatus failed: %s", err)
-	}
 }

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -431,6 +431,12 @@ func main() {
 	if enablePlugin || enablePluginV2 {
 		go plugin.Start(httpAddr, dockerCli, pluginSocket, pluginMeshSocket, !noDNS, enablePluginV2)
 	}
+	if enablePlugin {
+		Log.Println("Creating default 'weave' network")
+		options := map[string]interface{}{plugin.MulticastOption: "true"}
+		// TODO: the driver name should be extracted from pluginMeshSocket
+		dockerCli.EnsureNetwork("weave", "weavemesh", defaultSubnet.String(), options)
+	}
 
 	if bridgeConfig.AWSVPC {
 		// Run this on its own goroutine because the allocator can block

--- a/prog/weaveutil/main.go
+++ b/prog/weaveutil/main.go
@@ -23,7 +23,6 @@ func init() {
 		"delete-datapath":          deleteDatapath,
 		"check-datapath":           checkDatapath,
 		"add-datapath-interface":   addDatapathInterface,
-		"create-plugin-network":    createPluginNetwork,
 		"remove-plugin-network":    removePluginNetwork,
 		"container-addrs":          containerAddrs,
 		"process-addrs":            processAddrs,

--- a/prog/weaveutil/plugin_network.go
+++ b/prog/weaveutil/plugin_network.go
@@ -7,43 +7,7 @@ import (
 
 	"github.com/docker/docker/client"
 	docker "github.com/fsouza/go-dockerclient"
-
-	"github.com/weaveworks/weave/plugin/net"
 )
-
-func createPluginNetwork(args []string) error {
-	if len(args) != 3 {
-		cmdUsage("create-plugin-network", "<network-name> <driver-name> <default-subnet>")
-	}
-	networkName := args[0]
-	driverName := args[1]
-	subnet := args[2]
-	d, err := newDockerClient()
-	if err != nil {
-		return err
-	}
-	_, err = d.CreateNetwork(
-		docker.CreateNetworkOptions{
-			Name:           networkName,
-			CheckDuplicate: true,
-			Driver:         driverName,
-			IPAM: docker.IPAMOptions{
-				Driver: driverName,
-				Config: []docker.IPAMConfig{{Subnet: subnet}},
-			},
-			Options: map[string]interface{}{plugin.MulticastOption: "true"},
-		})
-	if err != docker.ErrNetworkAlreadyExists && err != nil {
-		// Despite appearances to the contrary, CreateNetwork does
-		// sometimes(always?) *not* return ErrNetworkAlreadyExists
-		// when the network already exists. Hence we need to check for
-		// this explicitly.
-		if _, err2 := d.NetworkInfo(networkName); err2 != nil {
-			return fmt.Errorf("unable to create network: %s", err)
-		}
-	}
-	return nil
-}
 
 func removePluginNetwork(args []string) error {
 	if len(args) != 1 {

--- a/weave
+++ b/weave
@@ -1395,11 +1395,6 @@ launch_router() {
         --resolv-conf "/var/run/weave/etc/$RESOLV_CONF_BASE" \
         "$@")
     wait_for_status $CONTAINER_NAME http_call $HTTP_ADDR
-
-    if [ -n "$ENABLE_PLUGIN" ]; then
-        wait_for_status $CONTAINER_NAME http_call_unix $CONTAINER_NAME plugin-status.sock
-        util_op create-plugin-network weave weavemesh $IPRANGE
-    fi
 }
 
 stop_router() {


### PR DESCRIPTION
In the process, use the default subnet instead of the whole IP allocation range.

Fixes #2919 
