### PR TITLE
Simplify checks for plugin running

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -57,8 +57,7 @@ func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddre
 	if !isPluginV2 {
 		Log.Println("Creating default 'weave' network")
 		options := map[string]interface{}{MulticastOption: "true"}
-		// TODO: the driver name should be extracted from pluginMeshSocket
-		dockerClient.EnsureNetwork("weave", "weavemesh", defaultSubnet, options)
+		dockerClient.EnsureNetwork("weave", pluginNameFromAddress(meshAddress), defaultSubnet, options)
 	}
 	ready()
 
@@ -70,7 +69,7 @@ func listenAndServe(dockerClient *docker.Client, weave *weaveapi.Client, address
 	if isPluginV2 {
 		name = pluginV2Name
 	} else {
-		name = strings.TrimSuffix(path.Base(address), ".sock")
+		name = pluginNameFromAddress(address)
 	}
 
 	d, err := netplugin.New(dockerClient, weave, name, scope, dns, isPluginV2, forceMulticast)
@@ -94,4 +93,9 @@ func listenAndServe(dockerClient *docker.Client, weave *weaveapi.Client, address
 	}()
 
 	return listener, nil
+}
+
+// Take a socket address like "/run/docker/plugins/weavemesh.sock" and extract the plugin name "weavemesh"
+func pluginNameFromAddress(address string) string {
+	return strings.TrimSuffix(path.Base(address), ".sock")
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	pluginV2Name    = "net-plugin"
+	defaultNetwork  = "weave"
 	MulticastOption = netplugin.MulticastOption
 )
 
@@ -53,11 +54,11 @@ func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddre
 		}
 		defer os.Remove(meshAddress)
 		defer meshListener.Close()
