### PR TITLE
Ability to set IPALLOC_RANGE via plugin-v2 configuration parameters

### DIFF
--- a/prog/net-plugin/config.json
+++ b/prog/net-plugin/config.json
@@ -74,6 +74,14 @@
           "value"
       ],
       "value": ""
+    },
+    {
+      "description": "The range of IP addresses used by Weave Net",
+      "name": "IPALLOC_RANGE",
+      "settable": [
+          "value"
+      ],
+      "value": ""
     }
   ],
   "network": {

--- a/site/plugin-v2.md
+++ b/site/plugin-v2.md
@@ -43,6 +43,9 @@ The parameters include:
   a larger size for better performance if your network supports jumbo
   frames - see [here](/site/using-weave/fastdp.md#mtu) for more
   details.
+* `IPALLOC_RANGE` - the range of IP addresses used by Weave Net and the subnet
+  they are placed in (CIDR format; default 10.32.0.0/12).
+  See [here](/site/using-weave/configuring-weave.md) for more details.
 
 Before setting any parameter, the plugin has to be disabled with:
 


### PR DESCRIPTION
Unfortunately, we can not set `--ipalloc-range` using `EXTRA_ARGS` plugin configuration parameter. It's just not take effect in `prog/net-plugin/launch.sh` and there is no way to change `--ipalloc-range` for plugin.

This PR simply add `IPALLOC_RANGE` as plugin configuration parameter and update documentation accordingly.