### PR TITLE
Fix shfmt lint error by escaping $ in sed expression

### DIFF
--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -284,7 +284,7 @@ function configure() {
         local inventory_file=$(mktemp /tmp/ansible_inventory_XXXXX)
         echo "[all]" >"$inventory_file"
         # shellcheck disable=SC2001
-        echo "$2" | sed "s/$/:$3/" >>"$inventory_file"
+        echo "$2" | sed "s/\$/:$3/" >>"$inventory_file"
 
         # Configure the provisioned machines using Ansible, allowing up to 3 retries upon failure (e.g. APT connectivity issues, etc.):
         for i in $(seq 3); do


### PR DESCRIPTION
This fixes new error raised by latest version of shfmt, leading to build failures.