### PR TITLE
added search tag type

### DIFF
--- a/site/building.md
+++ b/site/building.md
@@ -1,6 +1,7 @@
 ---
 title: Building Weave Net
 menu_order: 120
+search_type: Documentation
 ---
 You only need to build Weave Net if you want to work on the Weave Net codebase
 (or you just enjoy building software).

--- a/site/cni-plugin.md
+++ b/site/cni-plugin.md
@@ -1,6 +1,7 @@
 ---
 title: Integrating Kubernetes and Mesos via the CNI Plugin
 menu_order: 65
+search_type: Documentation
 ---
 
 > The recommended way of using Weave with Kubernetes is via the new

--- a/site/faq.md
+++ b/site/faq.md
@@ -1,6 +1,7 @@
 ---
 title: FAQ
 menu_order: 200
+search_type: Documentation
 ---
 
 

--- a/site/features.md
+++ b/site/features.md
@@ -1,6 +1,7 @@
 ---
 title: Feature Overview
 menu_order: 20
+search_type: Documentation
 ---
 
  * [Virtual Ethernet Switch](#virtual-ethernet-switch)

--- a/site/how-it-works.md
+++ b/site/how-it-works.md
@@ -1,6 +1,7 @@
 ---
 title: Understanding how Weave Net Works
 menu_order: 90
+search_type: Documentation
 ---
 
 

--- a/site/how-it-works/encryption-implementation.md
+++ b/site/how-it-works/encryption-implementation.md
@@ -1,6 +1,7 @@
 ---
 title: How Weave Net Implements Encryption
 menu_order: 70
+search_type: Documentation
 ---
 
 This section describes some details of Weave Net's built-in

--- a/site/how-it-works/encryption.md
+++ b/site/how-it-works/encryption.md
@@ -1,6 +1,7 @@
 ---
 title: Encryption and Weave Net
 menu_order: 60
+search_type: Documentation
 ---
 
 

--- a/site/how-it-works/fastdp-how-it-works.md
+++ b/site/how-it-works/fastdp-how-it-works.md
@@ -1,6 +1,7 @@
 ---
 title: How Fast Datapath Works
 menu_order: 30
+search_type: Documentation
 ---
 
 

--- a/site/how-it-works/ip-addresses.md
+++ b/site/how-it-works/ip-addresses.md
@@ -1,6 +1,7 @@
 ---
 title: IP Addresses, Routes and Networks
 menu_order: 50
+search_type: Documentation
 ---
 
 

--- a/site/how-it-works/network-topology.md
+++ b/site/how-it-works/network-topology.md
@@ -1,6 +1,7 @@
 ---
 title: How Weave Net Interprets Network Topology
 menu_order: 20
+search_type: Documentation
 ---
 
 This section contains the following topics: 

--- a/site/how-it-works/router-encapsulation.md
+++ b/site/how-it-works/router-encapsulation.md
@@ -1,6 +1,7 @@
 ---
 title: Weave Net Router Sleeve Encapsulation
 menu_order: 10
+search_type: Documentation
 ---
 
 When the Weave Net router forwards packets to peers in `sleeve` mode

--- a/site/installing-weave.md
+++ b/site/installing-weave.md
@@ -1,6 +1,7 @@
 ---
 title: Installing Weave Net
 menu_order: 30
+search_type: Documentation
 ---
 
 

--- a/site/installing-weave/systemd.md
+++ b/site/installing-weave/systemd.md
@@ -1,6 +1,7 @@
 ---
 title: Using Weave with Systemd
 menu_order: 130
+search_type: Documentation
 ---
 
 

--- a/site/introducing-weave.md
+++ b/site/introducing-weave.md
@@ -1,6 +1,7 @@
 ---
 title: Introducing Weave Net
 menu_order: 10
+search_type: Documentation
 ---
 
 

--- a/site/ipam.md
+++ b/site/ipam.md
@@ -1,6 +1,7 @@
 ---
 title: Allocating IP Addresses
 menu_order: 70
+search_type: Documentation
 ---
 
 

--- a/site/ipam/allocation-multi-ipam.md
+++ b/site/ipam/allocation-multi-ipam.md
@@ -1,6 +1,7 @@
 ---
 title: Automatic Allocation Across Multiple Subnets
 menu_order: 10
+search_type: Documentation
 ---
 
 

--- a/site/ipam/stop-remove-peers-ipam.md
+++ b/site/ipam/stop-remove-peers-ipam.md
@@ -1,6 +1,7 @@
 ---
 title: Starting, Stopping and Removing Peers
 menu_order: 20
+search_type: Documentation
 ---
 
 

--- a/site/ipam/troubleshooting-ipam.md
+++ b/site/ipam/troubleshooting-ipam.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting the IP Allocator
 menu_order: 30
+search_type: Documentation
 ---
 
 

--- a/site/kube-addon.md
+++ b/site/kube-addon.md
@@ -1,6 +1,7 @@
 ---
 title: Integrating Kubernetes via the Addon
 menu_order: 63
+search_type: Documentation
 ---
 
 The following topics are discussed:

--- a/site/metrics.md
+++ b/site/metrics.md
@@ -1,6 +1,7 @@
 ---
 title: Monitoring with Prometheus
 menu_order: 105
+search_type: Documentation
 ---
 
 Two endpoints are exposed: one for the Weave Net router, and, when deployed as

--- a/site/operational-guide.md
+++ b/site/operational-guide.md
@@ -1,6 +1,7 @@
 ---
 title: Operational Guide
 menu_order: 45
+search_type: Documentation
 ---
 This operational guide is intended to give you an overview of how to
 operate and manage a Weave Network in production. It consists of three

--- a/site/operational-guide/autoscaling.md
+++ b/site/operational-guide/autoscaling.md
@@ -1,6 +1,7 @@
 ---
 title: Autoscaling
 menu_order: 40
+search_type: Documentation
 ---
 
 ### Bootstrapping

--- a/site/operational-guide/concepts.md
+++ b/site/operational-guide/concepts.md
@@ -1,6 +1,7 @@
 ---
 title: Concepts
 menu_order: 10
+search_type: Documentation
 ---
 This section describes some of the essential concepts with which you will
 need to be familiar before continuing to the example deployment

--- a/site/operational-guide/interactive.md
+++ b/site/operational-guide/interactive.md
@@ -1,6 +1,7 @@
 ---
 title: Interactive Deployment
 menu_order: 20
+search_type: Documentation
 ---
 Weave Net can be launched interactively on the command line, and as 
 long as Docker is configured to start on boot, the network will survive 

--- a/site/operational-guide/tasks.md
+++ b/site/operational-guide/tasks.md
@@ -1,6 +1,7 @@
 ---
 title: Administrative Tasks
 menu_order: 60
+search_type: Documentation
 ---
 
 The following administrative tasks are discussed: 

--- a/site/operational-guide/uniform-dynamic-cluster.md
+++ b/site/operational-guide/uniform-dynamic-cluster.md
@@ -1,6 +1,7 @@
 ---
 title: Uniform Dynamic Clusters
 menu_order: 50
+search_type: Documentation
 ---
 
 A uniform dynamic cluster has the following characteristics:

--- a/site/operational-guide/uniform-fixed-cluster.md
+++ b/site/operational-guide/uniform-fixed-cluster.md
@@ -1,6 +1,7 @@
 ---
 title: Uniform Fixed Clusters
 menu_order: 30
+search_type: Documentation
 ---
 
 This scenario describes a production deployment of a fixed number of N

--- a/site/plugin.md
+++ b/site/plugin.md
@@ -1,6 +1,7 @@
 ---
 title: Integrating Docker via the Network Plugin
 menu_order: 60
+search_type: Documentation
 ---
 
  * [Launching Weave Net and Running Containers Using the Plugin](#launching)

--- a/site/plugin/plugin-how-it-works.md
+++ b/site/plugin/plugin-how-it-works.md
@@ -1,6 +1,7 @@
 ---
 title: How the Weave Net Docker Network Plugin Works
 menu_order: 20
+search_type: Documentation
 ---
 
 

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting Weave Net
 menu_order: 110
+search_type: Documentation
 ---
 
 

--- a/site/using-weave.md
+++ b/site/using-weave.md
@@ -1,6 +1,7 @@
 ---
 title: Using Weave Net
 menu_order: 40
+search_type: Documentation
 ---
 
 Weave Net provides a simple to deploy networking solution for containerized apps. Here, we describe how to manage a Weave container network using a sample application which consists of two simple `netcat` services deployed to containers on two separate hosts.

--- a/site/using-weave/application-isolation.md
+++ b/site/using-weave/application-isolation.md
@@ -1,6 +1,7 @@
 ---
 title: Isolating Applications on a Weave Network
 menu_order: 30
+search_type: Documentation
 ---
 
 A single Weave network can host multiple, isolated applications where each application's containers are able 

--- a/site/using-weave/awsvpc.md
+++ b/site/using-weave/awsvpc.md
@@ -1,6 +1,7 @@
 ---
 title: Using IP Routing on an Amazon Web Services Virtual Private Cloud
 menu_order: 110
+search_type: Documentation
 ---
 
 If your container infrastructure is running entirely within Amazon Web Services (AWS) 

--- a/site/using-weave/configuring-weave.md
+++ b/site/using-weave/configuring-weave.md
@@ -1,6 +1,7 @@
 ---
 title: Allocating IPs in a Specific Range
 menu_order: 15
+search_type: Documentation
 ---
 
 The default configurations for both Weave Net and Docker use [Private

--- a/site/using-weave/dynamically-attach-containers.md
+++ b/site/using-weave/dynamically-attach-containers.md
@@ -1,6 +1,7 @@
 ---
 title: Dynamically Attaching and Detaching Applications
 menu_order: 40
+search_type: Documentation
 ---
 
 

--- a/site/using-weave/fastdp.md
+++ b/site/using-weave/fastdp.md
@@ -1,6 +1,7 @@
 ---
 title: Using Fast Datapath
 menu_order: 96
+search_type: Documentation
 ---
 
 

--- a/site/using-weave/finding-adding-hosts-dynamically.md
+++ b/site/using-weave/finding-adding-hosts-dynamically.md
@@ -1,6 +1,7 @@
 ---
 title: Adding and Removing Hosts Dynamically
 menu_order: 90
+search_type: Documentation
 ---
 
 To add a host to an existing Weave network, launch Weave Net on the

--- a/site/using-weave/host-network-integration.md
+++ b/site/using-weave/host-network-integration.md
@@ -1,6 +1,7 @@
 ---
 title: Integrating with the Host Network
 menu_order: 60
+search_type: Documentation
 ---
 
 Weave application networks can be integrated with an external host network, establishing connectivity between the host and with application containers running anywhere.

--- a/site/using-weave/manual-ip-address.md
+++ b/site/using-weave/manual-ip-address.md
@@ -1,6 +1,7 @@
 ---
 title: Manually Specifying the IP Address of a Container
 menu_order: 20
+search_type: Documentation
 ---
 
 Containers are automatically allocated an IP address that is unique across the Weave network. You can see which address was allocated by running, [`weave ps`](/site/troubleshooting.md#weave-status):

--- a/site/using-weave/multi-cloud-multi-hop.md
+++ b/site/using-weave/multi-cloud-multi-hop.md
@@ -1,6 +1,7 @@
 ---
 title: Enabling Multi-Cloud, Multi-Hop Networking and Routing
 menu_order: 100
+search_type: Documentation
 ---
 
 

--- a/site/using-weave/security-untrusted-networks.md
+++ b/site/using-weave/security-untrusted-networks.md
@@ -1,6 +1,7 @@
 ---
 title: Securing Connections Across Untrusted Networks
 menu_order: 80
+search_type: Documentation
 ---
 
 

--- a/site/using-weave/service-management.md
+++ b/site/using-weave/service-management.md
@@ -1,6 +1,7 @@
 ---
 title: Managing Services - Exporting, Importing, Binding and Routing
 menu_order: 70
+search_type: Documentation
 ---
 
 This section contains the following topics: 

--- a/site/weave-docker-api.md
+++ b/site/weave-docker-api.md
@@ -1,6 +1,7 @@
 ---
 title: Integrating Docker via the API Proxy
 menu_order: 50
+search_type: Documentation
 ---
 
 The Docker API proxy automatically attaches containers to the Weave

--- a/site/weave-docker-api/automatic-discovery-proxy.md
+++ b/site/weave-docker-api/automatic-discovery-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Using Automatic Discovery With the Weave Net Proxy
 menu_order: 30
+search_type: Documentation
 ---
 
 Containers launched via the proxy use [weaveDNS](/site/weavedns.md)

--- a/site/weave-docker-api/ipam-proxy.md
+++ b/site/weave-docker-api/ipam-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Automatic IP Allocation and the Weave Proxy
 menu_order: 25
+search_type: Documentation
 ---
 
 

--- a/site/weave-docker-api/launching-without-proxy.md
+++ b/site/weave-docker-api/launching-without-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Launching Containers With Weave Run (without the Proxy)
 menu_order: 50
+search_type: Documentation
 ---
 
 

--- a/site/weave-docker-api/name-resolution-proxy.md
+++ b/site/weave-docker-api/name-resolution-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Name resolution via `/etc/hosts`
 menu_order: 40
+search_type: Documentation
 ---
 
 

--- a/site/weave-docker-api/securing-proxy.md
+++ b/site/weave-docker-api/securing-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Securing the Docker Communications With TLS
 menu_order: 20
+search_type: Documentation
 ---
 
 If you are [connecting to the docker daemon with

--- a/site/weave-docker-api/troubleshooting-proxy.md
+++ b/site/weave-docker-api/troubleshooting-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting
 menu_order: 60
+search_type: Documentation
 ---
 
 The command

--- a/site/weave-docker-api/using-proxy.md
+++ b/site/weave-docker-api/using-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Using The Weave Docker API Proxy
 menu_order: 10
+search_type: Documentation
 ---
 
 

--- a/site/weavedns.md
+++ b/site/weavedns.md
@@ -1,6 +1,7 @@
 ---
 title: Discovering Containers with WeaveDNS
 menu_order: 80
+search_type: Documentation
 ---
 
 

--- a/site/weavedns/how-works-weavedns.md
+++ b/site/weavedns/how-works-weavedns.md
@@ -1,6 +1,7 @@
 ---
 title: How Weave Finds Containers
 menu_order: 10
+search_type: Documentation
 ---
 
 

--- a/site/weavedns/load-balance-fault-weavedns.md
+++ b/site/weavedns/load-balance-fault-weavedns.md
@@ -1,6 +1,7 @@
 ---
 title: Load Balancing and Fault Resilience with weaveDNS
 menu_order: 20
+search_type: Documentation
 ---
 
 

--- a/site/weavedns/managing-domains-weavedns.md
+++ b/site/weavedns/managing-domains-weavedns.md
@@ -1,6 +1,7 @@
 ---
 title: Managing Domains
 menu_order: 30
+search_type: Documentation
 ---
 
 The following topics are discussed:

--- a/site/weavedns/managing-entries-weavedns.md
+++ b/site/weavedns/managing-entries-weavedns.md
@@ -1,6 +1,7 @@
 ---
 title: Managing Domain Entries
 menu_order: 40
+search_type: Documentation
 ---
 
 

--- a/site/weavedns/troubleshooting-weavedns.md
+++ b/site/weavedns/troubleshooting-weavedns.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting and Present Limitations
 menu_order: 50
+search_type: Documentation
 ---
 
 


### PR DESCRIPTION
Added `search_type: Documentation` as a first step for search in the new site.  This variable groups all documentation type content together. 

@bboreham please check that I haven't gaffe'ed anything. 