### PR TITLE
Fix protect_against_docker_hang

### DIFF
--- a/weave
+++ b/weave
@@ -1442,7 +1442,7 @@ stop_proxy() {
 
 protect_against_docker_hang() {
     # If the plugin is not running, remove its socket so Docker doesn't try to talk to it
-    if ! is_plugin_v2_enabled 2>/dev/null ; then
+    if [ ! is_plugin_v1_enabled ] && [ ! is_plugin_v2_enabled ] ; then
         rm -f $HOST_ROOT/run/docker/plugins/weave.sock $HOST_ROOT/run/docker/plugins/weavemesh.sock
     fi
 }


### PR DESCRIPTION
Check not only for plugin-v2 but also for plugin-v1, as both create the same plugin sockets (`weave.sock` and `weavemesh.sock`).

Should fix flakiness in 80* smoke tests.