### PR TITLE
Remote deprecated create-bridge command

### DIFF
--- a/weave
+++ b/weave
@@ -136,7 +136,7 @@ exec_options() {
             ;;
         # All the other commands that may create the bridge and need machine id files.
         # We don't mount '/' to avoid recursive mounts of '/var'
-        create-bridge|attach|expose|hide)
+        attach|expose|hide)
             echo -v /etc:/host/etc -v /var/lib/dbus:/host/var/lib/dbus -e HOST_ROOT=/host
             ;;
     esac
@@ -1522,21 +1522,6 @@ case "$COMMAND" in
         [ $# -eq 0 ] || usage
         ask_version $CONTAINER_NAME $IMAGE || true
         ask_version $PROXY_CONTAINER_NAME $EXEC_IMAGE --entrypoint=/home/weave/weaveproxy || true
-        ;;
-    # intentionally undocumented since it assumes knowledge of weave
-    # internals
-    create-bridge)
-        if [ "$1" != "--force" ] ; then
-            cat 1>&2 <<EOF
-WARNING: 'weave create-bridge' is deprecated. Instead use 'weave attach-bridge'
-to link the docker and weave bridges after both docker and weave have been
-started. Note that, unlike 'weave create-bridge', 'weave attach-bridge' is
-compatible with fast data path.
-EOF
-        else
-            shift 1
-        fi
-        create_bridge "$@"
         ;;
     attach-bridge)
         if detect_bridge_type ; then


### PR DESCRIPTION
Note that much of the code remains because it can get called from `attach` and `expose`