### PR TITLE
prometheus: export count of unreachable peers

### DIFF
--- a/prog/weaver/metrics.go
+++ b/prog/weaver/metrics.go
@@ -82,6 +82,18 @@ var metrics = []metric{
 				ch <- intGauge(desc, metrics.Flows)
 			}
 		}},
+	{desc("weave_ipam_unreachable_count", "Number of unreachable peers."),
+		func(s WeaveStatus, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
+			if s.IPAM != nil {
+				var count int64
+				for _, entry := range s.IPAM {
+					if !entry.IsKnownPeer {
+						count++
+					}
+				}
+				ch <- intGauge(desc, count)
+			}
+		}},
 	{desc("weave_ipam_pending_allocates", "Number of pending allocates."),
 		func(s WeaveStatus, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
 			if s.IPAM != nil {


### PR DESCRIPTION
it should help monitoring for https://github.com/weaveworks/weave/issues/2797