### PR TITLE
WIP: In the build container, request install/upgrade of openssl

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,10 +20,11 @@ ENV GCC_CROSSCOMPILERS \
 
 # Temporarily add the Ubuntu repositories, because we're going to install gcc cross-compilers from there
 # Install the build-essential and crossbuild-essential-ARCH packages
+# and openssl because the above might upgrade libssl to an incompatible version
 RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list.d/cgocrosscompiling.list \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
   && apt-get update \
-  && apt-get install -y build-essential \
+  && apt-get install -y build-essential openssl \
   && for platform in ${DEB_CROSSPLATFORMS}; do apt-get install -y crossbuild-essential-${platform}; done \
   && rm /etc/apt/sources.list.d/cgocrosscompiling.list \
   && apt-get update \


### PR DESCRIPTION
It seems that the install of libssl causes builds to break, because Python can no longer load the SSL code.
Example: https://circleci.com/gh/weaveworks/weave/8855
