### PR TITLE
Wait until ready; make test 810 more reliable 

### DIFF
--- a/api/weaveapi.go
+++ b/api/weaveapi.go
@@ -78,10 +78,12 @@ func (client *Client) Connect(remote string) error {
 }
 
 // IsReady returns true if the API server is up and running
+// (note it returns StatusServiceUnavailable until all parts are ready,
+// but callers of this function are expected to be ok with a partial service)
 func (client *Client) IsReady() bool {
-	_, err := client.httpVerb("GET", "/status", nil)
-
-	return err == nil
+	resp, err := http.Get(client.baseURL + "/status")
+	return err == nil &&
+		(resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusServiceUnavailable)
 }
 
 // WaitAPIServer waits until the API server is ready to serve.

--- a/common/wait.go
+++ b/common/wait.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type WaitGroup struct {
+	wg    sync.WaitGroup
+	count int32
+}
+
+// Increase the count of things waiting and return a closure which calls Done
+func (w *WaitGroup) Add() func() {
+	atomic.AddInt32(&w.count, 1)
+	w.wg.Add(1)
+	return func() {
+		w.wg.Done()
+		atomic.AddInt32(&w.count, -1)
+	}
+}
+
+func (w *WaitGroup) IsDone() bool {
+	return atomic.LoadInt32(&w.count) == 0
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -23,19 +23,19 @@ const (
 
 var Log = common.Log
 
-func Start(weaveAPIAddr string, dockerClient *docker.Client, address string, meshAddress string, dns bool, isPluginV2, forceMulticast bool) {
+func Start(weaveAPIAddr string, dockerClient *docker.Client, address string, meshAddress string, dns bool, isPluginV2, forceMulticast bool, defaultSubnet string) {
 	weave := weaveapi.NewClient(weaveAPIAddr, Log)
 
 	Log.Info("Waiting for Weave API Server...")
 	weave.WaitAPIServer(30)
 	Log.Info("Finished waiting for Weave API Server")
 
-	if err := run(dockerClient, weave, address, meshAddress, dns, isPluginV2, forceMulticast); err != nil {
+	if err := run(dockerClient, weave, address, meshAddress, dns, isPluginV2, forceMulticast, defaultSubnet); err != nil {
 		Log.Fatal(err)
 	}
 }
 
-func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddress string, dns, isPluginV2, forceMulticast bool) error {
+func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddress string, dns, isPluginV2, forceMulticast bool, defaultSubnet string) error {
 	endChan := make(chan error, 1)
 
 	if address != "" {
@@ -53,6 +53,12 @@ func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddre
 		}
 		defer os.Remove(meshAddress)
 		defer meshListener.Close()
+	}
+	if !isPluginV2 {
+		Log.Println("Creating default 'weave' network")
+		options := map[string]interface{}{MulticastOption: "true"}
+		// TODO: the driver name should be extracted from pluginMeshSocket
+		dockerClient.EnsureNetwork("weave", "weavemesh", defaultSubnet, options)
 	}
 
 	return <-endChan

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -23,19 +23,19 @@ const (
 
 var Log = common.Log
 
-func Start(weaveAPIAddr string, dockerClient *docker.Client, address string, meshAddress string, dns bool, isPluginV2, forceMulticast bool, defaultSubnet string) {
+func Start(weaveAPIAddr string, dockerClient *docker.Client, address string, meshAddress string, dns bool, isPluginV2, forceMulticast bool, defaultSubnet string, ready func()) {
 	weave := weaveapi.NewClient(weaveAPIAddr, Log)
 
 	Log.Info("Waiting for Weave API Server...")
 	weave.WaitAPIServer(30)
 	Log.Info("Finished waiting for Weave API Server")
 
-	if err := run(dockerClient, weave, address, meshAddress, dns, isPluginV2, forceMulticast, defaultSubnet); err != nil {
+	if err := run(dockerClient, weave, address, meshAddress, dns, isPluginV2, forceMulticast, defaultSubnet, ready); err != nil {
 		Log.Fatal(err)
 	}
 }
 
-func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddress string, dns, isPluginV2, forceMulticast bool, defaultSubnet string) error {
+func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddress string, dns, isPluginV2, forceMulticast bool, defaultSubnet string, ready func()) error {
 	endChan := make(chan error, 1)
 
 	if address != "" {
@@ -60,6 +60,7 @@ func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddre
 		// TODO: the driver name should be extracted from pluginMeshSocket
 		dockerClient.EnsureNetwork("weave", "weavemesh", defaultSubnet, options)
 	}
+	ready()
 
 	return <-endChan
 }

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -255,6 +255,8 @@ func main() {
 	}
 	config.ProtocolMinVersion = byte(protocolMinVersion)
 
+	var waitReady common.WaitGroup
+
 	if proxyConfig.Enabled {
 		// Start Weave Proxy:
 		proxy, err := weaveproxy.NewProxy(*proxyConfig)
@@ -264,7 +266,7 @@ func main() {
 		defer proxy.Stop()
 		listeners := proxy.Listen()
 		proxy.AttachExistingContainers()
-		go proxy.Serve(listeners)
+		go proxy.Serve(listeners, waitReady.Add())
 		go proxy.ListenAndServeStatus("/home/weave/status.sock")
 	}
 
@@ -432,7 +434,7 @@ func main() {
 			ns.HandleHTTP(muxRouter, dockerCli)
 		}
 		router.HandleHTTP(muxRouter)
-		HandleHTTP(muxRouter, version, router, allocator, defaultSubnet, ns, dnsserver)
+		HandleHTTP(muxRouter, version, router, allocator, defaultSubnet, ns, dnsserver, &waitReady)
 		HandleHTTPPeer(muxRouter, allocator, discoveryEndpoint, token, name.String())
 		muxRouter.Methods("GET").Path("/metrics").Handler(metricsHandler(router, allocator, ns, dnsserver))
 		http.Handle("/", common.LoggingHTTPHandler(muxRouter))
@@ -442,7 +444,7 @@ func main() {
 
 	if statusAddr != "" {
 		muxRouter := mux.NewRouter()
-		HandleHTTP(muxRouter, version, router, allocator, defaultSubnet, ns, dnsserver)
+		HandleHTTP(muxRouter, version, router, allocator, defaultSubnet, ns, dnsserver, &waitReady)
 		muxRouter.Methods("GET").Path("/metrics").Handler(metricsHandler(router, allocator, ns, dnsserver))
 		statusMux := http.NewServeMux()
 		statusMux.Handle("/", muxRouter)
@@ -451,26 +453,27 @@ func main() {
 	}
 
 	if enablePlugin || enablePluginV2 {
-		go plugin.Start(httpAddr, dockerCli, pluginSocket, pluginMeshSocket, !noDNS, enablePluginV2, enablePluginV2Multicast, defaultSubnet.String())
+		go plugin.Start(httpAddr, dockerCli, pluginSocket, pluginMeshSocket, !noDNS, enablePluginV2, enablePluginV2Multicast, defaultSubnet.String(), waitReady.Add())
 	}
 
 	if bridgeConfig.AWSVPC {
 		// Run this on its own goroutine because the allocator can block
 		// We remove the default route installed by the kernel,
 		// because awsvpc has installed it as well
-		go expose(allocator, defaultSubnet, bridgeConfig.WeaveBridgeName, bridgeConfig.AWSVPC)
+		go expose(allocator, defaultSubnet, bridgeConfig.WeaveBridgeName, bridgeConfig.AWSVPC, waitReady.Add())
 	}
 
 	signals.SignalHandlerLoop(common.Log, router)
 }
 
-func expose(alloc *ipam.Allocator, subnet address.CIDR, bridgeName string, removeDefaultRoute bool) {
+func expose(alloc *ipam.Allocator, subnet address.CIDR, bridgeName string, removeDefaultRoute bool, ready func()) {
 	addr, err := alloc.Allocate("weave:expose", subnet, false, func() bool { return false })
 	checkFatal(err)
 	cidr := address.MakeCIDR(subnet, addr)
 	err = weavenet.AddBridgeAddr(bridgeName, cidr.IPNet(), removeDefaultRoute)
 	checkFatal(err)
 	Log.Printf("Bridge %q exposed on address %v", bridgeName, cidr)
+	ready()
 }
 
 func options() map[string]string {

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -451,13 +451,7 @@ func main() {
 	}
 
 	if enablePlugin || enablePluginV2 {
-		go plugin.Start(httpAddr, dockerCli, pluginSocket, pluginMeshSocket, !noDNS, enablePluginV2, enablePluginV2Multicast)
-	}
-	if enablePlugin {
-		Log.Println("Creating default 'weave' network")
-		options := map[string]interface{}{plugin.MulticastOption: "true"}
-		// TODO: the driver name should be extracted from pluginMeshSocket
-		dockerCli.EnsureNetwork("weave", "weavemesh", defaultSubnet.String(), options)
+		go plugin.Start(httpAddr, dockerCli, pluginSocket, pluginMeshSocket, !noDNS, enablePluginV2, enablePluginV2Multicast, defaultSubnet.String())
 	}
 
 	if bridgeConfig.AWSVPC {

--- a/prog/weaver/metrics.go
+++ b/prog/weaver/metrics.go
@@ -118,10 +118,10 @@ func newMetrics(router *weave.NetworkRouter, allocator *ipam.Allocator, ns *name
 
 func (m *collector) Collect(ch chan<- prometheus.Metric) {
 
-	status := WeaveStatus{"", nil,
-		weave.NewNetworkRouterStatus(m.router),
-		ipam.NewStatus(m.allocator, address.CIDR{}),
-		nameserver.NewStatus(m.ns, m.dnsserver)}
+	status := WeaveStatus{
+		Router: weave.NewNetworkRouterStatus(m.router),
+		IPAM:   ipam.NewStatus(m.allocator, address.CIDR{}),
+		DNS:    nameserver.NewStatus(m.ns, m.dnsserver)}
 
 	for _, metric := range metrics {
 		metric.Collect(status, metric.Desc, ch)


### PR DESCRIPTION
Various parts of the system initialize asynchronously at startup.
Callers should not attempt operations until all parts are ready; the `weave` script already delays until `curl /status` returns 200, but this could happen too early.
So, we introduce a `ready` function to be called by each sub-part: plugin, proxy, expose; this function comes from a wrapped `WaitGroup`.
We don't actually wait on the `WaitGroup`; that could perhaps be simplified, but I thought it was a good idea to follow the pattern.