### PR TITLE
WIP: remove peers that have disappeared from kubernetes

### DIFF
--- a/api/ipam.go
+++ b/api/ipam.go
@@ -62,6 +62,12 @@ func (client *Client) ReleaseIPsFor(ID string) error {
 	return err
 }
 
+// release all IP space owned by a peer
+func (client *Client) RmPeer(peerName string) (string, error) {
+	result, err := client.httpVerb("DELETE", fmt.Sprintf("/peer/%s", peerName), nil)
+	return result, err
+}
+
 func (client *Client) DefaultSubnet() (*net.IPNet, error) {
 	cidr, err := client.httpVerb("GET", fmt.Sprintf("/ipinfo/defaultsubnet"), nil)
 	if err != nil {

--- a/prog/kube-peers/annotations.go
+++ b/prog/kube-peers/annotations.go
@@ -11,6 +11,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	kubeErrors "k8s.io/client-go/pkg/api/errors"
 	api "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/wait"
 )
 
 type configMapAnnotations struct {
@@ -52,6 +53,8 @@ func (pl *peerList) add(peerName string, name string) {
 
 const (
 	DefaultLeaseDuration = 5 * time.Second
+	retryPeriod          = time.Second * 2
+	jitterFactor         = 1.0
 
 	KubePeersAnnotationKey = "kube-peers.weave.works/peers"
 )
@@ -98,29 +101,40 @@ func (cml *configMapAnnotations) GetPeerList() (*peerList, error) {
 	return &record, nil
 }
 
-// Update will update and existing annotation on a given resource.
 func (cml *configMapAnnotations) UpdatePeerList(list peerList) error {
+	if cml.cm == nil {
+		return errors.New("endpoint not initialized, call Init first")
+	}
 	recordBytes, err := json.Marshal(list)
 	if err != nil {
 		return err
 	}
-	return cml.Update(KubePeersAnnotationKey, recordBytes)
+	cm := cml.cm
+	cm.Annotations[KubePeersAnnotationKey] = string(recordBytes)
+	cm, err = cml.Client.ConfigMaps(cml.Namespace).Update(cml.cm)
+	if err == nil {
+		cml.cm = cm
+	}
+	return err
 }
 
-func (cml *configMapAnnotations) Update(key string, recordBytes []byte) error {
-	if cml.cm == nil {
-		return errors.New("endpoint not initialized, call Init first")
-	}
+// Loop with jitter, fetching the cml data and calling f() until it
+// doesn't get an optimistic locking conflict.
+// If it succeeds or gets any other kind of error, stop the loop.
+func (cml *configMapAnnotations) LoopUpdate(f func() error) error {
+	stop := make(chan struct{})
 	var err error
-	for {
-		cml.cm.Annotations[key] = string(recordBytes)
-		cml.cm, err = cml.Client.ConfigMaps(cml.Namespace).Update(cml.cm)
+	wait.JitterUntil(func() {
+		if err = cml.Init(); err != nil {
+			close(stop)
+			return
+		}
+		err = f()
 		if err != nil && kubeErrors.IsConflict(err) {
 			log.Printf("Optimistic locking conflict: trying again: %s", err)
-			err = cml.Init()
-			continue
+			return
 		}
-		break
-	}
+		close(stop)
+	}, retryPeriod, jitterFactor, true, stop)
 	return err
 }

--- a/prog/kube-peers/annotations.go
+++ b/prog/kube-peers/annotations.go
@@ -1,0 +1,118 @@
+// Much of this copied from k8s.io/kubernetes/pkg/client/leaderelection/resourcelock/configmaplock.go
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	kubeErrors "k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/unversioned"
+	api "k8s.io/client-go/pkg/api/v1"
+)
+
+type LeaderElectionRecord struct {
+	HolderIdentity       string           `json:"holderIdentity"`
+	LeaseDurationSeconds int              `json:"leaseDurationSeconds"`
+	AcquireTime          unversioned.Time `json:"acquireTime"`
+	RenewTime            unversioned.Time `json:"renewTime"`
+}
+
+type configMapAnnotations struct {
+	Name      string
+	Namespace string
+	Client    corev1client.ConfigMapsGetter
+	cm        *api.ConfigMap
+}
+
+func newConfigMapAnnotations(ns string, name string, client *kubernetes.Clientset) *configMapAnnotations {
+	return &configMapAnnotations{
+		Namespace: ns,
+		Name:      name,
+		Client:    client,
+	}
+}
+
+type peerList struct {
+	Peers []peerInfo
+}
+
+type peerInfo struct {
+	PeerName string // Weave internal unique ID
+	Name     string // Kubernetes node name
+}
+
+func (pl peerList) contains(peerName string) bool {
+	for _, peer := range pl.Peers {
+		if peer.PeerName == peerName {
+			return true
+		}
+	}
+	return false
+}
+
+func (pl *peerList) add(peerName string, name string) {
+	pl.Peers = append(pl.Peers, peerInfo{PeerName: peerName, Name: name})
+}
+
+const (
+	KubePeersAnnotationKey = "kube-peers.weave.works/peers"
+)
+
+func (cml *configMapAnnotations) Init() error {
+	for { // Loop only if we call Create() and it's already there
+		var err error
+		cml.cm, err = cml.Client.ConfigMaps(cml.Namespace).Get(cml.Name)
+		if err != nil {
+			if !kubeErrors.IsNotFound(err) {
+				return errors.Wrapf(err, "Unable to fetch ConfigMap %s/%s", cml.Namespace, cml.Name)
+			}
+			cml.cm, err = cml.Client.ConfigMaps(cml.Namespace).Create(&api.ConfigMap{
+				ObjectMeta: api.ObjectMeta{
+					Name:      cml.Name,
+					Namespace: cml.Namespace,
+				},
+			})
+			if err != nil {
+				if kubeErrors.IsAlreadyExists(err) {
+					continue
+				}
+				return errors.Wrapf(err, "Unable to create ConfigMap %s/%s", cml.Namespace, cml.Name)
+			}
+		}
+		break
+	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	return nil
+}
+
+func (cml *configMapAnnotations) GetPeerList() (*peerList, error) {
+	var record peerList
+	if cml.cm == nil {
+		return nil, errors.New("endpoint not initialized, call Init first")
+	}
+	if recordBytes, found := cml.cm.Annotations[KubePeersAnnotationKey]; found {
+		if err := json.Unmarshal([]byte(recordBytes), &record); err != nil {
+			return nil, err
+		}
+	}
+	return &record, nil
+}
+
+// Update will update and existing annotation on a given resource.
+func (cml *configMapAnnotations) UpdatePeerList(list peerList) error {
+	if cml.cm == nil {
+		return errors.New("endpoint not initialized, call Init first")
+	}
+	recordBytes, err := json.Marshal(list)
+	if err != nil {
+		return err
+	}
+	cml.cm.Annotations[KubePeersAnnotationKey] = string(recordBytes)
+	cml.cm, err = cml.Client.ConfigMaps(cml.Namespace).Update(cml.cm)
+	return err
+}

--- a/prog/kube-peers/main.go
+++ b/prog/kube-peers/main.go
@@ -10,15 +10,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func getKubePeers() ([]string, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-	c, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
+func getKubePeers(c *kubernetes.Clientset) ([]string, error) {
 	nodeList, err := c.Nodes().List(api.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -50,7 +42,15 @@ func getKubePeers() ([]string, error) {
 }
 
 func main() {
-	peers, err := getKubePeers()
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("Could not get cluster config: %v", err)
+	}
+	c, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatalf("Could not make Kubernetes connection: %v", err)
+	}
+	peers, err := getKubePeers(c)
 	if err != nil {
 		log.Fatalf("Could not get peers: %v", err)
 	}

--- a/prog/kube-peers/main.go
+++ b/prog/kube-peers/main.go
@@ -21,17 +21,6 @@ func getKubePeers() ([]string, error) {
 	}
 	nodeList, err := c.Nodes().List(api.ListOptions{})
 	if err != nil {
-		// Fallback for cases (e.g. from kube-up.sh) where kube-proxy is not running on master
-		config.Host = "http://localhost:8080"
-		log.Print("error contacting APIServer: ", err, "; trying with fallback: ", config.Host)
-		c, err = kubernetes.NewForConfig(config)
-		if err != nil {
-			return nil, err
-		}
-		nodeList, err = c.Nodes().List(api.ListOptions{})
-	}
-
-	if err != nil {
 		return nil, err
 	}
 	addresses := make([]string, 0, len(nodeList.Items))

--- a/prog/kube-peers/main.go
+++ b/prog/kube-peers/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -10,12 +11,18 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func getKubePeers(c *kubernetes.Clientset) ([]string, error) {
+type nodeInfo struct {
+	name string
+	addr string
+}
+
+// return the IP addresses of all nodes in the cluster
+func getKubePeers(c *kubernetes.Clientset) ([]nodeInfo, error) {
 	nodeList, err := c.Nodes().List(api.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	addresses := make([]string, 0, len(nodeList.Items))
+	addresses := make([]nodeInfo, 0, len(nodeList.Items))
 	for _, peer := range nodeList.Items {
 		var internalIP, externalIP string
 		for _, addr := range peer.Status.Addresses {
@@ -33,15 +40,59 @@ func getKubePeers(c *kubernetes.Clientset) ([]string, error) {
 
 		// Fallback for cases where a Node has an ExternalIP but no InternalIP
 		if internalIP != "" {
-			addresses = append(addresses, internalIP)
+			addresses = append(addresses, nodeInfo{name: peer.Name, addr: internalIP})
 		} else if externalIP != "" {
-			addresses = append(addresses, externalIP)
+			addresses = append(addresses, nodeInfo{name: peer.Name, addr: externalIP})
 		}
 	}
 	return addresses, nil
 }
 
+const (
+	configMapName      = "weave-net"
+	configMapNamespace = "kube-system"
+)
+
+// update the list of all peers that have gone through this code path
+func addMyselfToPeerList(c *kubernetes.Clientset, peerName, name string) (*peerList, error) {
+	cml := newConfigMapAnnotations(configMapNamespace, configMapName, c)
+	if err := cml.Init(); err != nil {
+		return nil, err
+	}
+	list, err := cml.GetPeerList()
+	if err != nil {
+		return nil, err
+	}
+	log.Println("Fetched existing peer list", list)
+	if !list.contains(peerName) {
+		list.add(peerName, name)
+		log.Println("Storing new peer list", list)
+		err = cml.UpdatePeerList(*list)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+// For each of those peers that is no longer listed as a node by
+// Kubernetes, remove it from Weave IPAM
+func reclaimRemovedPeers(apl *peerList, nodes []nodeInfo) error {
+	// TODO
+	return nil
+}
+
 func main() {
+	var (
+		justReclaim bool
+		peerName    string
+		nodeName    string
+	)
+	flag.BoolVar(&justReclaim, "reclaim", false, "reclaim IP space from dead peers")
+	flag.StringVar(&peerName, "peer-name", "unknown", "name of this Weave Net peer")
+	flag.StringVar(&nodeName, "node-name", "unknown", "name of this Kubernetes node")
+	flag.Parse()
+
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		log.Fatalf("Could not get cluster config: %v", err)
@@ -54,7 +105,19 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not get peers: %v", err)
 	}
-	for _, addr := range peers {
-		fmt.Println(addr)
+	if justReclaim {
+		log.Println("Checking if any peers need to be reclaimed")
+		list, err := addMyselfToPeerList(c, peerName, nodeName)
+		if err != nil {
+			log.Fatalf("Could not get peer list: %v", err)
+		}
+		err = reclaimRemovedPeers(list, peers)
+		if err != nil {
+			log.Fatalf("Error while reclaiming space: %v", err)
+		}
+		return
+	}
+	for _, node := range peers {
+		fmt.Println(node.addr)
 	}
 }

--- a/prog/kube-peers/main.go
+++ b/prog/kube-peers/main.go
@@ -81,6 +81,27 @@ func addMyselfToPeerList(c *kubernetes.Clientset, peerName, name string) (*peerL
 // Kubernetes, remove it from Weave IPAM
 func reclaimRemovedPeers(apl *peerList, nodes []nodeInfo) error {
 	// TODO
+	// Outline of function:
+	// 1. Compare peers stored in the peerList against all peers reported by k8s now.
+	// 2. Loop for each X in the first set and not in the second - we wish to remove X from our data structures
+	// 3. Check if there is an existing annotation with key X
+	// 4.   If annotation already contains my identity, ok;
+	// 5.   If non-existent, write an annotation with key X and contents "my identity"
+	// 6.   If step 4 or 5 succeeded, rmpeer X
+	// 7aa.   Remove any annotations Z* that have contents X
+	// 7a.    Remove X from peerList
+	// 7b.    Remove annotation with key X
+	// 8.   If step 5 failed due to optimistic lock conflict, stop: someone else is handling X
+	// 9. Go back to step 1 until there is no difference between the two sets
+
+	// Step 3-5 is to protect against two simultaneous rmpeers of X
+	// Step 4 is to pick up again after a restart between step 5 and step 7b
+	// If the peer doing the reclaim disappears between steps 5 and 7a, then someone will clean it up in step 7aa
+	// If peer doing the reclaim disappears forever between 7a and 7b then we get a dangling annotation
+	// This should be sufficiently rare that we don't care.
+
+	// Question: Should we narrow step 2 by checking against Weave Net IPAM?
+	// i.e. If peer X owns any address space and is marked unreachable, we want to rmpeer X
 	return nil
 }
 

--- a/prog/kube-peers/main.go
+++ b/prog/kube-peers/main.go
@@ -5,10 +5,14 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 
 	"k8s.io/client-go/kubernetes"
 	api "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
+
+	weaveapi "github.com/weaveworks/weave/api"
+	"github.com/weaveworks/weave/common"
 )
 
 type nodeInfo struct {
@@ -54,8 +58,7 @@ const (
 )
 
 // update the list of all peers that have gone through this code path
-func addMyselfToPeerList(c *kubernetes.Clientset, peerName, name string) (*peerList, error) {
-	cml := newConfigMapAnnotations(configMapNamespace, configMapName, c)
+func addMyselfToPeerList(cml *configMapAnnotations, c *kubernetes.Clientset, peerName, name string) (*peerList, error) {
 	var list *peerList
 	err := cml.LoopUpdate(func() error {
 		var err error
@@ -79,27 +82,78 @@ func addMyselfToPeerList(c *kubernetes.Clientset, peerName, name string) (*peerL
 
 // For each of those peers that is no longer listed as a node by
 // Kubernetes, remove it from Weave IPAM
-func reclaimRemovedPeers(apl *peerList, nodes []nodeInfo) error {
-	// TODO
-	// Outline of function:
-	// 1. Compare peers stored in the peerList against all peers reported by k8s now.
-	// 2. Loop for each X in the first set and not in the second - we wish to remove X from our data structures
-	// 3. Check if there is an existing annotation with key X
-	// 4.   If annotation already contains my identity, ok;
-	// 5.   If non-existent, write an annotation with key X and contents "my identity"
-	// 6.   If step 4 or 5 succeeded, rmpeer X
-	// 7aa.   Remove any annotations Z* that have contents X
-	// 7a.    Remove X from peerList
-	// 7b.    Remove annotation with key X
-	// 8.   If step 5 failed due to optimistic lock conflict, stop: someone else is handling X
-	// 9. Go back to step 1 until there is no difference between the two sets
+func reclaimRemovedPeers(weave *weaveapi.Client, cml *configMapAnnotations, nodes []nodeInfo, myPeerName string) error {
+	for {
+		// 1. Compare peers stored in the peerList against all peers reported by k8s now.
+		storedPeerList, err := cml.GetPeerList()
+		if err != nil {
+			return err
+		}
+		peerMap := make(map[string]peerInfo, len(storedPeerList.Peers))
+		for _, peer := range storedPeerList.Peers {
+			peerMap[peer.NodeName] = peer
+		}
+		for _, node := range nodes {
+			delete(peerMap, node.name)
+		}
+		log.Println("Nodes that have disappeared:", peerMap)
+		if len(peerMap) == 0 {
+			break
+		}
+		// 2. Loop for each X in the first set and not in the second - we wish to remove X from our data structures
+		for _, peer := range peerMap {
+			common.Log.Debugln("Preparing to remove disappeared peer", peer)
+			okToRemove := false
+			// 3. Check if there is an existing annotation with key X
+			if existingAnnotation, found := cml.cm.Annotations[peer.PeerName]; found {
+				common.Log.Debugln("Existing annotation", existingAnnotation)
+				// 4.   If annotation already contains my identity, ok;
+				if existingAnnotation == myPeerName {
+					okToRemove = true
+				}
+			} else {
+				// 5.   If non-existent, write an annotation with key X and contents "my identity"
+				common.Log.Debugln("Noting I plan to remove ", peer.PeerName)
+				if err := cml.UpdateAnnotation(peer.PeerName, myPeerName); err == nil {
+					okToRemove = true
+				}
+			}
+			if okToRemove {
+				// 6.   If step 4 or 5 succeeded, rmpeer X
+				result, err := weave.RmPeer(peer.PeerName)
+				if err != nil {
+					return err
+				}
+				log.Println("rmpeer of", peer.PeerName, ":", result)
+				cml.LoopUpdate(func() error {
+					// 7aa.   Remove any annotations Z* that have contents X
+					if err := cml.RemoveAnnotationsWithValue(peer.PeerName); err != nil {
+						return err
+					}
+					// 7a.    Remove X from peerList
+					storedPeerList.remove(peer.PeerName)
+					if err := cml.UpdatePeerList(*storedPeerList); err != nil {
+						return err
+					}
+					// 7b.    Remove annotation with key X
+					if err := cml.RemoveAnnotation(peer.PeerName); err != nil {
+						return err
+					}
+					return nil
+				})
+				common.Log.Debugln("Finished removal of ", peer.PeerName)
+			}
+			// 8.   If step 5 failed due to optimistic lock conflict, stop: someone else is handling X
 
-	// Step 3-5 is to protect against two simultaneous rmpeers of X
-	// Step 4 is to pick up again after a restart between step 5 and step 7b
-	// If the peer doing the reclaim disappears between steps 5 and 7a, then someone will clean it up in step 7aa
-	// If peer doing the reclaim disappears forever between 7a and 7b then we get a dangling annotation
-	// This should be sufficiently rare that we don't care.
+			// Step 3-5 is to protect against two simultaneous rmpeers of X
+			// Step 4 is to pick up again after a restart between step 5 and step 7b
+			// If the peer doing the reclaim disappears between steps 5 and 7a, then someone will clean it up in step 7aa
+			// If peer doing the reclaim disappears forever between 7a and 7b then we get a dangling annotation
+			// This should be sufficiently rare that we don't care.
+		}
 
+		// 9. Go back to step 1 until there is no difference between the two sets
+	}
 	// Question: Should we narrow step 2 by checking against Weave Net IPAM?
 	// i.e. If peer X owns any address space and is marked unreachable, we want to rmpeer X
 	return nil
@@ -129,12 +183,14 @@ func main() {
 		log.Fatalf("Could not get peers: %v", err)
 	}
 	if justReclaim {
-		log.Println("Checking if any peers need to be reclaimed")
-		list, err := addMyselfToPeerList(c, peerName, nodeName)
+		cml := newConfigMapAnnotations(configMapNamespace, configMapName, c)
+		common.Log.Infoln("Adding myself to peer list")
+		_, err := addMyselfToPeerList(cml, c, peerName, nodeName)
 		if err != nil {
 			log.Fatalf("Could not get peer list: %v", err)
 		}
-		err = reclaimRemovedPeers(list, peers)
+		weave := weaveapi.NewClient(os.Getenv("WEAVE_HTTP_ADDR"), common.Log)
+		err = reclaimRemovedPeers(weave, cml, peers, peerName)
 		if err != nil {
 			log.Fatalf("Error while reclaiming space: %v", err)
 		}

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -108,6 +108,8 @@ post_start_actions() {
     export HOST_ROOT
     /home/weave/weave --local setup-cni
 
+    /home/weave/kube-peers -reclaim -node-name="$HOSTNAME" -peer-name="$(cat /sys/class/net/weave/address)"
+
     # Expose the weave network so host processes can communicate with pods
     /home/weave/weave --local expose $WEAVE_EXPOSE_IP
 }

--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -47,6 +47,44 @@ items:
       - kind: ServiceAccount
         name: weave-net
         namespace: kube-system
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: Role
+    metadata:
+      name: weave-net2
+      namespace: kube-system
+      labels:
+        name: weave-net2
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - configmaps
+        resourceNames:
+          - weave-net
+        verbs:
+          - get
+          - update
+      - apiGroups:
+          - ''
+        resources:
+          - configmaps
+        verbs:
+          - create
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: RoleBinding
+    metadata:
+      name: weave-net2
+      namespace: kube-system
+      labels:
+        name: weave-net2
+    roleRef:
+      kind: Role
+      name: weave-net2
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
   - apiVersion: extensions/v1beta1
     kind: DaemonSet
     metadata:


### PR DESCRIPTION
Fixes #2797 

Using Kubernetes annotations as a way to ensure only one peer at a time runs `rmpeer`
