### PR TITLE
Add back EXEC_IMAGE so proxy can docker-run itself

### DIFF
--- a/proxy/hosts.go
+++ b/proxy/hosts.go
@@ -20,8 +20,7 @@ func (proxy *Proxy) RewriteEtcHosts(hostsPath, fqdn string, ips []*net.IPNet, ex
 	contents := buf.String()
 	cmdLine := fmt.Sprintf("echo '%s' > %s && rm -f %s && echo '%s' > %s", contents, mntHosts, mntHosts, contents, mntHosts)
 	mounts := []string{hostsPathDir + ":" + mnt}
-	proxy.runTransientContainer([]string{"sh"}, []string{"-c", cmdLine}, mounts)
-	return nil
+	return proxy.runTransientContainer([]string{"sh"}, []string{"-c", cmdLine}, mounts)
 }
 
 // we assume (for compatibility with the weave script) that fqdn has a dot

--- a/weave
+++ b/weave
@@ -1278,6 +1278,7 @@ launch() {
         -e WEAVE_DEBUG \
         -e WEAVE_HTTP_ADDR \
         -e WEAVE_PASSWORD \
+        -e EXEC_IMAGE=$EXEC_IMAGE \
         -e CHECKPOINT_DISABLE \
         $WEAVE_DOCKER_ARGS \
         $IMAGE \


### PR DESCRIPTION
Fixes #3136 

Also add error reporting so it's easier to figure out next time something breaks.

Was broken in #2947 