### PR TITLE
Pass check-alive flag on claim for container

### DIFF
--- a/api/ipam.go
+++ b/api/ipam.go
@@ -51,8 +51,8 @@ func (client *Client) LookupIP(ID string) (*net.IPNet, error) {
 }
 
 // Claim a specific IP on behalf of the ID
-func (client *Client) ClaimIP(ID string, cidr *net.IPNet) error {
-	_, err := client.httpVerb("PUT", fmt.Sprintf("/ip/%s/%s", ID, cidr), nil)
+func (client *Client) ClaimIP(ID string, cidr *net.IPNet, checkAlive bool) error {
+	_, err := client.httpVerb("PUT", fmt.Sprintf("/ip/%s/%s", ID, cidr), ipamValues(checkAlive))
 	return err
 }
 

--- a/plugin/ipam/driver.go
+++ b/plugin/ipam/driver.go
@@ -87,7 +87,7 @@ func (i *Ipam) RequestAddress(poolID string, address net.IP, options map[string]
 	}
 	if address != nil { // try to claim specific address requested
 		ip = &net.IPNet{IP: address, Mask: subnet.Mask}
-		if err = i.weave.ClaimIP(api.NoContainerID, ip); err != nil {
+		if err = i.weave.ClaimIP(api.NoContainerID, ip, false); err != nil {
 			return
 		}
 	} else {

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -392,7 +392,7 @@ func main() {
 		observeContainers(allocator)
 
 		if dockerCli != nil {
-			allContainerIDs, err := dockerCli.AllContainerIDs()
+			allContainerIDs, err := dockerCli.RunningContainerIDs()
 			checkFatal(err)
 			allocator.PruneOwned(allContainerIDs)
 		}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -568,7 +568,7 @@ func (proxy *Proxy) claimCIDR(containerID, cidr string) (*net.IPNet, error) {
 		return nil, err
 	}
 	ipnet.IP = ip // we want the specific IP plus the mask
-	err = proxy.weave.ClaimIP(containerID, ipnet)
+	err = proxy.weave.ClaimIP(containerID, ipnet, true)
 	return ipnet, err
 }
 

--- a/test/610_proxy_wait_for_weave_test.sh
+++ b/test/610_proxy_wait_for_weave_test.sh
@@ -27,6 +27,7 @@ check_iface_ready 10.2.1.1/24
 # Check committed containers only have one weavewait prepended
 proxy_start_container $HOST1 --name c1 -e 'WEAVE_CIDR=10.2.1.1/24'
 COMMITTED_IMAGE=$(proxy docker_on $HOST1 commit c1)
+docker_on $HOST1 stop -t=1 c1
 assert_raises "proxy docker_on $HOST1 run --name c2 $COMMITTED_IMAGE"
 assert "entrypoint c2" "$(entrypoint $COMMITTED_IMAGE)"
 


### PR DESCRIPTION
Otherwise it doesn't clear out addresses when it dies.
This is currently causing test failures on master after merge of #3010 

Note change of behaviour: previously if a container died we would retain its owned address across a `weave` restart; now we drop that allocation.  This means if you were counting on your container getting the same address when it restarted, this is now less likely to happen if `weave` restarts at the same time.