### PR TITLE
Better plugin-v2 detection

### DIFF
--- a/prog/weaveutil/plugin_network.go
+++ b/prog/weaveutil/plugin_network.go
@@ -65,6 +65,7 @@ func isDockerPluginEnabled(args []string) error {
 
 	for _, p := range plugins {
 		if p.Enabled && strings.Contains(p.Name, pluginName) {
+			fmt.Println(p.Name)
 			return nil
 		}
 	}

--- a/prog/weaveutil/plugin_network.go
+++ b/prog/weaveutil/plugin_network.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker/client"
 	docker "github.com/fsouza/go-dockerclient"
@@ -56,16 +57,19 @@ func isDockerPluginEnabled(args []string) error {
 	}
 
 	ctx := context.Background()
-	p, _, err := c.PluginInspectWithRaw(ctx, pluginName)
+
+	plugins, err := c.PluginList(ctx)
 	if err != nil {
 		return err
 	}
 
-	if !p.Enabled {
-		return fmt.Errorf("plugin %q is disabled", pluginName)
+	for _, p := range plugins {
+		if p.Enabled && strings.Contains(p.Name, pluginName) {
+			return nil
+		}
 	}
 
-	return nil
+	return fmt.Errorf("plugin %q not found", pluginName)
 }
 
 func newDockerClient() (*docker.Client, error) {

--- a/weave
+++ b/weave
@@ -1526,7 +1526,7 @@ case "$COMMAND" in
             echo "Invalid 'weave status' sub-command: $SUB_COMMAND" >&2
             usage
         fi
-        if [ -z "$SUB_STATUS" ] && PROXY_ADDRS=$(proxy_addrs) ; then
+        if [ -z "$SUB_STATUS" ] && PROXY_ADDRS=$(proxy_addrs 2>/dev/null) ; then
             echo
             echo "        Service: proxy"
             echo "        Address: $PROXY_ADDRS"
@@ -1535,10 +1535,10 @@ case "$COMMAND" in
             echo
             echo "        Service: plugin (v1)"
             echo "     DriverName: weave"
-        elif [ -z "$SUB_STATUS" ] && is_plugin_v2_enabled ; then
+        elif [ -z "$SUB_STATUS" ] && PLUGIN_FULL_NAME=$(is_plugin_v2_enabled) ; then
             echo
             echo "        Service: plugin (v2)"
-            echo "     DriverName: $PLUGIN_NAME"
+            echo "     DriverName: $PLUGIN_FULL_NAME"
         fi
         [ -n "$SUB_STATUS" ] || echo
         [ $res -eq 0 ]


### PR DESCRIPTION
Make plugin-v2 detection to work when plugin-v2 name includes a registry name (e.g. "store/weaveworks/net-plugin").