### PR TITLE
Put a more sane log-level as default for weave-npc

### DIFF
--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -241,7 +241,7 @@ func main() {
 		Run:   root}
 
 	rootCmd.PersistentFlags().StringVar(&metricsAddr, "metrics-addr", ":6781", "metrics server bind address")
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "warning", "logging level (debug, info, warning, error)")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "logging level (debug, info, warning, error)")
 	rootCmd.PersistentFlags().BoolVar(&allowMcast, "allow-mcast", true, "allow all multicast traffic")
 	rootCmd.PersistentFlags().StringVar(&nodeName, "node-name", "", "only generate rules that apply to this node")
 	rootCmd.PersistentFlags().BoolVar(&legacy, "use-legacy-netpol", false, "use legacy network policies (pre k8s 1.7 vsn)")

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -241,7 +241,7 @@ func main() {
 		Run:   root}
 
 	rootCmd.PersistentFlags().StringVar(&metricsAddr, "metrics-addr", ":6781", "metrics server bind address")
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "debug", "logging level (debug, info, warning, error)")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "warning", "logging level (debug, info, warning, error)")
 	rootCmd.PersistentFlags().BoolVar(&allowMcast, "allow-mcast", true, "allow all multicast traffic")
 	rootCmd.PersistentFlags().StringVar(&nodeName, "node-name", "", "only generate rules that apply to this node")
 	rootCmd.PersistentFlags().BoolVar(&legacy, "use-legacy-netpol", false, "use legacy network policies (pre k8s 1.7 vsn)")


### PR DESCRIPTION
The debug value prints out ALOT in the log file and i'm sure most users will get a chock the first time they open it not expecting debug to be on by default