### PR TITLE
Turn on hairpin mode on veth bridge ports

### DIFF
--- a/plugin/net/cni.go
+++ b/plugin/net/cni.go
@@ -128,7 +128,7 @@ func (c *CNIPlugin) CmdAdd(args *skel.CmdArgs) error {
 		id = fmt.Sprintf("%x", data)
 	}
 
-	if err := weavenet.AttachContainer(args.Netns, id, args.IfName, conf.BrName, conf.MTU, false, []*net.IPNet{&ip.Address}, false); err != nil {
+	if err := weavenet.AttachContainer(args.Netns, id, args.IfName, conf.BrName, conf.MTU, false, []*net.IPNet{&ip.Address}, false, conf.HairpinMode); err != nil {
 		return err
 	}
 	if err := weavenet.WithNetNSLinkUnsafe(ns, args.IfName, func(link netlink.Link) error {
@@ -218,8 +218,9 @@ func logOnStderr(err error) {
 
 type NetConf struct {
 	types.NetConf
-	BrName string `json:"bridge"`
-	IsGW   bool   `json:"isGateway"`
-	IPMasq bool   `json:"ipMasq"`
-	MTU    int    `json:"mtu"`
+	BrName      string `json:"bridge"`
+	IsGW        bool   `json:"isGateway"`
+	IPMasq      bool   `json:"ipMasq"`
+	MTU         int    `json:"mtu"`
+	HairpinMode bool   `json:"hairpinMode"`
 }

--- a/plugin/net/cni.go
+++ b/plugin/net/cni.go
@@ -34,7 +34,8 @@ func NewCNIPlugin(weave *weaveapi.Client) *CNIPlugin {
 
 func loadNetConf(bytes []byte) (*NetConf, error) {
 	n := &NetConf{
-		BrName: weavenet.WeaveBridgeName,
+		BrName:      weavenet.WeaveBridgeName,
+		HairpinMode: true,
 	}
 	if err := json.Unmarshal(bytes, n); err != nil {
 		return nil, fmt.Errorf("failed to load netconf: %v", err)

--- a/prog/weaveutil/attach.go
+++ b/prog/weaveutil/attach.go
@@ -14,11 +14,12 @@ import (
 
 func attach(args []string) error {
 	if len(args) < 4 {
-		cmdUsage("attach-container", "[--no-multicast-route] [--keep-tx-on] <container-id> <bridge-name> <mtu> <cidr>...")
+		cmdUsage("attach-container", "[--no-multicast-route] [--keep-tx-on] [--hairpin-mode=true|false] <container-id> <bridge-name> <mtu> <cidr>...")
 	}
 
 	keepTXOn := false
 	withMulticastRoute := true
+	hairpinMode := true
 	for i := 0; i < len(args); {
 		switch args[i] {
 		case "--no-multicast-route":
@@ -26,6 +27,9 @@ func attach(args []string) error {
 			args = append(args[:i], args[i+1:]...)
 		case "--keep-tx-on":
 			keepTXOn = true
+			args = append(args[:i], args[i+1:]...)
+		case "--hairpin-mode=false":
+			hairpinMode = false
 			args = append(args[:i], args[i+1:]...)
 		default:
 			i++
@@ -55,7 +59,7 @@ func attach(args []string) error {
 		return err
 	}
 
-	err = weavenet.AttachContainer(weavenet.NSPathByPid(pid), fmt.Sprint(pid), weavenet.VethName, args[1], mtu, withMulticastRoute, cidrs, keepTXOn)
+	err = weavenet.AttachContainer(weavenet.NSPathByPid(pid), fmt.Sprint(pid), weavenet.VethName, args[1], mtu, withMulticastRoute, cidrs, keepTXOn, hairpinMode)
 	// If we detected an error but the container has died, tell the user that instead.
 	if err != nil && !processExists(pid) {
 		err = fmt.Errorf("Container %s died", args[0])

--- a/site/kube-addon.md
+++ b/site/kube-addon.md
@@ -241,3 +241,7 @@ The list of variables you can set is:
   a larger size for better performance if your network supports jumbo
   frames - see [here](/site/using-weave/fastdp.md#mtu) for more
   details.
+* `HAIRPIN_MODE` - Weave Net defaults to enabling hairpin on the bridge side of
+  the `veth` pair for containers attached. If you need to disable hairpin, e.g. your
+  kernel is one of those that can panic if hairpin is enabled, then you can disable it
+  by setting `HAIRPIN_MODE=false`.

--- a/weave
+++ b/weave
@@ -1070,17 +1070,20 @@ create_cni_config() {
     cat >"$1" <<EOF
 {
     "name": "weave",
-    "type": "weave-net"
+    "type": "weave-net",
+    "hairpinMode": $2
 }
 EOF
 }
 
 setup_cni() {
+    # if env var HAIRPIN_MODE is not set, default it to true
+    HAIRPIN_MODE=${HAIRPIN_MODE:-true}
     if install_cni_plugin $CNI_PLUGIN_DIR ; then
         upgrade_cni_plugin $CNI_PLUGIN_DIR
     fi
     if [ -d $HOST_ROOT/etc/cni/net.d -a ! -f $HOST_ROOT/etc/cni/net.d/10-weave.conf ] ; then
-        create_cni_config $HOST_ROOT/etc/cni/net.d/10-weave.conf
+        create_cni_config $HOST_ROOT/etc/cni/net.d/10-weave.conf $HAIRPIN_MODE
     fi
 }
 


### PR DESCRIPTION
excerpted from #2971 from @deitch

> As discussed with @bboreham , there is an issue wherein kubernetes in CRI seems to have forgotten to handle hairpin. In pre-CRI, when kubelet received the veth back from the CNI plugin, it enabled hairpin (or not, depending on the kubelet command-line setting).

This PR adds a `hairpinMode` to the CNI config file to match the CNI bridge plugin, with a default of "on".

It also adds a hairpin option to `weaveutil attach` but that option is not set so again the option defaults on. To be clear, this means hairpin will also be on for containers attached by `weave run`, `weave attach` and the proxy, in Weave Net 1.9.