### PR TITLE
Allow outward traffic when NPC is on

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -453,14 +453,14 @@ func configureIPTables(config *BridgeConfig) error {
 		if err = ipt.AppendUnique("filter", "FORWARD", "-i", config.WeaveBridgeName, "-o", config.WeaveBridgeName, "-j", "ACCEPT"); err != nil {
 			return err
 		}
-		// Forward from weave to the rest of the world
-		if err = ipt.AppendUnique("filter", "FORWARD", "-i", config.WeaveBridgeName, "!", "-o", config.WeaveBridgeName, "-j", "ACCEPT"); err != nil {
-			return err
-		}
-		// and allow replies back
-		if err = ipt.AppendUnique("filter", "FORWARD", "-o", config.WeaveBridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"); err != nil {
-			return err
-		}
+	}
+	// Forward from weave to the rest of the world
+	if err = ipt.AppendUnique("filter", "FORWARD", "-i", config.WeaveBridgeName, "!", "-o", config.WeaveBridgeName, "-j", "ACCEPT"); err != nil {
+		return err
+	}
+	// and allow replies back
+	if err = ipt.AppendUnique("filter", "FORWARD", "-o", config.WeaveBridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"); err != nil {
+		return err
 	}
 
 	// create a chain for masquerading

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -101,6 +101,10 @@ check_all_pods_communicate() {
 
 assert_raises 'wait_for_x check_all_pods_communicate pods'
 
+# Check that a pod can contact the outside world
+podName=$($SSH $HOST1 "$KUBECTL get pods -l run=nettest -o go-template='{{(index .items 0).metadata.name}}'")
+assert_raises "$SSH $HOST1 $KUBECTL exec $podName -- $PING 8.8.8.8"
+
 tear_down_kubeadm
 
 # Destroy our test ipset, and implicitly check it is still there


### PR DESCRIPTION
Correct a change in behaviour when the iptables rules set-up was moved from shell-script to Go code in https://github.com/weaveworks/weave/pull/1958/commits/dd232775e68a18122560af20637d96626e991d94 - the "Forward from weave to the rest of the world" rule was moved inside the `if config.ExpectNPC`.

This had the effect that, when NPC was in effect, nothing could leave the weave bridge, even to contact the Kubernetes DNS server.