### PR TITLE
Improve flag handling

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -210,7 +210,7 @@ func main() {
 	mflag.StringVar(&pluginConfig.Socket, []string{"-plugin-socket"}, "/run/docker/plugins/weave.sock", "plugin socket on which to listen")
 	mflag.StringVar(&pluginConfig.MeshSocket, []string{"-plugin-mesh-socket"}, "/run/docker/plugins/weavemesh.sock", "plugin socket on which to listen in mesh mode")
 
-	proxyConfig := configureProxy(version, defaultDockerHost)
+	proxyConfig := newProxyConfig(version, defaultDockerHost)
 	if bridgeConfig.AWSVPC {
 		proxyConfig.NoMulticastRoute = true
 		proxyConfig.KeepTXOn = true
@@ -525,7 +525,7 @@ func (nopPacketLogging) LogPacket(string, weave.PacketKey) {
 func (nopPacketLogging) LogForwardPacket(string, weave.ForwardPacketKey) {
 }
 
-func configureProxy(version string, defaultDockerHost string) *weaveproxy.Config {
+func newProxyConfig(version string, defaultDockerHost string) *weaveproxy.Config {
 	proxyConfig := weaveproxy.Config{
 		Version:      version,
 		Image:        getenvOrDefault("EXEC_IMAGE", "weaveworks/weaveexec"),

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -210,7 +210,7 @@ func main() {
 	mflag.StringVar(&pluginConfig.Socket, []string{"-plugin-socket"}, "/run/docker/plugins/weave.sock", "plugin socket on which to listen")
 	mflag.StringVar(&pluginConfig.MeshSocket, []string{"-plugin-mesh-socket"}, "/run/docker/plugins/weavemesh.sock", "plugin socket on which to listen in mesh mode")
 
-	proxyConfig := newProxyConfig(version, defaultDockerHost)
+	proxyConfig := newProxyConfig(defaultDockerHost)
 
 	// crude way of detecting that we probably have been started in a
 	// container, with `weave launch` --> suppress misleading paths in
@@ -526,9 +526,8 @@ func (nopPacketLogging) LogPacket(string, weave.PacketKey) {
 func (nopPacketLogging) LogForwardPacket(string, weave.ForwardPacketKey) {
 }
 
-func newProxyConfig(version string, defaultDockerHost string) *weaveproxy.Config {
+func newProxyConfig(defaultDockerHost string) *weaveproxy.Config {
 	proxyConfig := weaveproxy.Config{
-		Version:      version,
 		Image:        getenvOrDefault("EXEC_IMAGE", "weaveworks/weaveexec"),
 		DockerBridge: getenvOrDefault("DOCKER_BRIDGE", "docker0"),
 		DockerHost:   defaultDockerHost,

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -210,7 +210,7 @@ func main() {
 	mflag.StringVar(&pluginConfig.Socket, []string{"-plugin-socket"}, "/run/docker/plugins/weave.sock", "plugin socket on which to listen")
 	mflag.StringVar(&pluginConfig.MeshSocket, []string{"-plugin-mesh-socket"}, "/run/docker/plugins/weavemesh.sock", "plugin socket on which to listen in mesh mode")
 
-	proxyConfig := newProxyConfig(defaultDockerHost)
+	proxyConfig := newProxyConfig()
 
 	// crude way of detecting that we probably have been started in a
 	// container, with `weave launch` --> suppress misleading paths in
@@ -227,6 +227,7 @@ func main() {
 		os.Exit(0)
 	}
 
+	proxyConfig.DockerHost = dockerAPI
 	if bridgeConfig.AWSVPC {
 		proxyConfig.NoMulticastRoute = true
 		proxyConfig.KeepTXOn = true
@@ -526,11 +527,10 @@ func (nopPacketLogging) LogPacket(string, weave.PacketKey) {
 func (nopPacketLogging) LogForwardPacket(string, weave.ForwardPacketKey) {
 }
 
-func newProxyConfig(defaultDockerHost string) *weaveproxy.Config {
+func newProxyConfig() *weaveproxy.Config {
 	proxyConfig := weaveproxy.Config{
 		Image:        getenvOrDefault("EXEC_IMAGE", "weaveworks/weaveexec"),
 		DockerBridge: getenvOrDefault("DOCKER_BRIDGE", "docker0"),
-		DockerHost:   defaultDockerHost,
 	}
 	mflag.BoolVar(&proxyConfig.Enabled, []string{"-proxy"}, false, "instruct Weave Net to start its Docker proxy")
 	mflagext.ListVar(&proxyConfig.ListenAddrs, []string{"H"}, nil, "addresses on which to listen for Docker proxy")

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -211,10 +211,6 @@ func main() {
 	mflag.StringVar(&pluginConfig.MeshSocket, []string{"-plugin-mesh-socket"}, "/run/docker/plugins/weavemesh.sock", "plugin socket on which to listen in mesh mode")
 
 	proxyConfig := newProxyConfig(version, defaultDockerHost)
-	if bridgeConfig.AWSVPC {
-		proxyConfig.NoMulticastRoute = true
-		proxyConfig.KeepTXOn = true
-	}
 
 	// crude way of detecting that we probably have been started in a
 	// container, with `weave launch` --> suppress misleading paths in
@@ -229,6 +225,11 @@ func main() {
 	if justVersion {
 		fmt.Printf("weave %s\n", version)
 		os.Exit(0)
+	}
+
+	if bridgeConfig.AWSVPC {
+		proxyConfig.NoMulticastRoute = true
+		proxyConfig.KeepTXOn = true
 	}
 
 	peers = mflag.Args()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -60,7 +60,6 @@ type Config struct {
 	NoDefaultIPAM       bool
 	NoRewriteHosts      bool
 	TLSConfig           TLSConfig
-	Version             string
 	WithoutDNS          bool
 	NoMulticastRoute    bool
 	KeepTXOn            bool


### PR DESCRIPTION
Fixing a few things I noticed in passing: principally that we were using some values from command-line parameters before calling `mflag.Parse()`.  But only in AWSVPC mode which nobody seems to use.

Also, if `--docker-api` is supplied, use that for the proxy instead of the default setting.