### PR TITLE
Fix builds on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ coverage.html
 # Vim backup files
 *.swp
 
+# Sed backup files
+*.bak
+
 # Project specific
 prog/weaver/weaver
 prog/weavedns/weavedns

--- a/Makefile
+++ b/Makefile
@@ -241,13 +241,13 @@ $(BUILD_UPTODATE): build/*
 	sed -e "s|DOCKERHUB_USER|$(DOCKERHUB_USER)|g;s|ARCH_EXT|$(ARCH_EXT)|g;s|ALPINE_BASEIMAGE|$(ALPINE_BASEIMAGE)|g;s|QEMUARCH|$(QEMUARCH)|g" $^ > $@
 ifeq ($(ARCH),amd64)
 # When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
-	sed -i "/CROSS_BUILD_/d" $@
+	sed -i.bak "/CROSS_BUILD_/d" $@
 else
 # When cross-building, only the placeholder "CROSS_BUILD_" should be removed
 # Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMU_VERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(shell dirname $@)
 	cd $(shell dirname $@) && sha256sum -c $(shell pwd)/build/shasums/qemu-$(QEMUARCH)-static.sha256sum
-	sed -i "s/CROSS_BUILD_//g" $@
+	sed -i.bak "s/CROSS_BUILD_//g" $@
 endif
 
 # The targets below builds the weave images

--- a/bin/release
+++ b/bin/release
@@ -88,9 +88,9 @@ build() {
 
     ## Inject the version numbers and build the distributables
     ## (library versions?)
-    sed -i "/SCRIPT_VERSION=/ c\SCRIPT_VERSION=\"$VERSION\"" ./weave
-    sed -i -e "s/:latest/:$VERSION/" -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset.yaml
-    sed -i -e "s/:latest/:$VERSION/" -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+    sed -i.bak "/SCRIPT_VERSION=/ c\SCRIPT_VERSION=\"$VERSION\"" ./weave
+    sed -i.bak -e "s/:latest/:$VERSION/" -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset.yaml
+    sed -i.bak -e "s/:latest/:$VERSION/" -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset-k8s-1.6.yaml
     make SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER
 
     if make tests; then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       host.vm.provision :shell, :inline => <<END
 # Tests rely on hostnames, so we remove potentially incorrect entries (e.g. localhost), and add mappings of IP addresses to hostnames:
-sed -i '/#{hostname}/d' /etc/hosts
+sed -i.bak '/#{hostname}/d' /etc/hosts
 echo "#{ETC_HOSTS_ENTRIES}" >> /etc/hosts
 
 # Fix the resolution errors by using 8.8.8.8

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -175,7 +175,7 @@ function use_or_create_image() {
 function update_local_etc_hosts() {
     echo "> Updating local /etc/hosts..."
     # Remove old entries (if present):
-    for host in $1; do sudo sed -i "/$host/d" /etc/hosts; done
+    for host in $1; do sudo sed -i.bak "/$host/d" /etc/hosts; done
     # Add new entries:
     sudo sh -c "echo \"$2\" >> /etc/hosts"
 }
@@ -183,7 +183,7 @@ function update_local_etc_hosts() {
 function upload_etc_hosts() {
     # Remove old entries (if present):
     # shellcheck disable=SC2016,SC2086
-    $SSH $3 'for host in '$1'; do sudo sed -i "/$host/d" /etc/hosts; done'
+    $SSH $3 'for host in '$1'; do sudo sed -i.bak "/$host/d" /etc/hosts; done'
     # Add new entries:
     echo "$2" | $SSH "$3" "sudo -- sh -c \"cat >> /etc/hosts\""
 }


### PR DESCRIPTION
Due to differences in the GNU `sed` and BSD `sed`, the builds were broken on OSX. 

It's a small and simple fix: we tell sed an extension for backup files when carrying our in-place operations, and ignore the backup files in the `.gitignore`

Tested on Alpine Linux and OSX.