### PR TITLE
Set the default namespace to weave-daemonset-k8s

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -45,7 +45,7 @@ items:
     subjects:
       - kind: ServiceAccount
         name: weave-net
-        namespace: kube-system
+        namespace: default
   - apiVersion: extensions/v1beta1
     kind: DaemonSet
     metadata:


### PR DESCRIPTION
Since the ``namespace: kube-system`` was removed in https://github.com/weaveworks/weave/commit/067ce6de9f3800e06369140a832c12f74dcefb90#diff-63ba20698025213b0dce5f67c19f76db  the current master fresh deployment will fail (Tried k8s 1.6.5 with RBAC):

```
kubectl logs pods/weave-net-x6gj4 -c weave
2017/06/23 08:12:14 error contacting APIServer: the server does not allow access to the requested resource (get nodes); trying with fallback: http://localhost:8080
2017/06/23 08:12:14 Could not get peers: Get http://localhost:8080/api/v1/nodes: dial tcp 127.0.0.1:8080: getsockopt: connection refused
Failed to get peers
```

The following resources should be under the same namespace for the RBAC to properly function:
- ServiceAccount
- ClusterRoleBinding
- DaemonSet

I am wondering whether the ``weave-net`` common namespace would be more suitable than the ``default``?

**Upd:** I have noticed that the same is valid for the ``https://cloud.weave.works/k8s/v1.6/scope.yaml?k8s-service-type=NodePort`` but could not find this file in https://github.com/weaveworks/scope repo...