### PR TITLE
Move weave-npc checks to top of FORWARD chain

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -504,7 +504,7 @@ func linkSetUpByName(linkName string) error {
 // ensureRules ensures the presence of given iptables rules.
 //
 // If any rule from the list is missing, the function deletes all given
-// rules and re-appends them to ensure the order of the rules.
+// rules and re-inserts them to ensure the order of the rules.
 func ensureRules(table, chain string, rulespecs [][]string, ipt *iptables.IPTables) error {
 	allFound := true
 
@@ -524,13 +524,13 @@ func ensureRules(table, chain string, rulespecs [][]string, ipt *iptables.IPTabl
 		return nil
 	}
 
-	for _, rs := range rulespecs {
+	for pos, rs := range rulespecs {
 		// If any is missing, then delete all, as we need to preserve the order of
 		// given rules. Ignore errors, as rule might not exist.
 		if !allFound {
 			ipt.Delete(table, chain, rs...)
 		}
-		if err := ipt.Append(table, chain, rs...); err != nil {
+		if err := ipt.Insert(table, chain, pos+1, rs...); err != nil {
 			return errors.Wrapf(err, "ipt.Append(%s, %s, %s)", table, chain, rs)
 		}
 	}


### PR DESCRIPTION
We want our DROP rule to be executed ahead of any ACCEPT rules which might have been added by another program on the host.

Since #3204 gave us the framework to ensure we are recreating every rule, just inserting them all at the top, in order, works nicely.

~I also moved the NFLOG and DROP rules from FORWARD to WEAVE-NPC to simplify the logic about which order they come in.~

Extend kubernetes test to include the circumstances that trigger the issue.

Fixes #3209 
  