### PR TITLE
Remove deprecated flag --with-dns.

### DIFF
--- a/prog/weaveproxy/main.go
+++ b/prog/weaveproxy/main.go
@@ -28,7 +28,6 @@ func main() {
 		justVersion bool
 		logLevel    = "info"
 		c           proxy.Config
-		withDNS     bool
 	)
 
 	c.Version = version
@@ -47,7 +46,6 @@ func main() {
 	mflag.BoolVar(&c.TLSConfig.Enabled, []string{"#tls", "-tls"}, false, "Use TLS; implied by --tlsverify")
 	mflag.StringVar(&c.TLSConfig.Key, []string{"#tlskey", "-tlskey"}, "", "Path to TLS key file")
 	mflag.BoolVar(&c.TLSConfig.Verify, []string{"#tlsverify", "-tlsverify"}, false, "Use TLS and verify the remote")
-	mflag.BoolVar(&withDNS, []string{"#-with-dns", "#w"}, false, "option removed")
 	mflag.BoolVar(&c.WithoutDNS, []string{"-without-dns"}, false, "instruct created containers to never use weaveDNS as their nameserver")
 	mflag.BoolVar(&c.NoMulticastRoute, []string{"-no-multicast-route"}, false, "do not add a multicast route via the weave interface when attaching containers")
 	mflag.Parse()
@@ -61,10 +59,6 @@ func main() {
 
 	Log.Infoln("weave proxy", version)
 	Log.Infoln("Command line arguments:", strings.Join(os.Args[1:], " "))
-
-	if withDNS {
-		Log.Warning("--with-dns option has been removed; DNS is on by default")
-	}
 
 	c.Image = getenv("EXEC_IMAGE", "weaveworks/weaveexec")
 	c.DockerBridge = getenv("DOCKER_BRIDGE", "docker0")


### PR DESCRIPTION
## Context

This warning was added in #1812 following the merge of DNS in the router ~1.5 year ago.
Given we are planning a 2.0 release for Weave Net, such a warning is now irrelevant and can be removed.

## Changelog

Remove deprecated flag `--with-dns` and related warning.