### PR TITLE
weave-npc to check local addresses only

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -453,14 +453,14 @@ func configureIPTables(config *BridgeConfig) error {
 		if err = ipt.AppendUnique("filter", "FORWARD", "-i", config.WeaveBridgeName, "-o", config.WeaveBridgeName, "-j", "ACCEPT"); err != nil {
 			return err
 		}
-		// Forward from weave to the rest of the world
-		if err = ipt.AppendUnique("filter", "FORWARD", "-i", config.WeaveBridgeName, "!", "-o", config.WeaveBridgeName, "-j", "ACCEPT"); err != nil {
-			return err
-		}
-		// and allow replies back
-		if err = ipt.AppendUnique("filter", "FORWARD", "-o", config.WeaveBridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"); err != nil {
-			return err
-		}
+	}
+	// Forward from weave to the rest of the world
+	if err = ipt.AppendUnique("filter", "FORWARD", "-i", config.WeaveBridgeName, "!", "-o", config.WeaveBridgeName, "-j", "ACCEPT"); err != nil {
+		return err
+	}
+	// and allow replies back
+	if err = ipt.AppendUnique("filter", "FORWARD", "-o", config.WeaveBridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"); err != nil {
+		return err
 	}
 
 	// create a chain for masquerading

--- a/npc/constants.go
+++ b/npc/constants.go
@@ -8,4 +8,6 @@ const (
 	IngressChain = "WEAVE-NPC-INGRESS"
 
 	IpsetNamePrefix = "weave-"
+
+	LocalIpset = IpsetNamePrefix + "local-pods"
 )

--- a/npc/ipset/ipset.go
+++ b/npc/ipset/ipset.go
@@ -1,6 +1,7 @@
 package ipset
 
 import (
+	"log"
 	"os/exec"
 	"strings"
 
@@ -31,10 +32,11 @@ type Interface interface {
 
 type ipset struct {
 	refCount
+	*log.Logger
 }
 
-func New() Interface {
-	return &ipset{refCount: newRefCount()}
+func New(logger *log.Logger) Interface {
+	return &ipset{refCount: newRefCount(), Logger: logger}
 }
 
 func (i *ipset) Create(ipsetName Name, ipsetType Type) error {
@@ -42,6 +44,7 @@ func (i *ipset) Create(ipsetName Name, ipsetType Type) error {
 }
 
 func (i *ipset) AddEntry(ipsetName Name, entry string) error {
+	i.Logger.Printf("adding entry %s to %s", entry, ipsetName)
 	if i.inc(ipsetName, entry) > 1 { // already in the set
 		return nil
 	}
@@ -49,6 +52,7 @@ func (i *ipset) AddEntry(ipsetName Name, entry string) error {
 }
 
 func (i *ipset) DelEntry(ipsetName Name, entry string) error {
+	i.Logger.Printf("deleting entry %s from %s", entry, ipsetName)
 	if i.dec(ipsetName, entry) > 0 { // still needed
 		return nil
 	}

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -88,6 +88,7 @@ func (ns *ns) addPod(obj *coreapi.Pod) error {
 		return nil
 	}
 
+	ns.ips.AddEntry(LocalIpset, obj.Status.PodIP)
 	return ns.podSelectors.addToMatching(obj.ObjectMeta.Labels, obj.Status.PodIP)
 }
 
@@ -100,10 +101,12 @@ func (ns *ns) updatePod(oldObj, newObj *coreapi.Pod) error {
 	}
 
 	if hasIP(oldObj) && !hasIP(newObj) {
+		ns.ips.DelEntry(LocalIpset, oldObj.Status.PodIP)
 		return ns.podSelectors.delFromMatching(oldObj.ObjectMeta.Labels, oldObj.Status.PodIP)
 	}
 
 	if !hasIP(oldObj) && hasIP(newObj) {
+		ns.ips.AddEntry(LocalIpset, newObj.Status.PodIP)
 		return ns.podSelectors.addToMatching(newObj.ObjectMeta.Labels, newObj.Status.PodIP)
 	}
 
@@ -139,6 +142,7 @@ func (ns *ns) deletePod(obj *coreapi.Pod) error {
 		return nil
 	}
 
+	ns.ips.DelEntry(LocalIpset, obj.Status.PodIP)
 	return ns.podSelectors.delFromMatching(obj.ObjectMeta.Labels, obj.Status.PodIP)
 }
 

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -43,12 +43,10 @@ func (s *selector) matches(labelMap map[string]string) bool {
 }
 
 func (s *selector) addEntry(entry string) error {
-	common.Log.Infof("adding entry %s to %s", entry, s.spec.ipsetName)
 	return s.ips.AddEntry(s.spec.ipsetName, entry)
 }
 
 func (s *selector) delEntry(entry string) error {
-	common.Log.Infof("deleting entry %s from %s", entry, s.spec.ipsetName)
 	return s.ips.DelEntry(s.spec.ipsetName, entry)
 }
 

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -112,6 +112,16 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 		return err
 	}
 
+	// If the destination address is not any of the local pods, let it through
+	if err := ips.Create(npc.LocalIpset, ipset.HashIP); err != nil {
+		return err
+	}
+	if err := ipt.Append(npc.TableFilter, npc.MainChain,
+		"-m", "set", "--match-set", npc.LocalIpset, "src",
+		"-m", "set", "!", "--match-set", npc.LocalIpset, "dst", "-j", "ACCEPT"); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -135,7 +135,7 @@ func root(cmd *cobra.Command, args []string) {
 	ipt, err := iptables.New()
 	handleError(err)
 
-	ips := ipset.New()
+	ips := ipset.New(common.LogLogger())
 
 	handleError(resetIPTables(ipt))
 	handleError(resetIPSets(ips))

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -101,6 +101,10 @@ check_all_pods_communicate() {
 
 assert_raises 'wait_for_x check_all_pods_communicate pods'
 
+# Check that a pod can contact the outside world
+podName=$($SSH $HOST1 "$KUBECTL get pods -l run=nettest -o go-template='{{(index .items 0).metadata.name}}'")
+assert_raises "$SSH $HOST1 $KUBECTL exec $podName -- $PING 8.8.8.8"
+
 tear_down_kubeadm
 
 # Destroy our test ipset, and implicitly check it is still there


### PR DESCRIPTION
This branch is based off the branch for #2978, because I need the rule to contact kube-dns.
Only the last four commits are relevant to this PR.

This PR does two things: it fixes #2622 by only adding IP addresses from pods on the current node; and it then corrects a bug exposed by that change: weave-npc used to filter on the destination address at both ends of a connection.

I suspect this is the cause of #2973.

To address that, I create a new IPset which has all local pod addresses, and if a new connection comes from a local pod but does not target a local pod we let it through.  In this way all the real filtering is done at the destination end of the connection.