### PR TITLE
Issues/2953 reorg images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,14 +53,14 @@ testing/runner/runner
 releases
 .*.uptodate
 weave*.tar.gz
-prog/weaveexec/weave
+prog/weaver/weave
 prog/weaveexec/weavehosts
 prog/weaveexec/weaveproxy
 prog/weaveexec/weavewait
 prog/weaveexec/weavewait_noop
 prog/weaveexec/weavewait_nomcast
 prog/weaveexec/sigproxy
-prog/weaveexec/weaveutil
+prog/weaver/weaveutil
 prog/weaveexec/docker*
 Vagrantfile.local
 test/tls/tls

--- a/Makefile
+++ b/Makefile
@@ -248,17 +248,17 @@ else
 endif
 
 # The targets below builds the weave images
-$(WEAVER_UPTODATE): prog/weaver/Dockerfile.$(DOCKERHUB_USER) $(WEAVER_EXE) $(WEAVEEXEC_UPTODATE)
+$(WEAVER_UPTODATE): prog/weaver/Dockerfile.$(DOCKERHUB_USER) $(WEAVER_EXE) weave $(WEAVEUTIL_EXE)
+	cp $(WEAVEUTIL_EXE) prog/weaver/weaveutil
+	cp weave prog/weaver/weave
 	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -f prog/weaver/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVER_IMAGE) prog/weaver
 	touch $@
 
-$(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile.$(DOCKERHUB_USER) prog/weaveexec/symlink $(DOCKER_DISTRIB) weave $(SIGPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(WEAVEWAIT_NOMCAST_EXE) $(WEAVEUTIL_EXE)
-	cp weave prog/weaveexec/weave
+$(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile.$(DOCKERHUB_USER) prog/weaveexec/symlink $(DOCKER_DISTRIB) $(SIGPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(WEAVEWAIT_NOMCAST_EXE) $(WEAVER_UPTODATE)
 	cp $(SIGPROXY_EXE) prog/weaveexec/sigproxy
 	cp $(WEAVEWAIT_EXE) prog/weaveexec/weavewait
 	cp $(WEAVEWAIT_NOOP_EXE) prog/weaveexec/weavewait_noop
 	cp $(WEAVEWAIT_NOMCAST_EXE) prog/weaveexec/weavewait_nomcast
-	cp $(WEAVEUTIL_EXE) prog/weaveexec/weaveutil
 	tar -xf $(DOCKER_DISTRIB) usr/local/bin/docker -O > prog/weaveexec/docker
 	chmod +x prog/weaveexec/docker
 	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -f prog/weaveexec/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVEEXEC_IMAGE) prog/weaveexec

--- a/prog/weaveexec/Dockerfile.template
+++ b/prog/weaveexec/Dockerfile.template
@@ -1,32 +1,9 @@
-FROM ALPINE_BASEIMAGE
-
-# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
-# If we're building normally, for amd64, CROSS_BUILD lines are removed
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
-LABEL maintainer "Weaveworks Inc <help@weave.works>"
-LABEL works.weave.role=system \
-      org.label-schema.name="Weave Net" \
-      org.label-schema.description="Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery" \
-      org.label-schema.url="https://weave.works" \
-      org.label-schema.vcs-url="https://github.com/weaveworks/weave" \
-      org.label-schema.vendor="Weaveworks"
+FROM DOCKERHUB_USER/weaveARCH_EXT
 
 ENTRYPOINT ["/home/weave/sigproxy", "/home/weave/weave"]
 
-RUN apk add --update \
-    curl \
-    ethtool \
-    iptables \
-    ipset \
-    iproute2 \
-    util-linux \
-    conntrack-tools \
-    bind-tools \
-  && rm -rf /var/cache/apk/*
-
-ADD ./weave ./sigproxy ./symlink /home/weave/
-ADD ./weaveutil ./docker /usr/bin/
+ADD ./sigproxy ./symlink /home/weave/
+ADD ./docker /usr/bin/
 ADD ./weavewait /w/w
 ADD ./weavewait_noop /w-noop/w
 ADD ./weavewait_nomcast /w-nomcast/w

--- a/prog/weaver/Dockerfile.template
+++ b/prog/weaver/Dockerfile.template
@@ -28,3 +28,4 @@ ADD ./weaveutil /usr/bin/
 ADD weavedata.db /weavedb/
 COPY ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/home/weave/weaver"]
+WORKDIR /home/weave

--- a/prog/weaver/Dockerfile.template
+++ b/prog/weaver/Dockerfile.template
@@ -1,5 +1,30 @@
-FROM DOCKERHUB_USER/weaveexecARCH_EXT
-ADD ./weaver /home/weave/
+FROM ALPINE_BASEIMAGE
+
+# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
+# If we're building normally, for amd64, CROSS_BUILD lines are removed
+CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
+
+LABEL maintainer "Weaveworks Inc <help@weave.works>"
+LABEL works.weave.role=system \
+      org.label-schema.name="Weave Net" \
+      org.label-schema.description="Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery" \
+      org.label-schema.url="https://weave.works" \
+      org.label-schema.vcs-url="https://github.com/weaveworks/weave" \
+      org.label-schema.vendor="Weaveworks"
+
+RUN apk add --update \
+    curl \
+    ethtool \
+    iptables \
+    ipset \
+    iproute2 \
+    util-linux \
+    conntrack-tools \
+    bind-tools \
+  && rm -rf /var/cache/apk/*
+
+ADD ./weave ./weaver /home/weave/
+ADD ./weaveutil /usr/bin/
 ADD weavedata.db /weavedb/
 COPY ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/home/weave/weaver"]

--- a/weave
+++ b/weave
@@ -219,8 +219,6 @@ kill_container() {
 # main
 ######################################################################
 
-check_docker_version
-
 [ "$1" = "--local" ] && shift 1 && IS_LOCAL=1
 
 # "--help|help" are special because we always want to process them
@@ -245,6 +243,7 @@ elif [ "$1" = "env" -a "$2" = "--restore" ] ; then
 fi
 
 if [ -z "$IS_LOCAL" ] ; then
+    check_docker_version
     exec_remote "$@"
     exit $?
 fi


### PR DESCRIPTION
Fixes #2953 

Results:
```
On master:
weaveworks/weave            latest      e3263035a80c        52 seconds ago      108 MB
weaveworks/weave-kube       latest      a34820b12cc7        22 seconds ago      150 MB
weaveworks/weave-npc        latest      aa9ee3fef304        13 seconds ago      54.7 MB
weaveworks/weaveexec        latest      d894ce240403        55 seconds ago      80.8 MB
-rw-rw-r-- 1 vagrant vagrant 56214606 May 12 16:42 weave.tar.gz

on 2953 branch
weaveworks/weave            latest      29e6d7d0d911        About a minute ago   58.2 MB
weaveworks/weave-kube       latest      e159fd3ec977        19 seconds ago       101 MB
weaveworks/weave-npc        latest      a9ace58c1338        10 seconds ago       54.7 MB
weaveworks/weaveexec        latest      a34044eb2e63        50 seconds ago       108 MB
-rw-rw-r-- 1 vagrant vagrant 56209157 May 12 16:45 weave.tar.gz
```

50MB less for weave-kube seems like a win; weaveexec is nominally bigger but the layers are shared so that's an ilusion