### PR TITLE
Fix build libssl issue: Use cross-compilers from debian rather than ubuntu

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,13 +20,12 @@ ENV GCC_CROSSCOMPILERS \
 
 # Temporarily add the Ubuntu repositories, because we're going to install gcc cross-compilers from there
 # Install the build-essential and crossbuild-essential-ARCH packages
-RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list.d/cgocrosscompiling.list \
-  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
+RUN echo "deb http://emdebian.org/tools/debian/ jessie main" > /etc/apt/sources.list.d/cgocrosscompiling.list \
+  && curl http://emdebian.org/tools/debian/emdebian-toolchain-archive.key | apt-key add - \
+  && for platform in ${DEB_CROSSPLATFORMS}; do dpkg --add-architecture $platform; done \
   && apt-get update \
   && apt-get install -y build-essential \
   && for platform in ${DEB_CROSSPLATFORMS}; do apt-get install -y crossbuild-essential-${platform}; done \
-  && rm /etc/apt/sources.list.d/cgocrosscompiling.list \
-  && apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install some required packages


### PR DESCRIPTION
Golang containers seem to built on debian jessie, not ubuntu.