### PR TITLE
npc: Track ipset entries per user and refcount default-allow ipsets

### DIFF
--- a/npc/controller.go
+++ b/npc/controller.go
@@ -59,7 +59,7 @@ func (npc *controller) onNewNsSelector(selector *selector) error {
 	for _, ns := range npc.nss {
 		if ns.namespace != nil {
 			if selector.matches(ns.namespace.ObjectMeta.Labels) {
-				if err := selector.addEntry(string(ns.allPods.ipsetName), namespaceComment(ns)); err != nil {
+				if err := selector.addEntry(ns.namespace.ObjectMeta.UID, string(ns.allPods.ipsetName), namespaceComment(ns)); err != nil {
 					return err
 				}
 			}

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -46,12 +46,12 @@ func (s *selector) matches(labelMap map[string]string) bool {
 	return s.spec.selector.Matches(labels.Set(labelMap))
 }
 
-func (s *selector) addEntry(entry string, comment string) error {
-	return s.ips.AddEntry(s.spec.ipsetName, entry, comment)
+func (s *selector) addEntry(user types.UID, entry string, comment string) error {
+	return s.ips.AddEntry(user, s.spec.ipsetName, entry, comment)
 }
 
-func (s *selector) delEntry(entry string) error {
-	return s.ips.DelEntry(s.spec.ipsetName, entry)
+func (s *selector) delEntry(user types.UID, entry string) error {
+	return s.ips.DelEntry(user, s.spec.ipsetName, entry)
 }
 
 type selectorFn func(selector *selector) error
@@ -85,14 +85,14 @@ func newSelectorSet(ips ipset.Interface, onNewSelector, onNewDstSelector selecto
 		dstSelectorsCount:    make(map[string]int)}
 }
 
-func (ss *selectorSet) addToMatching(labelMap map[string]string, entry string, comment string) (bool, error) {
+func (ss *selectorSet) addToMatching(user types.UID, labelMap map[string]string, entry string, comment string) (bool, error) {
 	found := false
 	for _, s := range ss.entries {
 		if s.matches(labelMap) {
 			if ss.dstSelectorExist(s) {
 				found = true
 			}
-			if err := s.addEntry(entry, comment); err != nil {
+			if err := s.addEntry(user, entry, comment); err != nil {
 				return found, err
 			}
 		}
@@ -100,10 +100,10 @@ func (ss *selectorSet) addToMatching(labelMap map[string]string, entry string, c
 	return found, nil
 }
 
-func (ss *selectorSet) delFromMatching(labelMap map[string]string, entry string) error {
+func (ss *selectorSet) delFromMatching(user types.UID, labelMap map[string]string, entry string) error {
 	for _, s := range ss.entries {
 		if s.matches(labelMap) {
-			if err := s.delEntry(entry); err != nil {
+			if err := s.delEntry(user, entry); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
There was a bug in handling `default-allow` ipsets - it could not cope with out of order receive of Pod updates. E.g:

1) `AddPod(Pod_A, PodIP_A)`,
2) `AddPod(Pod_B, PodIP_A)`,
3) `DeletePod(Pod_A)`,

would result with `PodIP_A` being removed from `default-allow` ipset, as such ipset entries were not refcounted. Bypassing of refcounting was due to the fact that adding a netpol which dst-selects a Pod which IP addr is in `default-allow` ipset has to remove the IP addr from the ipset regardless of refcount value of the IP addr entry in the ipset. So, refcounting in such case didn't make sense and it was bypassed.

This commit changes the way entries are refcounted in ipsets, and it makes `default-allow` ipset the same citizen as other ipsets, so from now `default-allow` ipset is refcounted.

Fix #3177