### PR TITLE
Weave-NPC should get hostname from K8s Downward API.

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -92,6 +92,12 @@ spec:
               cpu: 10m
           securityContext:
             privileged: true
+          env:
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
       restartPolicy: Always
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -59,6 +59,12 @@ spec:
               cpu: 10m
           securityContext:
             privileged: true
+          env:
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
       restartPolicy: Always
       volumes:
         - name: weavedb


### PR DESCRIPTION
It is necessary in case when kubelet's args includes `--hostname_override=`.
Without this change, pods on hostname overriding kubelets will never be local,
and all pod's traffic will be blocked.