### PR TITLE
Remove unsafe netns change in proxy

### DIFF
--- a/prog/weaveutil/main.go
+++ b/prog/weaveutil/main.go
@@ -32,6 +32,7 @@ func init() {
 		"check-iface":              checkIface,
 		"del-iface":                delIface,
 		"setup-iface":              setupIface,
+		"setup-iface-addrs":        setupIfaceAddrs,
 		"list-netdevs":             listNetDevs,
 		"cni-net":                  cniNet,
 		"cni-ipam":                 cniIPAM,

--- a/prog/weaveutil/netdev.go
+++ b/prog/weaveutil/netdev.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/j-keck/arping"
 	"github.com/vishvananda/netlink"
 
@@ -48,27 +47,7 @@ func setupIface(args []string) error {
 	ifaceName := args[0]
 	newIfName := args[1]
 
-	ipt, err := iptables.New()
-	if err != nil {
-		return err
-	}
-
-	link, err := netlink.LinkByName(ifaceName)
-	if err != nil {
-		return err
-	}
-	if err := netlink.LinkSetName(link, newIfName); err != nil {
-		return err
-	}
-	// This is only called by AttachContainer which is only called in host pid namespace
-	if err := weavenet.ConfigureARPCache("/proc", newIfName); err != nil {
-		return err
-	}
-	if err := ipt.Append("filter", "INPUT", "-i", newIfName, "-d", "224.0.0.0/4", "-j", "DROP"); err != nil {
-		return err
-	}
-
-	return nil
+	return weavenet.SetupIface(ifaceName, newIfName)
 }
 
 func configureARP(args []string) error {

--- a/prog/weaveutil/netdev.go
+++ b/prog/weaveutil/netdev.go
@@ -50,6 +50,26 @@ func setupIface(args []string) error {
 	return weavenet.SetupIface(ifaceName, newIfName)
 }
 
+// setupIfaceAddrs sets up addresses on an interface. It expects to be called inside the container's netns.
+func setupIfaceAddrs(args []string) error {
+	if len(args) < 1 {
+		cmdUsage("setup-iface-addrs", "<iface-name> <with-multicast> <cidr>...")
+	}
+	link, err := netlink.LinkByName(args[0])
+	if err != nil {
+		return err
+	}
+	withMulticastRoute, err := strconv.ParseBool(args[1])
+	if err != nil {
+		return err
+	}
+	cidrs, err := parseCIDRs(args[2:])
+	if err != nil {
+		return err
+	}
+	return weavenet.SetupIfaceAddrs(link, withMulticastRoute, cidrs)
+}
+
 func configureARP(args []string) error {
 	if len(args) != 2 {
 		cmdUsage("configure-arp", "<iface-name-prefix> <root-path>")

--- a/site/cni-plugin.md
+++ b/site/cni-plugin.md
@@ -108,5 +108,8 @@ For more information, see the
 
 ### Caveats
 
+- The program `nsenter` must be present on the host; it is required by
+  the CNI plugin.  In some distros (e.g. Alpine, Ubuntu) it is in the
+  util-linux package
 - The Weave Net router container must be running for CNI to allocate addresses
 - The CNI plugin does not add entries to weaveDNS.


### PR DESCRIPTION
This became unsafe when we started calling `AttachContainer` directly from the proxy.

We need two sub-functions which enter the container netns: one is called before we set the host end of the veth up, and one after.  Linux networking semantics require this split.

This leaves two instances of `WithNetNSUnsafe`: one from `weaveutil detach` and one when the CNI plugin configures routes.  In both cases the process exits straight away, so they are low risk.