### PR TITLE
Fix broken link to ECS guide

### DIFF
--- a/site/installing-weave.md
+++ b/site/installing-weave.md
@@ -51,7 +51,7 @@ To disable this check, run the following before launching Weave Net:
 CoreOS users see [here](/guides/networking-docker-containers-with-weave-on-coreos/) for an example of installing Weave using cloud-config.
 
 Amazon ECS users see [here](https://github.com/weaveworks/integrations/blob/master/aws/ecs/README.md)
-for the latest Weave AMIs and [here](http://weave.works/guides/service-discovery-with-weave-aws-ecs.html) to get started with Weave Net on ECS.
+for the latest Weave AMIs and [here](https://www.weave.works/docs/tutorials/old-guides/ecs/) to get started with Weave Net on ECS.
 
 If you're on Amazon EC2, the standard installation instructions at the
 top of this page, provide the simplest setup and the most flexibility.


### PR DESCRIPTION
As discussed [on Slack](https://weaveworks.slack.com/archives/C0CGANX6W/p1495451119984880) this URL should be updated.
cc: @lukemarsden, @abuehrle, @soschwei