### PR TITLE
Remove deprecated --init-peer-count option

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -66,9 +66,7 @@ func (c *ipamConfig) Enabled() bool {
 	case !hasRange && hasSubnet:
 		Log.Fatal("--ipalloc-default-subnet specified without --ipalloc-range.")
 	case !hasRange:
-		Log.Fatal("--ipalloc-init or --init-peer-count specified without --ipalloc-range.")
-	case hasMode && hasPeerCount:
-		Log.Fatal("At most one of --ipalloc-init or --init-peer-count may be specified.")
+		Log.Fatal("--ipalloc-init specified without --ipalloc-range.")
 	}
 	if hasMode {
 		if err := c.parseMode(); err != nil {
@@ -187,7 +185,6 @@ func main() {
 	mflag.StringVar(&ipamConfig.Mode, []string{"-ipalloc-init"}, "", "allocator initialisation strategy (consensus, seed or observer)")
 	mflag.StringVar(&ipamConfig.IPRangeCIDR, []string{"-ipalloc-range"}, "", "IP address range reserved for automatic allocation, in CIDR notation")
 	mflag.StringVar(&ipamConfig.IPSubnetCIDR, []string{"-ipalloc-default-subnet"}, "", "subnet to allocate within by default, in CIDR notation")
-	mflag.IntVar(&ipamConfig.PeerCount, []string{"-init-peer-count"}, 0, "number of peers in network (for IP address allocation)")
 	mflag.StringVar(&dockerAPI, []string{"-docker-api"}, defaultDockerHost, "Docker API endpoint")
 	mflag.BoolVar(&noDNS, []string{"-no-dns"}, false, "disable DNS server")
 	mflag.StringVar(&dnsConfig.Domain, []string{"-dns-domain"}, nameserver.DefaultDomain, "local domain to server requests for")

--- a/weave
+++ b/weave
@@ -1306,31 +1306,6 @@ protect_against_docker_hang() {
 }
 
 ######################################################################
-# argument deprecation handling
-######################################################################
-
-deprecation_warning() {
-    echo "Warning: ${1%=*} is deprecated; please use $2" >&2
-}
-
-deprecation_warnings() {
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            # Flags that have a following argument which should not be inspected
-            --password|--nickname|--ipalloc-range|--ipalloc-default-subnet)
-                shift
-                ;;
-            --init-peer-count|--init-peer-count=*)
-                deprecation_warning $1 "--ipalloc-init consensus=<count>"
-                [ ${1#--} = "init-peer-count" ] && shift
-                shift
-                ;;
-        esac
-        shift
-    done
-}
-
-######################################################################
 # main (remote and --local)
 ######################################################################
 
@@ -1393,7 +1368,6 @@ case "$COMMAND" in
         detect_bridge_type && echo $BRIDGE_TYPE
         ;;
     launch)
-        deprecation_warnings "$@"
         check_not_running router $CONTAINER_NAME        $BASE_IMAGE
         if http_call $HTTP_ADDR GET /status >/dev/null 2>&1 ; then
             echo "Weave Net is already running" >&2


### PR DESCRIPTION
And, since this was the last deprecated option, remove all code to generate deprecation warnings in the weave script.

This incidentally fixes a bug: calling `Enabled()` had the side-effect of computing `PeerCount` from `--ipalloc-init consensus=x`, so if it was called twice you would get a fatal error.

```
$ weave launch --ipalloc-init='consensus=3' --awsvpc
The weave container has died. Consult the container logs for further details.
$ docker logs weave
[...]
FATA: 2017/05/26 15:14:47.541745 At most one of --ipalloc-init or --init-peer-count may be specified.
```
