### PR TITLE
Make proxy use configured WeaveDNS address

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -271,6 +271,7 @@ func main() {
 	var proxy *weaveproxy.Proxy
 	var err error
 	if proxyConfig.Enabled {
+		proxyConfig.DNSListenAddress = dnsConfig.addressOnly()
 		if noDNS {
 			proxyConfig.WithoutDNS = true
 		}

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -272,6 +272,7 @@ func main() {
 	var err error
 	if proxyConfig.Enabled {
 		proxyConfig.DNSListenAddress = dnsConfig.addressOnly()
+		proxyConfig.DNSDomain = dnsConfig.Domain
 		if noDNS {
 			proxyConfig.WithoutDNS = true
 		}

--- a/proxy/create_container_interceptor.go
+++ b/proxy/create_container_interceptor.go
@@ -68,11 +68,11 @@ func (i *createContainerInterceptor) InterceptRequest(r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		if dnsDomain := i.proxy.getDNSDomain(); dnsDomain != "" {
-			if err := i.setHostname(container, hostname, dnsDomain); err != nil {
+		if !i.proxy.WithoutDNS {
+			if err := i.setHostname(container, hostname, i.proxy.DNSDomain); err != nil {
 				return err
 			}
-			if err := i.proxy.setWeaveDNS(hostConfig, hostname, dnsDomain); err != nil {
+			if err := i.proxy.setWeaveDNS(hostConfig, hostname, i.proxy.DNSDomain); err != nil {
 				return err
 			}
 		}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -62,6 +62,7 @@ type Config struct {
 	TLSConfig           TLSConfig
 	WithoutDNS          bool
 	DNSListenAddress    string
+	DNSDomain           string
 	NoMulticastRoute    bool
 	KeepTXOn            bool
 	DockerBridge        string
@@ -601,14 +602,6 @@ func (proxy *Proxy) setWeaveDNS(hostConfig jsonObject, hostname, dnsDomain strin
 	}
 
 	return nil
-}
-
-func (proxy *Proxy) getDNSDomain() string {
-	if proxy.WithoutDNS {
-		return ""
-	}
-	domain, _ := proxy.weave.DNSDomain()
-	return domain
 }
 
 func (proxy *Proxy) updateContainerNetworkSettings(container jsonObject) error {

--- a/proxy/start_container_interceptor.go
+++ b/proxy/start_container_interceptor.go
@@ -50,8 +50,8 @@ func (i *startContainerInterceptor) InterceptRequest(r *http.Request) error {
 						return err
 					}
 				}
-				if dnsDomain := i.proxy.getDNSDomain(); dnsDomain != "" {
-					if err := i.proxy.setWeaveDNS(hostConfig, container.Config.Hostname, dnsDomain); err != nil {
+				if !i.proxy.WithoutDNS {
+					if err := i.proxy.setWeaveDNS(hostConfig, container.Config.Hostname, i.proxy.DNSDomain); err != nil {
 						return err
 					}
 				}

--- a/weave
+++ b/weave
@@ -1234,7 +1234,6 @@ launch() {
         --host-root=/host \
         $(router_bridge_opts) \
         --ipalloc-range "$IPRANGE" \
-        --dns-effective-listen-address $DOCKER_BRIDGE_IP \
         --dns-listen-address $DOCKER_BRIDGE_IP:53 \
         --http-addr $HTTP_ADDR \
         --status-addr $STATUS_ADDR \


### PR DESCRIPTION
Part of #1770 

* Make proxy use configured WeaveDNS address rather than assuming it is listening on the docker bridge
* Remove obsolete --dns-effective-listen-address parameter
* Pass the WeaveDNS Domain into the proxy instead of obtaining it via the http api

Remaining work on #1770 is to modify the `weave` script to respect the `--dns-listen-address` parameter and document it.