### PR TITLE
WIP: Don't mount root as part of `weave launch`

### DIFF
--- a/weave
+++ b/weave
@@ -120,7 +120,7 @@ docker_run_options() {
 exec_options() {
     case "$1" in
         setup|setup-cni|launch|reset)
-            echo -v /etc:/host/etc -v /var/lib/dbus:/host/var/lib/dbus -v $CNI_PLUGIN_DIR:/host/$CNI_PLUGIN_DIR -e HOST_ROOT=/host
+            echo -v /etc:/host/etc -v /var/lib/dbus:/host/var/lib/dbus -v $CNI_PLUGIN_DIR:/host/$CNI_PLUGIN_DIR -v /run/docker/plugins:/host/run/docker/plugins -e HOST_ROOT=/host
             ;;
         # All the other commands that may create the bridge and need machine id files.
         # We don't mount '/' to avoid recursive mounts of '/var'

--- a/weave
+++ b/weave
@@ -21,6 +21,7 @@ IMAGE=$BASE_IMAGE:$IMAGE_VERSION
 PROXY_HOST=${PROXY_HOST:-$(echo "${DOCKER_HOST#tcp://}" | cut -s -d: -f1)}
 PROXY_HOST=${PROXY_HOST:-127.0.0.1}
 DOCKER_CLIENT_HOST=${DOCKER_CLIENT_HOST:-$DOCKER_HOST}
+CNI_PLUGIN_DIR=${WEAVE_CNI_PLUGIN_DIR:-$HOST_ROOT/opt/cni/bin}
 
 # Define some regular expressions for matching addresses.
 # The regexp here is far from precise, but good enough.
@@ -119,7 +120,7 @@ docker_run_options() {
 exec_options() {
     case "$1" in
         setup|setup-cni|launch|reset)
-            echo -v /:/host -e HOST_ROOT=/host
+            echo -v /etc:/host/etc -v /var/lib/dbus:/host/var/lib/dbus -v $CNI_PLUGIN_DIR:/host/$CNI_PLUGIN_DIR -e HOST_ROOT=/host
             ;;
         # All the other commands that may create the bridge and need machine id files.
         # We don't mount '/' to avoid recursive mounts of '/var'
@@ -259,7 +260,6 @@ CONTAINER_NAME=${WEAVE_CONTAINER_NAME:-weave}
 PLUGIN_NAME="$DOCKERHUB_USER/net-plugin"
 OLD_PLUGIN_CONTAINER_NAME=weaveplugin
 CNI_PLUGIN_NAME="weave-plugin-$IMAGE_VERSION"
-CNI_PLUGIN_DIR=${WEAVE_CNI_PLUGIN_DIR:-$HOST_ROOT/opt/cni/bin}
 VOLUMES_LABEL=weavevolumes
 # Note VOLUMES_CONTAINER which is for weavewait should change when you upgrade Weave
 VOLUMES_CONTAINER_NAME=weavevolumes-$IMAGE_VERSION

--- a/weave
+++ b/weave
@@ -154,6 +154,7 @@ exec_remote() {
         -e COVERAGE \
         -e CHECKPOINT_DISABLE \
         -e AWSVPC   \
+        -e RESOLV_CONF="$RESOLV_CONF" \
         $WEAVEEXEC_DOCKER_ARGS $EXEC_IMAGE --local "$@"
 }
 
@@ -227,6 +228,18 @@ case "$1" in
             for img in $IMAGE $WEAVEDB_IMAGE ; do
                 docker inspect -f "_" $img >/dev/null 2>&1 || docker pull $img
             done
+        fi
+        if [ -z "$RESOLV_CONF" ] ; then
+            # Figure out the location of the actual resolv.conf file because
+            # we want to bind mount its directory into the container.
+            if [ -L /etc/resolv.conf ]; then # symlink
+                # This assumes a host with readlink...
+                # Ideally, this would resolve the symlink manually, without
+                # using host commands.
+                RESOLV_CONF=$(readlink -f /etc/resolv.conf)
+            else
+                RESOLV_CONF=/etc/resolv.conf
+            fi
         fi
         ;;
     setup)
@@ -1198,16 +1211,6 @@ launch() {
         fi
     fi
 
-    # Figure out the location of the actual resolv.conf file because
-    # we want to bind mount its directory into the container.
-    if [ -L ${HOST_ROOT:-/}/etc/resolv.conf ]; then # symlink
-        # This assumes a host with readlink in FHS directories...
-        # Ideally, this would resolve the symlink manually, without
-        # using host commands.
-        RESOLV_CONF=$(chroot ${HOST_ROOT:-/} readlink -f /etc/resolv.conf)
-    else
-        RESOLV_CONF=/etc/resolv.conf
-    fi
     RESOLV_CONF_DIR=$(dirname "$RESOLV_CONF")
     RESOLV_CONF_BASE=$(basename "$RESOLV_CONF")
 


### PR DESCRIPTION
There's a comment in the script: "We don't mount '/' to avoid recursive mounts of '/var'", which relates to issues such as #1455.

So I changed the script to avoid mounting `/`.  This now means we have to compute the path to `/etc/resolv.conf` before the remote-exec, because it could be anywhere on the drive, but that move means we don't need a `chroot`

It turns out the attempt to find `weavedb` files wasn't working anyway for `attach|expose|hide`, and wasn't a good idea, so I took that out.

WIP because two tests are failing and I have no idea why.