### PR TITLE
net-plugin: bind mount /lib/modules

### DIFF
--- a/prog/net-plugin/config.json
+++ b/prog/net-plugin/config.json
@@ -13,7 +13,8 @@
   "linux": {
     "capabilities": [
       "CAP_SYS_ADMIN",
-      "CAP_NET_ADMIN"
+      "CAP_NET_ADMIN",
+      "CAP_SYS_MODULE"
     ]
   },
   "mounts": [
@@ -38,6 +39,12 @@
     {
       "destination": "/host/etc/",
       "source": "/etc/",
+      "type": "bind",
+      "options": ["rbind"]
+    },
+    {
+      "destination": "/lib/modules/",
+      "source": "/lib/modules/",
       "type": "bind",
       "options": ["rbind"]
     }


### PR DESCRIPTION
Otherwise, the plugin is not able to load kernel modules (openvswitch, vxlan, vport_vxlan) required by fastdp which makes weave to fallback to sleeve if the required modules are not loaded a priori.

`CAP_SYS_MODULE` is required in order to load kernel modules.