### PR TITLE
Change weavedb from an emptyDir to a hostPath volume

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -117,6 +117,7 @@ post_start_actions &
 /home/weave/weaver $EXTRA_ARGS --port=6783 $(router_bridge_opts) \
      --host-root=$HOST_ROOT \
      --http-addr=$HTTP_ADDR --status-addr=$STATUS_ADDR --docker-api='' --no-dns \
+     --db-prefix="/weavedb/weave-net" \
      --ipalloc-range=$IPALLOC_RANGE $NICKNAME_ARG \
      --ipalloc-init $IPALLOC_INIT \
      --conn-limit=$CONN_LIMIT \

--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -102,7 +102,8 @@ spec:
           type: spc_t
       volumes:
         - name: weavedb
-          emptyDir: {}
+          hostPath:
+            path: /var/lib/weave
         - name: cni-bin
           hostPath:
             path: /opt

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -62,7 +62,8 @@ spec:
       restartPolicy: Always
       volumes:
         - name: weavedb
-          emptyDir: {}
+          hostPath:
+            path: /var/lib/weave
         - name: cni-bin
           hostPath:
             path: /opt

--- a/weave
+++ b/weave
@@ -126,7 +126,7 @@ docker_run_options() {
 
 exec_options() {
     case "$1" in
-        setup|setup-cni|launch)
+        setup|setup-cni|launch|reset)
             echo -v /:/host -e HOST_ROOT=/host
             ;;
         # All the other commands that may create the bridge and need machine id files.
@@ -1634,6 +1634,7 @@ case "$COMMAND" in
         protect_against_docker_hang
         VOLUME_CONTAINERS=$(docker ps -qa --filter label=weavevolumes)
         [ -n "$VOLUME_CONTAINERS" ] && docker rm -v $VOLUME_CONTAINERS  >/dev/null 2>&1 || true
+        rm -f $HOST_ROOT/var/lib/weave/weave-netdata.db >/dev/null 2>&1 || true
         destroy_bridge
         for LOCAL_IFNAME in $(ip link show | grep v${CONTAINER_IFNAME}pl | cut -d ' ' -f 2 | tr -d ':') ; do
             ip link del ${LOCAL_IFNAME%@*} >/dev/null 2>&1 || true


### PR DESCRIPTION
`emptyDir` has the same lifetime as the pod, whereas we want our persistence to extend past that, e.g. when Weave Net is upgraded.

We assume that `/var/lib` is writable.

Fixes #2610 