### PR TITLE
Add comments to iptables rules and ipsets

### DIFF
--- a/npc/controller.go
+++ b/npc/controller.go
@@ -54,7 +54,7 @@ func (npc *controller) onNewNsSelector(selector *selector) error {
 	for _, ns := range npc.nss {
 		if ns.namespace != nil {
 			if selector.matches(ns.namespace.ObjectMeta.Labels) {
-				if err := ns.ips.AddEntry(selector.spec.ipsetName, string(ns.allPods.ipsetName)); err != nil {
+				if err := selector.addEntry(string(ns.allPods.ipsetName), namespaceComment(ns)); err != nil {
 					return err
 				}
 			}

--- a/npc/controller_test.go
+++ b/npc/controller_test.go
@@ -39,7 +39,7 @@ func (i *mockIPSet) Create(ipsetName ipset.Name, ipsetType ipset.Type) error {
 	return nil
 }
 
-func (i *mockIPSet) AddEntry(ipsetName ipset.Name, entry string) error {
+func (i *mockIPSet) AddEntry(ipsetName ipset.Name, entry string, comment string) error {
 	log.Printf("adding entry %s to %s", entry, ipsetName)
 	if _, ok := i.sets[entry]; !ok {
 		return errors.Errorf("ipset %s does not exist", entry)

--- a/npc/ipset/ipset.go
+++ b/npc/ipset/ipset.go
@@ -19,7 +19,7 @@ const (
 
 type Interface interface {
 	Create(ipsetName Name, ipsetType Type) error
-	AddEntry(ipsetName Name, entry string) error
+	AddEntry(ipsetName Name, entry string, comment string) error
 	DelEntry(ipsetName Name, entry string) error
 	Flush(ipsetName Name) error
 	Destroy(ipsetName Name) error
@@ -40,15 +40,15 @@ func New(logger *log.Logger) Interface {
 }
 
 func (i *ipset) Create(ipsetName Name, ipsetType Type) error {
-	return doExec("create", string(ipsetName), string(ipsetType))
+	return doExec("create", string(ipsetName), string(ipsetType), "comment")
 }
 
-func (i *ipset) AddEntry(ipsetName Name, entry string) error {
+func (i *ipset) AddEntry(ipsetName Name, entry string, comment string) error {
 	i.Logger.Printf("adding entry %s to %s", entry, ipsetName)
 	if i.inc(ipsetName, entry) > 1 { // already in the set
 		return nil
 	}
-	return doExec("add", string(ipsetName), entry)
+	return doExec("add", string(ipsetName), entry, "comment", comment)
 }
 
 func (i *ipset) DelEntry(ipsetName Name, entry string) error {

--- a/npc/rule.go
+++ b/npc/rule.go
@@ -1,6 +1,7 @@
 package npc
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/client-go/pkg/types"
@@ -29,6 +30,13 @@ func newRuleSpec(proto *string, srcHost *selectorSpec, dstHost *selectorSpec, ds
 		args = append(args, "--dport", *dstPort)
 	}
 	args = append(args, "-j", "ACCEPT")
+	srcComment := ""
+	if srcHost.nsName != "" {
+		srcComment = fmt.Sprintf("pods: namespace: %s, selector: %s", srcHost.nsName, srcHost.key)
+	} else {
+		srcComment = fmt.Sprintf("namespaces: selector: %s", srcHost.key)
+	}
+	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("%s -> namespace: %s, key: %s", srcComment, dstHost.nsName, dstHost.key))
 	key := strings.Join(args, " ")
 
 	return &ruleSpec{key, args}


### PR DESCRIPTION
Fixes #2621 

This is based off of #3057, as I need to update the tests to match the new signature.

Example output:
```
root@hotcpc17686:~# iptables-save | grep WEAVE-NPC
:WEAVE-NPC - [0:0]
:WEAVE-NPC-DEFAULT - [0:0]
:WEAVE-NPC-INGRESS - [0:0]
-A FORWARD -o weave -j WEAVE-NPC
-A WEAVE-NPC -m state --state RELATED,ESTABLISHED -j ACCEPT
-A WEAVE-NPC -d 224.0.0.0/4 -j ACCEPT
-A WEAVE-NPC -m state --state NEW -j WEAVE-NPC-DEFAULT
-A WEAVE-NPC -m state --state NEW -j WEAVE-NPC-INGRESS
-A WEAVE-NPC -m set ! --match-set weave-local-pods dst -j ACCEPT
-A WEAVE-NPC-DEFAULT -m set --match-set weave-k?Z;25^M}|1s7P3|H9i;*;MhG dst -m comment --comment "DefaultAllow isolation for namespace: default" -j ACCEPT
-A WEAVE-NPC-DEFAULT -m set --match-set weave-iuZcey(5DeXbzgRFs8Szo]+@p dst -m comment --comment "DefaultAllow isolation for namespace: kube-system" -j ACCEPT
-A WEAVE-NPC-DEFAULT -m set --match-set weave-4vtqMI+kx/2]jD%_c0S%thO%V dst -m comment --comment "DefaultAllow isolation for namespace: kube-public" -j ACCEPT
-A WEAVE-NPC-INGRESS -p tcp -m set --match-set weave-%:FTKw;6Z~kKUkeo5F)k8K+kI src -m set --match-set weave-2ZiDW)3]+I}!oR#ru=*KAc{x1 dst -m tcp --dport 6379 -m comment --comment "namespaces: selector: project=myproject -> namespace: default, key: role=db" -j ACCEPT
-A WEAVE-NPC-INGRESS -p tcp -m set --match-set weave-UbymzRD2/QjeNF/Kib4(cV*{P src -m set --match-set weave-2ZiDW)3]+I}!oR#ru=*KAc{x1 dst -m tcp --dport 6379 -m comment --comment "pods: namespace: default, selector: role=frontend -> namespace: default, key: role=db" -j ACCEPT


root@hotcpc17686:~# ipset list
Name: weave-local-pods
Type: hash:ip
Revision: 4
Header: family inet hashsize 1024 maxelem 65536 comment
Size in memory: 224
References: 1
Members:
10.32.0.2 comment "namespace: kube-system, pod: kube-dns-2425271678-d9dms"

Name: weave-k?Z;25^M}|1s7P3|H9i;*;MhG
Type: hash:ip
Revision: 4
Header: family inet hashsize 1024 maxelem 65536 comment
Size in memory: 128
References: 1
Members:

Name: weave-iuZcey(5DeXbzgRFs8Szo]+@p
Type: hash:ip
Revision: 4
Header: family inet hashsize 1024 maxelem 65536 comment
Size in memory: 224
References: 2
Members:
10.32.0.2 comment "namespace: kube-system, pod: kube-dns-2425271678-d9dms"

Name: weave-4vtqMI+kx/2]jD%_c0S%thO%V
Type: hash:ip
Revision: 4
Header: family inet hashsize 1024 maxelem 65536 comment
Size in memory: 128
References: 1
Members:

Name: weave-2ZiDW)3]+I}!oR#ru=*KAc{x1
Type: hash:ip
Revision: 4
Header: family inet hashsize 1024 maxelem 65536 comment
Size in memory: 128
References: 2
Members:

Name: weave-UbymzRD2/QjeNF/Kib4(cV*{P
Type: hash:ip
Revision: 4
Header: family inet hashsize 1024 maxelem 65536 comment
Size in memory: 128
References: 1
Members:

Name: weave-%:FTKw;6Z~kKUkeo5F)k8K+kI
Type: list:set
Revision: 3
Header: size 8 comment
Size in memory: 160
References: 1
Members:
weave-iuZcey(5DeXbzgRFs8Szo]+@p comment "namespace: kube-system"


```