### PR TITLE
Kubernetes' seLinuxOptions are empty by default

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -106,8 +106,7 @@ items:
           hostPID: true
           restartPolicy: Always
           securityContext:
-            seLinuxOptions:
-              type: spc_t
+            seLinuxOptions: {}
           serviceAccountName: weave-net
           tolerations:
             - effect: NoSchedule

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -70,8 +70,7 @@ items:
           hostPID: true
           restartPolicy: Always
           securityContext:
-            seLinuxOptions:
-              type: spc_t
+            seLinuxOptions: {}
           serviceAccountName: weave-net
           volumes:
             - name: weavedb

--- a/site/kube-addon.md
+++ b/site/kube-addon.md
@@ -216,6 +216,7 @@ If the YAML file is from `cloud.weave.works` as described above, then you can cu
   - `trusted-subnets`: comma-separated list of CIDRs. Default: empty.
   - `disable-npc`: boolean (`true|false`). Default: `false`.
   - `env.NAME=VALUE`: add environment variable `NAME` and set it to `VALUE`.
+  - `seLinuxOptions.NAME=VALUE`: add SELinux option `NAME` and set it to `VALUE`, e.g. `seLinuxOptions.type=spc_t`
 
 The list of variables you can set is:
 


### PR DESCRIPTION
... but can be customised via the Launch Generator, as per the updated documentation.

Fixes #2990.