### PR TITLE
Use shfmt v1.3.0 instead of latest from master

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -40,11 +40,15 @@ RUN apt-get update \
 		flex \
 		bison
 
+RUN curl -fsSLo shfmt https://github.com/mvdan/sh/releases/download/v1.3.0/shfmt_v1.3.0_linux_amd64 && \
+	echo "b1925c2c405458811f0c227266402cf1868b4de529f114722c2e3a5af4ac7bb2  shfmt" | sha256sum -c && \
+	chmod +x shfmt && \
+	mv shfmt /usr/bin
+
 # Install common Go tools
 RUN go get \
 	github.com/golang/lint/golint \
 	github.com/fzipp/gocyclo \
-	github.com/mvdan/sh/cmd/shfmt \
 	github.com/fatih/hclfmt \
 	github.com/client9/misspell/cmd/misspell
 


### PR DESCRIPTION
Before this change, `go get`-ting` would pick the latest version of `shfmt` which keeps changing, hence frequently breaking our builds.

After this change, we download the `shfmt` binary from its GitHub releases page which is fast and locks the version we use. Note that `RUN` does not like herestrings, hence `echo "..." | sha256sum -c` for checksum.

Alternatives considered:
- `go get gopkg.in/mvdan/sh.v1/cmd/shfmt` -- but `gopkg.in` currently doesn't behave well for this tool
- `go build` from a `git` tag -- but this is much more involved.