### PR TITLE
Add ability to set log level for net-plugin, and default to INFO

### DIFF
--- a/prog/net-plugin/config.json
+++ b/prog/net-plugin/config.json
@@ -51,6 +51,14 @@
   ],
   "env": [
     {
+      "description": "Log level",
+      "name": "LOG_LEVEL",
+      "settable": [
+          "value"
+      ],
+      "value": ""
+    },
+    {
       "description": "Extra args to `weaver` and `plugin`",
       "name": "EXTRA_ARGS",
       "settable": [

--- a/prog/net-plugin/launch.sh
+++ b/prog/net-plugin/launch.sh
@@ -7,6 +7,7 @@ IPALLOC_RANGE=${IPALLOC_RANGE:-10.32.0.0/12}
 HTTP_ADDR=${WEAVE_HTTP_ADDR:-127.0.0.1:6784}
 STATUS_ADDR=${WEAVE_STATUS_ADDR:-0.0.0.0:6782}
 HOST_ROOT=${HOST_ROOT:-/host}
+LOG_LEVEL=${LOG_LEVEL:-info}
 WEAVE_DIR="/host/var/lib/weave"
 
 mkdir $WEAVE_DIR || true
@@ -44,7 +45,7 @@ exec /home/weave/weaver $EXTRA_ARGS --port=6783 $(router_bridge_opts) \
     --no-dns \
     --ipalloc-range=$IPALLOC_RANGE \
     --nickname "$(hostname)" \
-    --log-level=debug \
+    --log-level=$LOG_LEVEL \
     --db-prefix="$WEAVE_DIR/weave" \
     --plugin-v2 \
     $(multicast_opt) \


### PR DESCRIPTION
Weave-net-plugin has `debug` as default log level without any way to change it. It is makes docker daemon logs (which we can get through `journalctl -u docker`) unreadable because there are a lot of useless debug messages from weave, like this:

    ERRO[3989] DEBU: 2017/12/12 14:39:05.033040 Expiring flow FlowSpec{keys: [UnknownFlowKey{type: 25, key: 00000000000000000000000000000000, mask: 00000000000000000000000000000000} BlobFlowKey{type: 20, key: 00000000, mask: 00000000} BlobFlowKey{type: 2, key: 00000000, mask: 00000000} InPortFlowKey{vport: 1} BlobFlowKey{type: 15, key: 00000000, mask: 00000000} UnknownFlowKey{type: 22, key: 00000000, mask: 00000000} UnknownFlowKey{type: 23, key: 0000, mask: 0000} UnknownFlowKey{type: 24, key: 00000000, mask: 00000000} BlobFlowKey{type: 6, key: 0000, mask: 0000} EthernetFlowKey{src: c2:2a:fd:a8:d5:de, dst: 33:33:00:00:00:02} BlobFlowKey{type: 19, key: 00000000, mask: 00000000} TunnelFlowKey{}], actions: [OutputAction{vport: 0}]}  plugin=c25deaecbbabd23c08f951dd3d6db9e5b1622e96433d977a1e406956fc1324b3
    ERRO[4379] DEBU: 2017/12/12 14:45:35.195020 fastdp: broadcast{1 false} {0e:2f:b0:ac:ea:01 33:33:00:00:00:02}  plugin=c25deaecbbabd23c08f951dd3d6db9e5b1622e96433d977a1e406956fc1324b3

In this PR I added ability to config log level usings `docker plugin set` command and change default log level to `info` (I can revert this change if you think that default debug is good idea). Please let me know if I missed something and need to make something else to this work properly (I am not docker/go developer, and can not be sure thats this is all I need to do to this work properly).

Thanks.