### PR TITLE
Remove proxy status.sock

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -442,7 +442,9 @@ func main() {
 		HandleHTTP(muxRouter, version, router, allocator, defaultSubnet, ns, dnsserver, &waitReady)
 		HandleHTTPPeer(muxRouter, allocator, discoveryEndpoint, token, name.String())
 		muxRouter.Methods("GET").Path("/metrics").Handler(metricsHandler(router, allocator, ns, dnsserver))
-		muxRouter.Methods("GET").Path("/proxyaddrs").HandlerFunc(proxy.StatusHTTP)
+		if proxy != nil {
+			muxRouter.Methods("GET").Path("/proxyaddrs").HandlerFunc(proxy.StatusHTTP)
+		}
 		http.Handle("/", common.LoggingHTTPHandler(muxRouter))
 		Log.Println("Listening for HTTP control messages on", httpAddr)
 		go listenAndServeHTTP(httpAddr, nil)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -310,17 +310,6 @@ func (proxy *Proxy) Serve(listeners []net.Listener, ready func()) {
 	}
 }
 
-func (proxy *Proxy) ListenAndServeStatus(socket string) {
-	listener, err := weavenet.ListenUnixSocket(socket)
-	if err != nil {
-		Log.Fatalf("ListenAndServeStatus failed: %s", err)
-	}
-	handler := http.HandlerFunc(proxy.StatusHTTP)
-	if err := (&http.Server{Handler: handler}).Serve(listener); err != nil {
-		Log.Fatalf("ListenAndServeStatus failed: %s", err)
-	}
-}
-
 func (proxy *Proxy) StatusHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, addr := range proxy.normalisedAddrs {
 		fmt.Fprintln(w, addr)

--- a/weave
+++ b/weave
@@ -1154,7 +1154,7 @@ proxy_args() {
 
 proxy_addrs() {
     if addr="$(call_weave GET /proxyaddrs)" ; then
-      echo "$addr" | sed "s/0.0.0.0/$PROXY_HOST/g"
+      echo "$addr" | sed "s/0.0.0.0/$PROXY_HOST/g" | tr '\n' ' '
     else
       return 1
     fi

--- a/weave
+++ b/weave
@@ -661,19 +661,6 @@ http_call() {
     return $retval
 }
 
-http_call_unix() {
-    container="$1"
-    socket="$2"
-    http_verb="$3"
-    url="$4"
-    shift 4
-    # NB: requires curl >= 7.40
-    output=$(docker exec $container curl -s -S -X $http_verb --unix-socket $socket "$@" http:$url) || return 1
-    # in some docker versions, `docker exec` does not fail when the executed command fails
-    [ -n "$output" ] || return 1
-    echo $output
-}
-
 call_weave() {
     TMPERR=/tmp/call_weave_err_$$
     retval=0
@@ -1166,10 +1153,9 @@ proxy_args() {
 }
 
 proxy_addrs() {
-    if addr="$(http_call_unix $CONTAINER_NAME status.sock GET /status 2>/dev/null)" ; then
+    if addr="$(call_weave GET /proxyaddrs)" ; then
       echo "$addr" | sed "s/0.0.0.0/$PROXY_HOST/g"
     else
-      echo "$CONTAINER_NAME container is not present. Have you launched it?" >&2
       return 1
     fi
 }

--- a/weave
+++ b/weave
@@ -1154,6 +1154,7 @@ proxy_args() {
 
 proxy_addrs() {
     if addr="$(call_weave GET /proxyaddrs)" ; then
+      [ -n "$addr" ] || return 1
       echo "$addr" | sed "s/0.0.0.0/$PROXY_HOST/g" | tr '\n' ' '
     else
       return 1


### PR DESCRIPTION
This is a hold-over from the multi-container implementation, so we can slim things down a bit by removing it.

Although #2036 recommends going in the opposite direction :thinking: 