### PR TITLE
Do not skip bridge creation if bridge exists

### DIFF
--- a/common/odp/odp.go
+++ b/common/odp/odp.go
@@ -75,6 +75,14 @@ func DeleteDatapath(dpname string) error {
 }
 
 func AddDatapathInterface(dpname string, ifname string) error {
+	return addDatapathInterface(dpname, ifname, false)
+}
+
+func AddDatapathInterfaceIfNotExist(dpname string, ifname string) error {
+	return addDatapathInterface(dpname, ifname, true)
+}
+
+func addDatapathInterface(dpname, ifname string, ignoreIfExist bool) error {
 	dpif, err := odp.NewDpif()
 	if err != nil {
 		return err
@@ -87,5 +95,9 @@ func AddDatapathInterface(dpname string, ifname string) error {
 	}
 
 	_, err = dp.CreateVport(odp.NewNetdevVportSpec(ifname))
+	if ignoreIfExist && err == odp.NetlinkError(syscall.EEXIST) {
+		return nil
+	}
+
 	return err
 }

--- a/net/bridge.go
+++ b/net/bridge.go
@@ -227,12 +227,19 @@ func (config *BridgeConfig) configuredBridgeType() Bridge {
 }
 
 func EnsureBridge(procPath string, config *BridgeConfig, log *logrus.Logger) (Bridge, error) {
-	bridgeType, err := ExistingBridgeType(config.WeaveBridgeName, config.DatapathName)
-	if bridgeType != nil || err != nil {
-		return bridgeType, err
+	existingBridgeType, err := ExistingBridgeType(config.WeaveBridgeName, config.DatapathName)
+	if err != nil {
+		return nil, err
 	}
 
-	bridgeType = config.configuredBridgeType()
+	bridgeType := config.configuredBridgeType()
+
+	if existingBridgeType != nil && bridgeType.String() != existingBridgeType.String() {
+		return nil,
+			fmt.Errorf("Existing bridge type %q is different than requested %q. Please do 'weave reset' and try again",
+				existingBridgeType, bridgeType)
+	}
+
 	for {
 		if err := bridgeType.init(config); err != nil {
 			if errors.Cause(err) == errBridgeNotSupported {
@@ -288,7 +295,7 @@ func (b bridgeImpl) initPrep(config *BridgeConfig) error {
 		config.MTU = 65535
 	}
 	b.bridge = &netlink.Bridge{LinkAttrs: linkAttrs}
-	if err = netlink.LinkAdd(b.bridge); err != nil {
+	if err := LinkAddIfNotExist(b.bridge); err != nil {
 		return errors.Wrapf(err, "creating bridge %q", config.WeaveBridgeName)
 	}
 	if err := netlink.LinkSetHardwareAddr(b.bridge, mac); err != nil {
@@ -320,7 +327,7 @@ func (b bridgeImpl) init(config *BridgeConfig) error {
 	if err := b.initPrep(config); err != nil {
 		return err
 	}
-	if _, err := CreateAndAttachVeth(BridgeIfName, PcapIfName, config.WeaveBridgeName, config.MTU, true, func(veth netlink.Link) error {
+	if _, err := CreateAndAttachVeth(BridgeIfName, PcapIfName, config.WeaveBridgeName, config.MTU, true, false, func(veth netlink.Link) error {
 		return netlink.LinkSetUp(veth)
 	}); err != nil {
 		return errors.Wrap(err, "creating pcap veth pair")
@@ -370,11 +377,11 @@ func (bf bridgedFastdpImpl) init(config *BridgeConfig) error {
 	if err := bf.bridgeImpl.initPrep(config); err != nil {
 		return err
 	}
-	if _, err := CreateAndAttachVeth(BridgeIfName, DatapathIfName, config.WeaveBridgeName, config.MTU, true, func(veth netlink.Link) error {
+	if _, err := CreateAndAttachVeth(BridgeIfName, DatapathIfName, config.WeaveBridgeName, config.MTU, true, false, func(veth netlink.Link) error {
 		if err := netlink.LinkSetUp(veth); err != nil {
 			return errors.Wrapf(err, "setting link up on %q", veth.Attrs().Name)
 		}
-		if err := odp.AddDatapathInterface(bf.datapathName, veth.Attrs().Name); err != nil {
+		if err := odp.AddDatapathInterfaceIfNotExist(bf.datapathName, veth.Attrs().Name); err != nil {
 			return errors.Wrapf(err, "adding interface %q to datapath %q", veth.Attrs().Name, bf.datapathName)
 		}
 		return nil
@@ -394,7 +401,7 @@ func (bf bridgedFastdpImpl) attach(veth *netlink.Veth) error {
 }
 
 func (f fastdpImpl) attach(veth *netlink.Veth) error {
-	return odp.AddDatapathInterface(f.datapathName, veth.Attrs().Name)
+	return odp.AddDatapathInterfaceIfNotExist(f.datapathName, veth.Attrs().Name)
 }
 
 func configureIPTables(config *BridgeConfig) error {
@@ -404,9 +411,17 @@ func configureIPTables(config *BridgeConfig) error {
 	}
 	if config.DockerBridgeName != "" {
 		if config.WeaveBridgeName != config.DockerBridgeName {
-			err := ipt.Insert("filter", "FORWARD", 1, "-i", config.DockerBridgeName, "-o", config.WeaveBridgeName, "-j", "DROP")
+			// This check is not ideal, as the rule should be at the very top
+			// of the chain.
+			found, err := ipt.Exists("filter", "FORWARD", "-i", config.DockerBridgeName, "-o", config.WeaveBridgeName, "-j", "DROP")
 			if err != nil {
 				return err
+			}
+			if !found {
+				err := ipt.Insert("filter", "FORWARD", 1, "-i", config.DockerBridgeName, "-o", config.WeaveBridgeName, "-j", "DROP")
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/net/netlink.go
+++ b/net/netlink.go
@@ -1,0 +1,16 @@
+package net
+
+import (
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+)
+
+func LinkAddIfNotExist(link netlink.Link) error {
+	err := netlink.LinkAdd(link)
+	if err != nil && err == syscall.EEXIST {
+		return nil
+	}
+	return errors.Wrapf(err, "creating link %q", link)
+}

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -134,7 +134,7 @@ func (driver *driver) CreateEndpoint(create *api.CreateEndpointRequest) (*api.Cr
 
 	// create veths. note we assume endpoint IDs are unique in the first 9 chars
 	name, peerName := vethPair(create.EndpointID)
-	if _, err := weavenet.CreateAndAttachVeth(name, peerName, weavenet.WeaveBridgeName, 0, false, nil); err != nil {
+	if _, err := weavenet.CreateAndAttachVeth(name, peerName, weavenet.WeaveBridgeName, 0, false, true, nil); err != nil {
 		return nil, driver.error("JoinEndpoint", "%s", err)
 	}
 

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -197,6 +197,7 @@ func main() {
 	mflag.StringVar(&dnsConfig.ResolvConf, []string{"-resolv-conf"}, "", "path to resolver configuration for fallback DNS lookups")
 	mflag.StringVar(&bridgeConfig.DatapathName, []string{"-datapath"}, "", "ODP datapath name")
 	mflag.BoolVar(&bridgeConfig.NoFastdp, []string{"-no-fastdp"}, false, "Disable Fast Datapath")
+	mflag.BoolVar(&bridgeConfig.NoBridgedFastdp, []string{"-no-bridged-fastdp"}, false, "Disable Bridged Fast Datapath")
 	mflag.StringVar(&trustedSubnetStr, []string{"-trusted-subnets"}, "", "comma-separated list of trusted subnets in CIDR notation")
 	mflag.StringVar(&dbPrefix, []string{"-db-prefix"}, "/weavedb/weave", "pathname/prefix of filename to store data")
 	mflag.StringVar(&procPath, []string{"-proc-path"}, "/proc", "path to reach host /proc filesystem")

--- a/prog/weaveutil/bridge.go
+++ b/prog/weaveutil/bridge.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"strconv"
 
-	"github.com/weaveworks/weave/common"
 	weavenet "github.com/weaveworks/weave/net"
 )
 
@@ -20,38 +18,5 @@ func detectBridgeType(args []string) error {
 	} else {
 		fmt.Println(bridgeType.String())
 	}
-	return nil
-}
-
-func createBridge(args []string) error {
-	if len(args) != 10 {
-		cmdUsage("create-bridge", "<docker-bridge-name> <weave-bridge-name> <datapath-name> <mtu> <port> <mac> <no-fastdp> <no-bridged-fastdp> <proc-path> <expect-npc>")
-	}
-
-	mtu, err := strconv.Atoi(args[3])
-	if err != nil && args[3] != "" {
-		return err
-	}
-	port, err := strconv.Atoi(args[4])
-	if err != nil {
-		return err
-	}
-	config := weavenet.BridgeConfig{
-		DockerBridgeName: args[0],
-		WeaveBridgeName:  args[1],
-		DatapathName:     args[2],
-		MTU:              mtu,
-		Port:             port,
-		Mac:              args[5],
-		NoFastdp:         args[6] != "",
-		NoBridgedFastdp:  args[7] != "",
-		NPC:              args[9] == "--expect-npc",
-	}
-	procPath := args[8]
-	bridgeType, err := weavenet.EnsureBridge(procPath, &config, common.Log)
-	if err != nil {
-		return err
-	}
-	fmt.Println(bridgeType.String())
 	return nil
 }

--- a/prog/weaveutil/main.go
+++ b/prog/weaveutil/main.go
@@ -17,7 +17,6 @@ func init() {
 		"help":                     help,
 		"netcheck":                 netcheck,
 		"docker-tls-args":          dockerTLSArgs,
-		"create-bridge":            createBridge,
 		"detect-bridge-type":       detectBridgeType,
 		"create-datapath":          createDatapath,
 		"delete-datapath":          deleteDatapath,

--- a/test/191_create_bridge_2_test.sh
+++ b/test/191_create_bridge_2_test.sh
@@ -2,18 +2,19 @@
 
 . "$(dirname "$0")/config.sh"
 
-C1=10.32.0.1
-C2=10.32.0.2
+C1=10.32.0.2
+C2=10.32.0.3
 
 kill_weaver() {
     run_on $HOST1 sudo ip link set weave down
     WEAVER_PID=$(container_pid $HOST1 weave)
     run_on $HOST1 sudo kill -9 $WEAVER_PID
+    sleep 3
 }
 
 start_suite "Re-create bridge after restart"
 
-# Should create a bridge of the "bridge" type
+# Should create a bridge of the "bridge" type.
 WEAVE_NO_FASTDP=1 weave_on $HOST1 launch
 WEAVE_NO_FASTDP=1 weave_on $HOST2 launch $HOST1
 
@@ -23,21 +24,36 @@ assert_raises "exec_on $HOST1 c1 $PING $C2"
 
 kill_weaver # should re-create the bridge
 
-sleep 3
-
 assert_raises "exec_on $HOST1 c1 $PING $C2"
 
 # Should create a bridge of the "bridged_fastdp" type
 weave_on $HOST1 reset
 weave_on $HOST1 launch $HOST2
 weave_on $HOST1 attach $C1/24 c1
-
 assert_raises "exec_on $HOST1 c1 $PING $C2"
 
 kill_weaver # should re-create the bridge
 
-sleep 3
-
 assert_raises "exec_on $HOST1 c1 $PING $C2"
+
+# test restore of iptables
+
+weave_on $HOST1 reset
+# `--expect-npc` to trigger creation of WEAVE-NPC iptables chain.
+weave_on $HOST1 launch --expect-npc
+# To create POSTROUTING rules.
+weave_on $HOST1 expose
+
+IPT_BEFORE=$(mktemp)
+IPT_AFTER=$(mktemp)
+run_on $HOST1 "sudo iptables-save | grep -i weave | grep -v '\[.*:.*\]' > $IPT_BEFORE"
+
+run_on $HOST1 sudo iptables -t filter -D FORWARD -o weave -j WEAVE-NPC
+run_on $HOST1 sudo iptables -t nat -D POSTROUTING -j WEAVE
+kill_weaver # should re-create the bridge and iptables friends
+
+# Rudimentary check that weave related iptables rules has been restored
+run_on $HOST1 "sudo iptables-save | grep -i weave | grep -v '\[.*:.*\]' > $IPT_AFTER"
+assert_raises "run_on $HOST1 diff $IPT_BEFORE $IPT_AFTER"
 
 end_suite

--- a/test/191_create_bridge_2_test.sh
+++ b/test/191_create_bridge_2_test.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+
+. "$(dirname "$0")/config.sh"
+
+C1=10.32.0.1
+C2=10.32.0.2
+
+kill_weaver() {
+    run_on $HOST1 sudo ip link set weave down
+    WEAVER_PID=$(container_pid $HOST1 weave)
+    run_on $HOST1 sudo kill -9 $WEAVER_PID
+}
+
+start_suite "Re-create bridge after restart"
+
+# Should create a bridge of the "bridge" type
+WEAVE_NO_FASTDP=1 weave_on $HOST1 launch
+WEAVE_NO_FASTDP=1 weave_on $HOST2 launch $HOST1
+
+start_container $HOST1 $C1/24 --name=c1
+start_container $HOST2 $C2/24 --name=c2
+assert_raises "exec_on $HOST1 c1 $PING $C2"
+
+kill_weaver # should re-create the bridge
+
+sleep 3
+
+assert_raises "exec_on $HOST1 c1 $PING $C2"
+
+# Should create a bridge of the "bridged_fastdp" type
+weave_on $HOST1 reset
+weave_on $HOST1 launch $HOST2
+weave_on $HOST1 attach $C1/24 c1
+
+assert_raises "exec_on $HOST1 c1 $PING $C2"
+
+kill_weaver # should re-create the bridge
+
+sleep 3
+
+assert_raises "exec_on $HOST1 c1 $PING $C2"
+
+end_suite

--- a/weave
+++ b/weave
@@ -918,9 +918,7 @@ check_overlap() {
 }
 
 detect_awsvpc() {
-    # Ignoring errors here: if we cannot detect AWSVPC we will skip the relevant
-    # steps, because "attach" should work without the weave router running.
-    [ "$(call_weave GET /ipinfo/tracker)" != "awsvpc" ] || AWSVPC=1
+    [ "$(call_weave GET /ipinfo/tracker 2>/dev/null)" != "awsvpc" ] || AWSVPC=1
 }
 
 # Call IPAM as necessary to lookup or allocate addresses
@@ -1436,7 +1434,6 @@ case "$COMMAND" in
         done
         [ $# -eq 1 ] || usage
         CONTAINER=$(util_op container-id $1)
-        create_bridge
         ipam_cidrs allocate $CONTAINER $CIDR_ARGS
         if [ -n "$REWRITE_HOSTS" ] ; then
             # rewrite /etc/hosts, unlinking the file (so Docker does
@@ -1444,7 +1441,7 @@ case "$COMMAND" in
             util_op rewrite-etc-hosts "$CONTAINER" "$EXEC_IMAGE" "$ALL_CIDRS" $DNS_EXTRA_HOSTS
         fi
         [ -n "$AWSVPC" ] && ATTACH_ARGS="--no-multicast-route --keep-tx-on"
-        util_op attach-container $ATTACH_ARGS $CONTAINER $BRIDGE $MTU $ALL_CIDRS >/dev/null
+        util_op attach-container $ATTACH_ARGS $CONTAINER $BRIDGE $ALL_CIDRS >/dev/null
         [ -n "$WITHOUT_DNS" ] || when_weave_running with_container_fqdn $CONTAINER put_dns_fqdn $ALL_CIDRS
         show_addrs $ALL_CIDRS
         ;;

--- a/weave
+++ b/weave
@@ -1494,7 +1494,6 @@ case "$COMMAND" in
             [ $# -eq 2 -a "$1" = "-h" ] || usage
             FQDN="$2"
         fi
-        create_bridge
         expose_ip
         show_addrs $ALL_CIDRS
         ;;
@@ -1502,7 +1501,6 @@ case "$COMMAND" in
         collect_cidr_args "$@"
         shift $CIDR_ARG_COUNT
         ipam_cidrs lookup weave:expose $CIDR_ARGS
-        create_bridge
         for CIDR in $ALL_CIDRS ; do
             if ip addr show dev $BRIDGE | grep -qF $CIDR ; then
                 ip addr del dev $BRIDGE $CIDR

--- a/weave
+++ b/weave
@@ -536,6 +536,7 @@ router_bridge_opts() {
     echo --docker-bridge "$DOCKER_BRIDGE" --weave-bridge "$BRIDGE" --datapath "$DATAPATH"
     [ -z "$WEAVE_MTU" ] || echo --mtu "$WEAVE_MTU"
     [ -z $WEAVE_NO_FASTDP ] || echo --no-fastdp
+    [ -z $WEAVE_NO_BRIDGED_FASTDP ] || echo --no-bridged-fastdp
 }
 
 ######################################################################

--- a/weave
+++ b/weave
@@ -405,27 +405,6 @@ detect_bridge_type() {
     MTU=${WEAVE_MTU:-$(cat /sys/class/net/$BRIDGE/mtu)}
 }
 
-try_create_bridge() {
-    # Pass /dev/null because we do not have access to the weavedb files when this runs; BoltDB
-    # cannot open the file anyway if weaver is running, which is likely for attach|expose|hide.
-    MAC=$(util_op unique-id "/dev/null" "$HOST_ROOT")
-    BRIDGE_TYPE=$(util_op create-bridge "$DOCKER_BRIDGE" "$BRIDGE" "$DATAPATH" "$WEAVE_MTU" "$PORT" "$MAC" "$WEAVE_NO_FASTDP" "$WEAVE_NO_BRIDGED_FASTDP" "$PROC_PATH" "$1")
-    # Set some variables that are expected by code that comes later
-    [ "$BRIDGE_TYPE" != "fastdp" ] || DATAPATH="$BRIDGE"
-    MTU=${WEAVE_MTU:-$(cat /sys/class/net/$BRIDGE/mtu)}
-}
-
-create_bridge() {
-    validate_bridge_type
-    if ! try_create_bridge "$@" ; then
-        echo "Creating bridge '$BRIDGE' failed" >&2
-        # reset to original value so we destroy both kinds
-        DATAPATH=datapath
-        destroy_bridge
-        exit 1
-    fi
-}
-
 validate_bridge_type() {
     detect_bridge_type || return 0
 


### PR DESCRIPTION
I recommend to review each commit separately.

This PR does a few things:

- Removes `create_bridge` from the weave script. As a consequence, `weave attach $CIDR $CONTAINER` is no longer possible without running weaver.
- Removes unnecessary `create_bridge` from `weave expose` and `weave hide`.
- Makes `net/bridge.go:EnsureBridge` do not skip creation of the bridge if such already exists, and also makes the function idempotent.

Part of the #3133 fix; going to add netlink subscribe for changes to the bridge in a separate PR.