### PR TITLE
Allow any non-local traffic onto the weave bridge

### DIFF
--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -117,7 +117,6 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 		return err
 	}
 	if err := ipt.Append(npc.TableFilter, npc.MainChain,
-		"-m", "set", "--match-set", npc.LocalIpset, "src",
 		"-m", "set", "!", "--match-set", npc.LocalIpset, "dst", "-j", "ACCEPT"); err != nil {
 		return err
 	}

--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -23,4 +23,4 @@ if [ -n "$CIRCLECI" -o -n "$PARALLEL" ]; then
     RUNNER_ARGS="$RUNNER_ARGS -parallel"
 fi
 
-HOSTS="$HOSTS" "${DIR}/../tools/runner/runner" $RUNNER_ARGS $TESTS
+HOSTS="$HOSTS" "${DIR}/../tools/runner/runner" -timeout=240 $RUNNER_ARGS $TESTS


### PR DESCRIPTION
If it's destined for a pod on another node it will be checked again when it reaches that other node.  The previous version was rejecting traffic coming in from outside the cluster.

Fixes #3011 