### PR TITLE
Make help instantaneous in the weave script

### DIFF
--- a/weave
+++ b/weave
@@ -222,9 +222,11 @@ kill_container() {
 
 [ "$1" = "--local" ] && shift 1 && IS_LOCAL=1
 
-# "--help|help" are special because we always want to process them
-# at the client end.
-handle_help_arg "$1" || handle_help_arg "--$1"
+# "--help|help" and "<command> --help" are special because we always want to
+# process them at the client end.
+handle_help_arg "$1"
+handle_help_arg "--$1"
+handle_help_arg "$2"
 
 if [ "$1" = "version" -a -z "$IS_LOCAL" ] ; then
     # non-local "version" is special because we want to show the
@@ -1342,8 +1344,6 @@ fi
 [ $# -gt 0 ] || usage
 COMMAND=$1
 shift 1
-
-handle_help_arg "$1"
 
 case "$COMMAND" in
     setup)


### PR DESCRIPTION
There are 3 ways to get help:

  • `weave --help`
  • `weave help`
  • `weave <command> --help`

At the moment, only the first one prints the usage instantaneously, the
others go much further in the script and take quite some time, which is
not idea of impatient users.

Note that "help" only works because it's not a recognized command and
ends up in the default case of "case $COMMAND" (and indeed, "Unknown
weave command 'help'" is displayed). This is because handle_help_arg()
always returns true and so the second part of:

  handle_help_arg "$1" || handle_help_arg "--$1"

is never evaluated.

This commit changes things a bit so all 3 ways to get help are
recognized early, print the usage and exit.