-	}
-	if !isPluginV2 {
-		Log.Println("Creating default 'weave' network")
-		options := map[string]interface{}{MulticastOption: "true"}
-		dockerClient.EnsureNetwork("weave", pluginNameFromAddress(meshAddress), defaultSubnet, options)
+		if !isPluginV2 {
+			Log.Printf("Creating default %q network", defaultNetwork)
+			options := map[string]interface{}{MulticastOption: "true"}
+			dockerClient.EnsureNetwork(defaultNetwork, pluginNameFromAddress(meshAddress), defaultSubnet, options)
+		}
 	}
 	ready()
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -24,40 +24,62 @@ const (
 
 var Log = common.Log
 
-func Start(weaveAPIAddr string, dockerClient *docker.Client, address string, meshAddress string, dns bool, isPluginV2, forceMulticast bool, defaultSubnet string, ready func()) {
+type Config struct {
+	Socket            string
+	MeshSocket        string
+	Enable            bool
+	EnableV2          bool
+	EnableV2Multicast bool
+	DNS               bool
+	DefaultSubnet     string
+}
+
+type Plugin struct {
+	Config
+}
+
+func NewPlugin(config Config) *Plugin {
+	if !config.Enable && !config.EnableV2 {
+		return nil
+	}
+	plugin := &Plugin{Config: config}
+	return plugin
+}
+
+func (plugin *Plugin) Start(weaveAPIAddr string, dockerClient *docker.Client, ready func()) {
 	weave := weaveapi.NewClient(weaveAPIAddr, Log)
 
 	Log.Info("Waiting for Weave API Server...")
 	weave.WaitAPIServer(30)
 	Log.Info("Finished waiting for Weave API Server")
 
-	if err := run(dockerClient, weave, address, meshAddress, dns, isPluginV2, forceMulticast, defaultSubnet, ready); err != nil {
+	if err := plugin.run(dockerClient, weave, ready); err != nil {
 		Log.Fatal(err)
 	}
 }
 
-func run(dockerClient *docker.Client, weave *weaveapi.Client, address, meshAddress string, dns, isPluginV2, forceMulticast bool, defaultSubnet string, ready func()) error {
+func (plugin *Plugin) run(dockerClient *docker.Client, weave *weaveapi.Client, ready func()) error {
 	endChan := make(chan error, 1)
 
-	if address != "" {
-		globalListener, err := listenAndServe(dockerClient, weave, address, endChan, "global", false, dns, isPluginV2, forceMulticast)
+	if plugin.Socket != "" {
+		globalListener, err := listenAndServe(dockerClient, weave, plugin.Socket, endChan, "global", false, plugin.DNS, plugin.EnableV2, plugin.EnableV2Multicast)
 		if err != nil {
 			return err
 		}
-		defer os.Remove(address)
+		defer os.Remove(plugin.Socket)
 		defer globalListener.Close()
 	}
-	if meshAddress != "" {
-		meshListener, err := listenAndServe(dockerClient, weave, meshAddress, endChan, "local", true, dns, isPluginV2, forceMulticast)
+	if plugin.MeshSocket != "" {
+		meshListener, err := listenAndServe(dockerClient, weave, plugin.MeshSocket, endChan, "local", true, plugin.DNS, plugin.EnableV2, plugin.EnableV2Multicast)
 		if err != nil {
 			return err
 		}
-		defer os.Remove(meshAddress)
+		defer os.Remove(plugin.MeshSocket)
 		defer meshListener.Close()
-		if !isPluginV2 {
+		if !plugin.EnableV2 {
 			Log.Printf("Creating default %q network", defaultNetwork)
 			options := map[string]interface{}{MulticastOption: "true"}
-			dockerClient.EnsureNetwork(defaultNetwork, pluginNameFromAddress(meshAddress), defaultSubnet, options)
+			dockerClient.EnsureNetwork(defaultNetwork, pluginNameFromAddress(plugin.MeshSocket), plugin.DefaultSubnet, options)
 		}
 	}
 	ready()

--- a/plugin/status.go
+++ b/plugin/status.go
@@ -1,0 +1,19 @@
+package plugin
+
+type Status struct {
+	DriverName     string
+	MeshDriverName string `json:"MeshDriverName,omitempty"`
+	Version        int
+}
+
+func NewStatus(address, meshAddress string, isPluginV2 bool) *Status {
+	status := &Status{
+		DriverName:     pluginNameFromAddress(address),
+		MeshDriverName: pluginNameFromAddress(meshAddress),
+		Version:        1,
+	}
+	if isPluginV2 {
+		status.Version = 2
+	}
+	return status
+}

--- a/plugin/status.go
+++ b/plugin/status.go
@@ -6,13 +6,16 @@ type Status struct {
 	Version        int
 }
 
-func NewStatus(address, meshAddress string, isPluginV2 bool) *Status {
+func (plugin *Plugin) NewStatus() *Status {
+	if plugin == nil {
+		return nil
+	}
 	status := &Status{
-		DriverName:     pluginNameFromAddress(address),
-		MeshDriverName: pluginNameFromAddress(meshAddress),
+		DriverName:     pluginNameFromAddress(plugin.Socket),
+		MeshDriverName: pluginNameFromAddress(plugin.MeshSocket),
 		Version:        1,
 	}
-	if isPluginV2 {
+	if plugin.EnableV2 {
 		status.Version = 2
 	}
 	return status

--- a/plugin/status.go
+++ b/plugin/status.go
@@ -1,9 +1,9 @@
 package plugin
 
 type Status struct {
+	Config         Config
 	DriverName     string
 	MeshDriverName string `json:"MeshDriverName,omitempty"`
-	Version        int
 }
 
 func (plugin *Plugin) NewStatus() *Status {
@@ -13,10 +13,7 @@ func (plugin *Plugin) NewStatus() *Status {
 	status := &Status{
 		DriverName:     pluginNameFromAddress(plugin.Socket),
 		MeshDriverName: pluginNameFromAddress(plugin.MeshSocket),
-		Version:        1,
-	}
-	if plugin.EnableV2 {
-		status.Version = 2
+		Config:         plugin.Config,
 	}
 	return status
 }

--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -214,7 +214,7 @@ var statusTemplate = defTemplate("status", `\
 
         Service: plugin (v{{.Plugin.Version}})
 {{if eq .Plugin.Version 1}}\
-        DriverName: {{.Plugin.DriverName}}
+     DriverName: {{.Plugin.DriverName}}
 {{end}}\
 {{end}}\
 `)

--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -299,7 +299,7 @@ type WeaveStatus struct {
 }
 
 // Read-only functions, suitable for exposing on an unprotected socket
-func HandleHTTP(muxRouter *mux.Router, version string, router *weave.NetworkRouter, allocator *ipam.Allocator, defaultSubnet address.CIDR, ns *nameserver.Nameserver, dnsserver *nameserver.DNSServer, prxy *proxy.Proxy, pluginStatus *plugin.Status, waitReady *common.WaitGroup) {
+func HandleHTTP(muxRouter *mux.Router, version string, router *weave.NetworkRouter, allocator *ipam.Allocator, defaultSubnet address.CIDR, ns *nameserver.Nameserver, dnsserver *nameserver.DNSServer, prxy *proxy.Proxy, plugin *plugin.Plugin, waitReady *common.WaitGroup) {
 	status := func() WeaveStatus {
 		return WeaveStatus{
 			waitReady.IsDone(),
@@ -309,7 +309,7 @@ func HandleHTTP(muxRouter *mux.Router, version string, router *weave.NetworkRout
 			ipam.NewStatus(allocator, defaultSubnet),
 			nameserver.NewStatus(ns, dnsserver),
 			proxy.NewStatus(prxy),
-			pluginStatus,
+			plugin.NewStatus(),
 		}
 	}
 	muxRouter.Methods("GET").Path("/report").Headers("Accept", "application/json").HandlerFunc(

--- a/prog/weaver/http.go
+++ b/prog/weaver/http.go
@@ -212,8 +212,10 @@ var statusTemplate = defTemplate("status", `\
 {{end}}\
 {{if .Plugin}}\
 
-        Service: plugin (v{{.Plugin.Version}})
-{{if eq .Plugin.Version 1}}\
+{{if .Plugin.Config.EnableV2}}\
+        Service: plugin (v2)
+{{else}}\
+        Service: plugin (legacy)
      DriverName: {{.Plugin.DriverName}}
 {{end}}\
 {{end}}\

--- a/proxy/status.go
+++ b/proxy/status.go
@@ -1,0 +1,15 @@
+package proxy
+
+type Status struct {
+	Addresses []string
+}
+
+func NewStatus(proxy *Proxy) *Status {
+	if proxy == nil {
+		return nil
+	}
+	status := &Status{
+		Addresses: proxy.normalisedAddrs,
+	}
+	return status
+}

--- a/weave
+++ b/weave
@@ -1456,20 +1456,6 @@ case "$COMMAND" in
             echo "Invalid 'weave status' sub-command: $SUB_COMMAND" >&2
             usage
         fi
-        if [ -z "$SUB_STATUS" ] && PROXY_ADDRS=$(proxy_addrs 2>/dev/null) ; then
-            echo
-            echo "        Service: proxy"
-            echo "        Address: $PROXY_ADDRS"
-        fi
-        if [ -z "$SUB_STATUS" ] && is_plugin_v1_enabled ; then
-            echo
-            echo "        Service: plugin (v1)"
-            echo "     DriverName: weave"
-        elif [ -z "$SUB_STATUS" ] && PLUGIN_FULL_NAME=$(is_plugin_v2_enabled) ; then
-            echo
-            echo "        Service: plugin (v2)"
-            echo "     DriverName: $PLUGIN_FULL_NAME"
-        fi
         [ -n "$SUB_STATUS" ] || echo
         [ $res -eq 0 ]
         ;;

--- a/weave
+++ b/weave
@@ -582,17 +582,6 @@ attach() {
 # functions for interacting with containers
 ######################################################################
 
-# Docker Plugin V1 runs in a Docker container.
-is_plugin_v1_enabled() {
-    docker inspect -f '{{.Config.Cmd}}' $CONTAINER_NAME 2>/dev/null | grep -q -- "--plugin"
-}
-
-# The presence of Docker Plugin V2 can be checked only via 'docker plugin',
-# as v2 plugins do not run as regular containers.
-is_plugin_v2_enabled() {
-    util_op is-docker-plugin-enabled $PLUGIN_NAME 2>/dev/null
-}
-
 # Check that a container for component $1 named $2 with image $3 is not running
 check_not_running() {
     RUN_STATUS=$(docker inspect --format='{{.State.Running}} {{.State.Status}} {{.Config.Image}}' $2 2>/dev/null) || true
@@ -1313,10 +1302,8 @@ stop() {
 }
 
 protect_against_docker_hang() {
-    # If the plugin is not running, remove its socket so Docker doesn't try to talk to it
-    if ! is_plugin_v1_enabled && ! is_plugin_v2_enabled ; then
-        rm -f $HOST_ROOT/run/docker/plugins/weave.sock $HOST_ROOT/run/docker/plugins/weavemesh.sock
-    fi
+    # Since the plugin is not running, remove its socket so Docker doesn't try to talk to it
+    rm -f $HOST_ROOT/run/docker/plugins/weave.sock $HOST_ROOT/run/docker/plugins/weavemesh.sock
 }
 
 ######################################################################

--- a/weave
+++ b/weave
@@ -593,14 +593,6 @@ is_plugin_v2_enabled() {
     util_op is-docker-plugin-enabled $PLUGIN_NAME 2>/dev/null
 }
 
-# Check that plugin (v2) is not running.
-check_not_running_plugin_v2() {
-    if is_plugin_v2_enabled; then
-        echo "Docker plugin \"$PLUGIN_NAME\" is running; Aborting." >&2
-        return 1
-    fi
-}
-
 # Check that a container for component $1 named $2 with image $3 is not running
 check_not_running() {
     RUN_STATUS=$(docker inspect --format='{{.State.Running}} {{.State.Status}} {{.Config.Image}}' $2 2>/dev/null) || true
@@ -1417,7 +1409,10 @@ case "$COMMAND" in
     launch)
         deprecation_warnings "$@"
         check_not_running router $CONTAINER_NAME        $BASE_IMAGE
-        check_not_running_plugin_v2
+        if http_call $HTTP_ADDR GET /status >/dev/null 2>&1 ; then
+            echo "Weave Net is already running" >&2
+            exit 1
+        fi
         # Plugin and proxy are started by default. Should users additionally pass --plugin=false or --proxy=false, their overrides will take precedence when parsed by Go.
         launch --plugin --proxy "$@"
         echo "$WEAVE_CONTAINER"

--- a/weave
+++ b/weave
@@ -1303,7 +1303,7 @@ launch() {
 }
 
 stop() {
-    ! is_plugin_v1_enabled || util_op remove-plugin-network weave || true
+    util_op remove-plugin-network weave || true
     warn_if_stopping_proxy_in_env
     docker stop $CONTAINER_NAME >/dev/null 2>&1 || echo "Weave is not running." >&2
     # In case user has upgraded from <v2.0 and left old containers running


### PR DESCRIPTION
Fixes #2956 
Fixes #2709

1. `weave status` now does plugin-v1 and plugin-v2 in Go code.
2. all other uses of `is_plugin_vX_enabled`collapse to "is weaver running?"
2a. in `stop` before calling `remove-plugin-network`, if plugin was disabled then `RemoveNetwork` will return `NoSuchNetwork`
2b. in `protect_against_docker_hang` if weaver is not running it's ok to remove the plugin sockets.
2c. in `launch` we now error if weaver is already running for any reason