### PR TITLE
Rearrange peer reclaim checks in weave-kube launch script

### DIFF
--- a/prog/kube-peers/main.go
+++ b/prog/kube-peers/main.go
@@ -79,7 +79,6 @@ func addMyselfToPeerList(cml *configMapAnnotations, c *kubernetes.Clientset, pee
 		}
 		return nil
 	})
-	common.Log.Infoln("[kube-peers] Added myself to peer list", list)
 	return list, err
 }
 
@@ -216,10 +215,11 @@ func main() {
 	if justReclaim {
 		cml := newConfigMapAnnotations(configMapNamespace, configMapName, c)
 
-		_, err := addMyselfToPeerList(cml, c, peerName, nodeName)
+		list, err := addMyselfToPeerList(cml, c, peerName, nodeName)
 		if err != nil {
 			common.Log.Fatalf("[kube-peers] Could not update peer list: %v", err)
 		}
+		common.Log.Infoln("[kube-peers] Added myself to peer list", list)
 
 		weave := weaveapi.NewClient(os.Getenv("WEAVE_HTTP_ADDR"), common.Log)
 		err = reclaimRemovedPeers(weave, cml, peers, peerName)


### PR DESCRIPTION
If the persistence file doesn't exist (and it doesn't on first install), there's no point doing all the other checks to see if we should delete it.

And I was worried about what would happen if a user installs the new image with the old manifest, without adding the additional annotation permissions;  added `|| true` to make sure we continue past the `kube-peers reclaim` on error.  

Also, in that error case, it would report `Added myself to peer list <nil>`, so I fixed that too.
