### PR TITLE
 fixing cross cluster weave communication

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -445,7 +445,7 @@ func configureIPTables(config *BridgeConfig) error {
 		if err = ipt.AppendUnique("filter", "FORWARD", "-o", config.WeaveBridgeName, "-m", "state", "--state", "NEW", "-j", "NFLOG", "--nflog-group", "86"); err != nil {
 			return err
 		}
-		if err = ipt.AppendUnique("filter", "FORWARD", "-o", config.WeaveBridgeName, "-j", "DROP"); err != nil {
+		if err = ipt.AppendUnique("filter", "FORWARD", "-i", "!" + config.WeaveBridgeName, "-o", config.WeaveBridgeName, "-j", "DROP"); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
We are only dropping traffic not coming from weave interface instead of dropping all traffic.
It enables communication between pods hosted on 2 different k8s clusters connected through weave.