### PR TITLE
 Remove explicit error check at end of functions to placate lint

### DIFF
--- a/net/arp.go
+++ b/net/arp.go
@@ -17,10 +17,7 @@ func ConfigureARPCache(procPath, name string) error {
 	if err := sysctl(procPath, fmt.Sprintf("net/ipv4/neigh/%s/delay_first_probe_time", name), "2"); err != nil {
 		return err
 	}
-	if err := sysctl(procPath, fmt.Sprintf("net/ipv4/neigh/%s/ucast_solicit", name), "1"); err != nil {
-		return err
-	}
-	return nil
+	return sysctl(procPath, fmt.Sprintf("net/ipv4/neigh/%s/ucast_solicit", name), "1")
 }
 
 func sysctl(procPath, variable, value string) error {

--- a/net/bridge.go
+++ b/net/bridge.go
@@ -383,11 +383,7 @@ func (bf bridgedFastdpImpl) init(config *BridgeConfig) error {
 		return errors.Wrap(err, "creating bridged fastdp veth pair")
 	}
 
-	if err := linkSetUpByName(bf.datapathName); err != nil {
-		return err
-	}
-
-	return nil
+	return linkSetUpByName(bf.datapathName)
 }
 
 func (b bridgeImpl) attach(veth *netlink.Veth) error {
@@ -473,11 +469,7 @@ func configureIPTables(config *BridgeConfig) error {
 	if err = ipt.ClearChain("nat", "WEAVE"); err != nil {
 		return errors.Wrap(err, "clearing WEAVE chain")
 	}
-	if err = ipt.AppendUnique("nat", "POSTROUTING", "-j", "WEAVE"); err != nil {
-		return err
-	}
-
-	return nil
+	return ipt.AppendUnique("nat", "POSTROUTING", "-j", "WEAVE")
 }
 
 func linkSetUpByName(linkName string) error {

--- a/net/ipsec/ipsec.go
+++ b/net/ipsec/ipsec.go
@@ -421,10 +421,7 @@ func (ipsec *IPSec) installDropNonEncrypted(srcIP, dstIP net.IP, udpPort int, in
 
 func (ipsec *IPSec) removeDropNonEncrypted(srcIP, dstIP net.IP, udpPort int, inSPI SPI) error {
 	rules := rulesDropNonEncrypted(srcIP, dstIP, udpPort, inSPI)
-	if err := ipsec.resetRules(rules, true); err != nil {
-		return err
-	}
-	return nil
+	return ipsec.resetRules(rules, true)
 }
 
 func (ipsec *IPSec) removeDropNonEncryptedInbound(srcIP, dstIP net.IP, inSPI SPI) error {

--- a/net/veth.go
+++ b/net/veth.go
@@ -218,11 +218,7 @@ func SetupIface(ifaceName, newIfName string) error {
 	if err := ConfigureARPCache("/proc", newIfName); err != nil {
 		return err
 	}
-	if err := ipt.Append("filter", "INPUT", "-i", newIfName, "-d", "224.0.0.0/4", "-j", "DROP"); err != nil {
-		return err
-	}
-
-	return nil
+	return ipt.Append("filter", "INPUT", "-i", newIfName, "-d", "224.0.0.0/4", "-j", "DROP")
 }
 
 // NB: This function can be used only by a process that terminates immediately
@@ -332,8 +328,5 @@ func ExposeNAT(ipnet net.IPNet) error {
 	if err := addNatRule(ipt, "-d", cidr, "!", "-s", cidr, "-j", "MASQUERADE"); err != nil {
 		return err
 	}
-	if err := addNatRule(ipt, "-s", cidr, "!", "-d", cidr, "-j", "MASQUERADE"); err != nil {
-		return err
-	}
-	return nil
+	return addNatRule(ipt, "-s", cidr, "!", "-d", cidr, "-j", "MASQUERADE")
 }

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -65,10 +65,7 @@ func (ns *ns) empty() bool {
 }
 
 func (ns *ns) destroy() error {
-	if err := ns.podSelectors.deprovision(ns.uid, map[string]*selectorSpec{ns.allPods.key: ns.allPods}, nil); err != nil {
-		return err
-	}
-	return nil
+	return ns.podSelectors.deprovision(ns.uid, map[string]*selectorSpec{ns.allPods.key: ns.allPods}, nil)
 }
 
 func (ns *ns) onNewPodSelector(selector *selector) error {
@@ -180,11 +177,7 @@ func (ns *ns) addNetworkPolicy(obj *extnapi.NetworkPolicy) error {
 	if err := ns.podSelectors.provision(obj.ObjectMeta.UID, nil, podSelectors); err != nil {
 		return err
 	}
-	if err := ns.rules.provision(obj.ObjectMeta.UID, nil, rules); err != nil {
-		return err
-	}
-
-	return nil
+	return ns.rules.provision(obj.ObjectMeta.UID, nil, rules)
 }
 
 func (ns *ns) updateNetworkPolicy(oldObj, newObj *extnapi.NetworkPolicy) error {
@@ -217,11 +210,7 @@ func (ns *ns) updateNetworkPolicy(oldObj, newObj *extnapi.NetworkPolicy) error {
 	if err := ns.podSelectors.provision(oldObj.ObjectMeta.UID, oldPodSelectors, newPodSelectors); err != nil {
 		return err
 	}
-	if err := ns.rules.provision(oldObj.ObjectMeta.UID, oldRules, newRules); err != nil {
-		return err
-	}
-
-	return nil
+	return ns.rules.provision(oldObj.ObjectMeta.UID, oldRules, newRules)
 }
 
 func (ns *ns) deleteNetworkPolicy(obj *extnapi.NetworkPolicy) error {
@@ -240,11 +229,7 @@ func (ns *ns) deleteNetworkPolicy(obj *extnapi.NetworkPolicy) error {
 	if err := ns.nsSelectors.deprovision(obj.ObjectMeta.UID, nsSelectors, nil); err != nil {
 		return err
 	}
-	if err := ns.podSelectors.deprovision(obj.ObjectMeta.UID, podSelectors, nil); err != nil {
-		return err
-	}
-
-	return nil
+	return ns.podSelectors.deprovision(obj.ObjectMeta.UID, podSelectors, nil)
 }
 
 func bypassRule(nsIpsetName ipset.Name, namespace string) []string {

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -50,11 +50,7 @@ func resetIPTables(ipt *iptables.IPTables) error {
 		return err
 	}
 
-	if err := ipt.ClearChain(npc.TableFilter, npc.MainChain); err != nil {
-		return err
-	}
-
-	return nil
+	return ipt.ClearChain(npc.TableFilter, npc.MainChain)
 }
 
 func resetIPSets(ips ipset.Interface) error {
@@ -116,12 +112,8 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 	if err := ips.Create(npc.LocalIpset, ipset.HashIP); err != nil {
 		return err
 	}
-	if err := ipt.Append(npc.TableFilter, npc.MainChain,
-		"-m", "set", "!", "--match-set", npc.LocalIpset, "dst", "-j", "ACCEPT"); err != nil {
-		return err
-	}
-
-	return nil
+	return ipt.Append(npc.TableFilter, npc.MainChain,
+		"-m", "set", "!", "--match-set", npc.LocalIpset, "dst", "-j", "ACCEPT")
 }
 
 func root(cmd *cobra.Command, args []string) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -330,11 +330,7 @@ func copyOwnerAndPermissions(from, to string) error {
 		return nil
 	}
 
-	if err = os.Chown(to, int(moreStat.Uid), int(moreStat.Gid)); err != nil {
-		return err
-	}
-
-	return nil
+	return os.Chown(to, int(moreStat.Uid), int(moreStat.Gid))
 }
 
 func (proxy *Proxy) listen(protoAndAddr string) (net.Listener, string, error) {


### PR DESCRIPTION
It's sad because this changes a regular pattern into an irregular one, which will create spurious diffs if more work is added at the end of the function.  Still, this is easier than fixing the lint runner to ignore the report.

And it's nice to have a PR that makes the code smaller.