### PR TITLE
Fix release script for plugin latest_release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -196,7 +196,7 @@ publish() {
 
     if [ "$RELEASE_TYPE" = 'PRERELEASE' ] ; then
         echo "== Building and pushing plugin"
-        make UPDATE_LATEST=$IS_MAINLINE SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER plugin_publish
+        make UPDATE_LATEST=false SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER plugin_publish
         echo "** Plugin built and pushed"
 
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"
@@ -232,7 +232,7 @@ publish() {
         echo '** Sanity checks OK for publishing tag' $LATEST_TAG as $DOCKERHUB_USER/weave:$VERSION
 
         echo "== Building and pushing plugin"
-        make UPDATE_LATEST=$IS_MAINLINE SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER plugin_publish
+        make UPDATE_LATEST=true SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER plugin_publish
         echo "** Plugin built and pushed"
 
         echo "== Tagging and pushing images on docker hub as user $DOCKERHUB_USER"


### PR DESCRIPTION
We should never update the `latest_release` plugin on a `PRERELEASE` (meaning something not tagged like 2.1.4 or flagged as prerelease on GitHub)

We should always update it on a `MAINLINE` or `BRANCH` release (meaning the version name matches a pattern like 2.3.0 or 2.1.9)

Fixes #3150 