### PR TITLE
Fix fallback to pcap based bridge when odp is not supported

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -282,7 +282,7 @@ func main() {
 	name := peerName(routerName, bridgeConfig.WeaveBridgeName, dbPrefix, hostRoot)
 
 	bridgeConfig.Mac = name.String()
-	bridgeType, err := weavenet.EnsureBridge(procPath, &bridgeConfig)
+	bridgeType, err := weavenet.EnsureBridge(procPath, &bridgeConfig, Log)
 	checkFatal(err)
 	Log.Println("Bridge type is", bridgeType)
 

--- a/prog/weaveutil/bridge.go
+++ b/prog/weaveutil/bridge.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/weaveworks/weave/common"
 	weavenet "github.com/weaveworks/weave/net"
 )
 
@@ -47,7 +48,7 @@ func createBridge(args []string) error {
 		NPC:              args[9] == "--expect-npc",
 	}
 	procPath := args[8]
-	bridgeType, err := weavenet.EnsureBridge(procPath, &config)
+	bridgeType, err := weavenet.EnsureBridge(procPath, &config, common.Log)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The fix ensures that if odp is not supported (usually due to missing `openvswitch`, `vxlan` or `vport-vxlan` kernel modules), weaver will create the pcap based bridge instead of crashing.