### PR TITLE
Don't check docker version when run --local

### DIFF
--- a/weave
+++ b/weave
@@ -218,8 +218,6 @@ kill_container() {
 # main
 ######################################################################
 
-check_docker_version
-
 [ "$1" = "--local" ] && shift 1 && IS_LOCAL=1
 
 # "--help|help" are special because we always want to process them
@@ -244,6 +242,7 @@ elif [ "$1" = "env" -a "$2" = "--restore" ] ; then
 fi
 
 if [ -z "$IS_LOCAL" ] ; then
+    check_docker_version
     exec_remote "$@"
     exit $?
 fi


### PR DESCRIPTION
The standard case for `--local` is when the weave script in the `weaveexec` container is run by the `weave` script, which has just checked the version. Also in this case we check the version of the docker binary embedded in `weaveexec`, which is entirely predictable.

`--local` is also used from `weave-kube` where we don't mount the docker socket and therefore cannot check.

Since `--local` is undocumented we will not worry about any other cases; the worst that can happen is a confusing error message. We are not using any recently-added features of the `docker` command so will most likely work with whatever docker version the user has.

This came up while working on #2954; it seems like a worthwhile (if small) performance improvement for other cases, e.g. Weave Scope running `weave ps --local` every three seconds.