### PR TITLE
Put kube-system namespace back in the weave-kube yaml

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -5,6 +5,7 @@ items:
     kind: ServiceAccount
     metadata:
       name: weave-net
+      namespace: kube-system
       labels:
         name: weave-net
   - apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -50,6 +51,7 @@ items:
     kind: DaemonSet
     metadata:
       name: weave-net
+      namespace: kube-system
       labels:
         name: weave-net
     spec:

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -5,12 +5,14 @@ items:
     kind: ServiceAccount
     metadata:
       name: weave-net
+      namespace: kube-system
       labels:
         name: weave-net
   - apiVersion: extensions/v1beta1
     kind: DaemonSet
     metadata:
       name: weave-net
+      namespace: kube-system
       labels:
         name: weave-net
     spec:


### PR DESCRIPTION
Save people getting in to trouble when they don't know to add `-n kube-system`