### PR TITLE
Fixing cross cluster communication

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -445,7 +445,7 @@ func configureIPTables(config *BridgeConfig) error {
 		if err = ipt.AppendUnique("filter", "FORWARD", "-o", config.WeaveBridgeName, "-m", "state", "--state", "NEW", "-j", "NFLOG", "--nflog-group", "86"); err != nil {
 			return err
 		}
-		if err = ipt.AppendUnique("filter", "FORWARD", "-o", config.WeaveBridgeName, "-j", "DROP"); err != nil {
+		if err = ipt.AppendUnique("filter", "FORWARD", "-i", config.WeaveBridgeName, "!", "-o", config.WeaveBridgeName, "-j", "DROP"); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
When using weave with kubernetes between 2 clusters, **all** ingress traffic is dropped by default.
This commit enables communication between 2 clusters by dropping all the traffic **but** from weave interface/subnet.