### PR TITLE
Remove localhost:8080 fallback for Kubernetes api-server

### DIFF
--- a/prog/kube-peers/main.go
+++ b/prog/kube-peers/main.go
@@ -21,17 +21,6 @@ func getKubePeers() ([]string, error) {
 	}
 	nodeList, err := c.Nodes().List(api.ListOptions{})
 	if err != nil {
-		// Fallback for cases (e.g. from kube-up.sh) where kube-proxy is not running on master
-		config.Host = "http://localhost:8080"
-		log.Print("error contacting APIServer: ", err, "; trying with fallback: ", config.Host)
-		c, err = kubernetes.NewForConfig(config)
-		if err != nil {
-			return nil, err
-		}
-		nodeList, err = c.Nodes().List(api.ListOptions{})
-	}
-
-	if err != nil {
 		return nil, err
 	}
 	addresses := make([]string, 0, len(nodeList.Items))


### PR DESCRIPTION
It was a hack for a badly-configured Kubernetes install: it shouldn't be necessary, it will only work on an unsecured install, and it generates confusing error messages when something is really wrong.