### PR TITLE
net-plugin release: swap publish and plugin_publish

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -187,13 +187,13 @@ publish() {
     fi
 
     if [ "$RELEASE_TYPE" = 'PRERELEASE' ] ; then
-        echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
-        make UPDATE_LATEST=$IS_MAINLINE SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
-        echo "** Docker images tagged and pushed"
-
         echo "== Building and pushing plugin"
         make UPDATE_LATEST=$IS_MAINLINE SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER plugin_publish
         echo "** Plugin built and pushed"
+
+        echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
+        make UPDATE_LATEST=$IS_MAINLINE SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
+        echo "** Docker images tagged and pushed"
 
         echo "== Publishing pre-release on GitHub"
 
@@ -223,13 +223,13 @@ publish() {
         fi
         echo '** Sanity checks OK for publishing tag' $LATEST_TAG as $DOCKERHUB_USER/weave:$VERSION
 
-        echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
-        make PUBLISH_WEAVEDB=$IS_MAINLINE UPDATE_LATEST=$IS_MAINLINE SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
-        echo "** Docker images tagged and pushed"
-
         echo "== Building and pushing plugin"
         make UPDATE_LATEST=$IS_MAINLINE SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER plugin_publish
         echo "** Plugin built and pushed"
+
+        echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
+        make PUBLISH_WEAVEDB=$IS_MAINLINE UPDATE_LATEST=$IS_MAINLINE SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER publish
+        echo "** Docker images tagged and pushed"
 
         echo "== Publishing release on GitHub"
 


### PR DESCRIPTION
Currently our `Makefile` and `bin/release` scripts are such that we effectively do the following when releasing:
```
publish:
  for arch in [amd64 arm arm64]:
    sub-publish:
      clean_bin
      publish
plugin_publish
```
which leads the Docker v2 plugin to contain `arm64` binaries even though we target `amd64`.
Swaping `publish` and `plugin_publish` is a simple way to avoid this.