### PR TITLE
Update YAMLs to be what the Launch Generator serves.

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -109,8 +109,8 @@ items:
             seLinuxOptions: {}
           serviceAccountName: weave-net
           tolerations:
-            - operator: "Exists"
-              effect: NoSchedule
+            - effect: NoSchedule
+              operator: Exists
           volumes:
             - name: weavedb
               hostPath:
@@ -130,3 +130,5 @@ items:
             - name: lib-modules
               hostPath:
                 path: /lib/modules
+      updateStrategy:
+        type: RollingUpdate


### PR DESCRIPTION
See also:
- weaveworks/launch-generator/pull/130
- weaveworks/launch-generator/pull/125

Command used:
```
$ curl -fsSo prog/weave-kube/weave-daemonset-k8s-1.6.yaml "https://localhost:8080/k8s/v1.6/net?v=latest"
$ curl -fsSo prog/weave-kube/weave-daemonset.yaml "https://localhost:8080/k8s/v1.5/net?v=latest"
```
Annotations then removed.