### PR TITLE
wip: Retry iptables

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -1,6 +1,10 @@
 package common
 
-import "strings"
+import (
+	"os/exec"
+	"strings"
+	"syscall"
+)
 
 // Assert test is true, panic otherwise
 func Assert(test bool) {
@@ -15,4 +19,18 @@ func ErrorMessages(errors []error) string {
 		result = append(result, err.Error())
 	}
 	return strings.Join(result, "\n")
+}
+
+// IsErrExitCode4 checks if the error is exit code 4 from an exec.Command.
+// Useful for use with iptables when you can't access the lock file and need to retry.
+func IsErrExitCode4(err error) bool {
+	if ierr, ok := err.(*exec.ExitError); ok {
+		if status, ok := ierr.Sys().(syscall.WaitStatus); ok {
+			// (magic exit code 4 found in iptables source code; undocumented)
+			if status.ExitStatus() == 4 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -1,0 +1,48 @@
+package common_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	commonutils "github.com/weaveworks/weave/common"
+)
+
+func TestExitCode4Helper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	os.Exit(4)
+}
+
+func TestExitCode1Helper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	os.Exit(1)
+}
+
+func TestExitCode0Helper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	os.Exit(0)
+}
+
+func TestExitCodes(t *testing.T) {
+	execEnv := []string{"GO_WANT_HELPER_PROCESS=1"}
+	c0 := exec.Command(os.Args[0], []string{"-test.run=TestExitCode0Helper", "--"}...)
+	c0.Env = execEnv
+	c1 := exec.Command(os.Args[0], []string{"-test.run=TestExitCode1Helper", "--"}...)
+	c1.Env = execEnv
+	c4 := exec.Command(os.Args[0], []string{"-test.run=TestExitCode4Helper", "--"}...)
+	c4.Env = execEnv
+
+	assert.False(t, commonutils.IsErrExitCode4(nil))
+	assert.False(t, commonutils.IsErrExitCode4(fmt.Errorf("some error")))
+	assert.False(t, commonutils.IsErrExitCode4(c0.Run()))
+	assert.False(t, commonutils.IsErrExitCode4(c1.Run()))
+	assert.True(t, commonutils.IsErrExitCode4(c4.Run()))
+}

--- a/npc/ipset/ipset.go
+++ b/npc/ipset/ipset.go
@@ -3,6 +3,7 @@ package ipset
 import (
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -67,11 +68,18 @@ func (i *ipset) FlushAll() error {
 
 func (i *ipset) Destroy(ipsetName Name) error {
 	i.removeSet(ipsetName)
-	// Loop until we get an exit code other than inUseErrStr
+	// Loop until we get an err other than inUseErrStr or 20 attempts
+	var attempt = 1
+	var err error
 	for {
-		if err := doExec("destroy", string(ipsetName)); !isErrInUse(err) {
+		if err = doExec("destroy", string(ipsetName)); !isErrInUse(err) {
 			return err
 		}
+		if attempt >= 20 {
+			return err
+		}
+		time.Sleep(time.Millisecond * 500)
+		attempt++
 	}
 }
 

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -230,11 +230,21 @@ func bypassRule(nsIpsetName ipset.Name) []string {
 }
 
 func (ns *ns) ensureBypassRule(nsIpsetName ipset.Name) error {
-	return ns.ipt.Append(TableFilter, DefaultChain, bypassRule(ns.allPods.ipsetName)...)
+	// Loop until we get an exit code other than "temporarily unavailable"
+	for {
+		if err := ns.ipt.Append(TableFilter, DefaultChain, bypassRule(ns.allPods.ipsetName)...); !common.IsErrExitCode4(err) {
+			return err
+		}
+	}
 }
 
 func (ns *ns) deleteBypassRule(nsIpsetName ipset.Name) error {
-	return ns.ipt.Delete(TableFilter, DefaultChain, bypassRule(ns.allPods.ipsetName)...)
+	// Loop until we get an exit code other than "temporarily unavailable"
+	for {
+		if err := ns.ipt.Delete(TableFilter, DefaultChain, bypassRule(ns.allPods.ipsetName)...); !common.IsErrExitCode4(err) {
+			return err
+		}
+	}
 }
 
 func (ns *ns) addNamespace(obj *coreapi.Namespace) error {


### PR DESCRIPTION
fixes #2939

In Kubernetes, multiple pods interact with iptables/ipsets. Unfortunately they are often using different binary versions or don't have access to a shared lock file.

For this reason we often run into problems like iptables exiting with status code 4 "temporarily unavailable" or ipset exiting with an "in use by a kernel component" error.

This change introduces: 
* retrying for iptables until the change is successful (expected to be temporary)
* multiple attempts for some ipset methods (to avoid getting stuck)