### PR TITLE
WIP: Refactor kubernetes test 2.0

### DIFF
--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -21,35 +21,40 @@ KUBE_PORT=6443
 IMAGE=weaveworks/network-tester:latest
 DOMAIN=nettest.default.svc.cluster.local.
 
-tear_down_kubeadm
-
-# Make an ipset, so we can check it doesn't get wiped out by Weave Net
-docker_on $HOST1 run --rm --privileged --net=host --entrypoint=/usr/sbin/ipset weaveworks/weave-npc create test_840_ipset bitmap:ip range 192.168.1.0/24 || true
-docker_on $HOST1 run --rm --privileged --net=host --entrypoint=/usr/sbin/ipset weaveworks/weave-npc add test_840_ipset 192.168.1.11
-
-# kubeadm init upgrades to latest Kubernetes version by default, therefore we try to lock the version using the below option:
-k8s_version="$(run_on $HOST1 "kubelet --version" | grep -oP "(?<=Kubernetes )v[\d\.\-beta]+")"
-k8s_version_option="$([[ "$k8s_version" > "v1.6" ]] && echo "kubernetes-version" || echo "use-kubernetes-version")"
-
-for host in $HOSTS; do
-    if [ $host = $HOST1 ] ; then
-	run_on $host "sudo systemctl start kubelet && sudo kubeadm init --$k8s_version_option=$k8s_version --token=$TOKEN"
-    else
-	run_on $host "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP:$KUBE_PORT"
-    fi
-done
-
 if [ -n "$COVERAGE" ]; then
     COVERAGE_ARGS="env:\\n                - name: EXTRA_ARGS\\n                  value: \"-test.coverprofile=/home/weave/cover.prof --\""
 else
     COVERAGE_ARGS="env:"
 fi
 
-# Ensure Kubernetes uses locally built container images and inject code coverage environment variable (or do nothing depending on $COVERAGE):
-sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never%" \
-    -e "s%env:%$COVERAGE_ARGS%" \
-    -e "s%#npc-args%              args:\n                - '--use-legacy-netpol'%" \
-    "$(dirname "$0")/../prog/weave-kube/weave-daemonset-k8s-1.7.yaml" | run_on "$HOST1" "$KUBECTL apply -n kube-system -f -"
+tear_down_kubeadm
+
+function setup_kubernetes_cluster {
+    # Make an ipset, so we can check it doesn't get wiped out by Weave Net
+    docker_on $HOST1 run --rm --privileged --net=host --entrypoint=/usr/sbin/ipset weaveworks/weave-npc create test_840_ipset bitmap:ip range 192.168.1.0/24 || true
+    docker_on $HOST1 run --rm --privileged --net=host --entrypoint=/usr/sbin/ipset weaveworks/weave-npc add test_840_ipset 192.168.1.11
+
+    # kubeadm init upgrades to latest Kubernetes version by default, therefore we try to lock the version using the below option:
+    k8s_version="$(run_on $HOST1 "kubelet --version" | grep -oP "(?<=Kubernetes )v[\d\.\-beta]+")"
+    k8s_version_option="$([[ "$k8s_version" > "v1.6" ]] && echo "kubernetes-version" || echo "use-kubernetes-version")"
+
+    for host in $HOSTS; do
+        if [ $host = $HOST1 ] ; then
+        run_on $host "sudo systemctl start kubelet && sudo kubeadm init --$k8s_version_option=$k8s_version --token=$TOKEN"
+        else
+        run_on $host "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP:$KUBE_PORT"
+        fi
+    done
+
+    
+
+    # Ensure Kubernetes uses locally built container images and inject code coverage environment variable (or do nothing depending on $COVERAGE):
+    sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never%" \
+        -e "s%env:%$COVERAGE_ARGS%" \
+        -e "s%#npc-args%              args:\n                - '--use-legacy-netpol'%" \
+        "$(dirname "$0")/../prog/weave-kube/weave-daemonset-k8s-1.7.yaml" | run_on "$HOST1" "$KUBECTL apply -n kube-system -f -"
+}
+setup_kubernetes_cluster
 
 sleep 5
 
@@ -59,22 +64,29 @@ check_connections() {
 
 assert_raises 'wait_for_x check_connections "connections to establish"'
 
-# Check we can ping between the Weave bridg IPs on each host
-HOST1EXPIP=$($SSH $HOST1 "weave expose" || true)
-HOST2EXPIP=$($SSH $HOST2 "weave expose" || true)
-HOST3EXPIP=$($SSH $HOST3 "weave expose" || true)
-assert_raises "run_on $HOST1 $PING $HOST2EXPIP"
-assert_raises "run_on $HOST2 $PING $HOST1EXPIP"
-assert_raises "run_on $HOST3 $PING $HOST2EXPIP"
+function check_can_ping_between_weave_bridge_IPs {
+    # Check we can ping between the Weave bridg IPs on each host
+    HOST1EXPIP=$($SSH $HOST1 "weave expose" || true)
+    HOST2EXPIP=$($SSH $HOST2 "weave expose" || true)
+    HOST3EXPIP=$($SSH $HOST3 "weave expose" || true)
+    assert_raises "run_on $HOST1 $PING $HOST2EXPIP"
+    assert_raises "run_on $HOST2 $PING $HOST1EXPIP"
+    assert_raises "run_on $HOST3 $PING $HOST2EXPIP"
+}
+check_can_ping_between_weave_bridge_IPs
 
-# Ensure we do not generate any defunct process (e.g. launch.sh) after starting weaver:
-assert "run_on $HOST1 ps aux | grep -c '[d]efunct'" "0"
-assert "run_on $HOST2 ps aux | grep -c '[d]efunct'" "0"
-assert "run_on $HOST3 ps aux | grep -c '[d]efunct'" "0"
+function check_weave_does_not_generate_defunct_processes {
+    # Ensure we do not generate any defunct process (e.g. launch.sh) after starting weaver:
+    assert "run_on $HOST1 ps aux | grep -c '[d]efunct'" "0"
+    assert "run_on $HOST2 ps aux | grep -c '[d]efunct'" "0"
+    assert "run_on $HOST3 ps aux | grep -c '[d]efunct'" "0"
+}
+check_weave_does_not_generate_defunct_processes
 
-# Set up a simple network policy so all our test pods can talk to each other
-run_on $HOST1 "$KUBECTL annotate ns default net.beta.kubernetes.io/network-policy='{\"ingress\":{\"isolation\":\"DefaultDeny\"}}'"
-run_on $HOST1 "$KUBECTL apply -f -" <<EOF
+function setup_pod_networking {
+    # Set up a simple network policy so all our test pods can talk to each other
+    run_on $HOST1 "$KUBECTL annotate ns default net.beta.kubernetes.io/network-policy='{\"ingress\":{\"isolation\":\"DefaultDeny\"}}'"
+    run_on $HOST1 "$KUBECTL apply -f -" <<EOF
 apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
@@ -96,8 +108,8 @@ spec:
       run: nettest
 EOF
 
-# Another policy, this time with no 'from' section, just to check that doesn't cause a crash
-run_on $HOST1 "$KUBECTL apply -f -" <<EOF
+    # Another policy, this time with no 'from' section, just to check that doesn't cause a crash
+    run_on $HOST1 "$KUBECTL apply -f -" <<EOF
 apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
@@ -109,6 +121,8 @@ spec:
     matchLabels:
       run: norealpods
 EOF
+}
+setup_pod_networking
 
 check_ready() {
     run_on $HOST1 "$KUBECTL get nodes | grep -c -w Ready | grep $NUM_HOSTS"
@@ -116,10 +130,11 @@ check_ready() {
 
 assert_raises 'wait_for_x check_ready "hosts to be ready"'
 
-# See if we can get some pods running that connect to the network
-run_on $HOST1 "$KUBECTL run --image-pull-policy=Never nettest --image=$IMAGE --replicas=3 -- -peers=3 -dns-name=$DOMAIN"
-# Create a headless service so they can be found in Kubernetes DNS
-run_on $HOST1 "$KUBECTL create -f -" <<EOF
+function setup_nettest_service {
+    # See if we can get some pods running that connect to the network
+    run_on $HOST1 "$KUBECTL run --image-pull-policy=Never nettest --image=$IMAGE --replicas=3 -- -peers=3 -dns-name=$DOMAIN"
+    # Create a headless service so they can be found in Kubernetes DNS
+    run_on $HOST1 "$KUBECTL create -f -" <<EOF
 apiVersion: v1
 kind: Service
 metadata:
@@ -133,6 +148,8 @@ spec:
   selector:
     run: nettest
 EOF
+}
+setup_nettest_service
 
 podName=$($SSH $HOST1 "$KUBECTL get pods -l run=nettest -o go-template='{{(index .items 0).metadata.name}}'")
 
@@ -154,24 +171,32 @@ assert_raises "$SSH $HOST1 $KUBECTL exec $podName -- $PING 8.8.8.8"
 # Check that our pods haven't crashed
 assert "$SSH $HOST1 $KUBECTL get pods -n kube-system -l name=weave-net | grep -c Running" 3
 
-# Start pod which should not have access to nettest
-run_on $HOST1 "$KUBECTL run nettest-deny --labels=\"access=deny,run=nettest-deny\" --image-pull-policy=Never --image=$IMAGE --replicas=1 --command -- sleep 3600"
-denyPodName=$($SSH $HOST1 "$KUBECTL get pods -l run=nettest-deny -o go-template='{{(index .items 0).metadata.name}}'")
+function setup_pod_with_policy {
+    # Start pod which should not have access to nettest
+    run_on $HOST1 "$KUBECTL run nettest-deny --labels=\"access=deny,run=nettest-deny\" --image-pull-policy=Never --image=$IMAGE --replicas=1 --command -- sleep 3600"
+    denyPodName=$($SSH $HOST1 "$KUBECTL get pods -l run=nettest-deny -o go-template='{{(index .items 0).metadata.name}}'")
+}
+setup_pod_with_policy
+
 assert_raises "! $SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
 
-# Restart weave-net with npc in non-legacy mode
-$SSH $HOST1 "$KUBECTL delete ds weave-net -n=kube-system"
-sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never%" \
-    -e "s%env:%$COVERAGE_ARGS%" \
-    "$(dirname "$0")/../prog/weave-kube/weave-daemonset-k8s-1.7.yaml" | run_on "$HOST1" "$KUBECTL apply -n kube-system -f -"
+function setup_weave_with_npc_in_non_legacy_mode {
+    # Restart weave-net with npc in non-legacy mode
+    $SSH $HOST1 "$KUBECTL delete ds weave-net -n=kube-system"
+    sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never%" \
+        -e "s%env:%$COVERAGE_ARGS%" \
+        "$(dirname "$0")/../prog/weave-kube/weave-daemonset-k8s-1.7.yaml" | run_on "$HOST1" "$KUBECTL apply -n kube-system -f -"
+}
+setup_weave_with_npc_in_non_legacy_mode
 
 assert_raises 'wait_for_x check_all_pods_communicate pods'
 
 # nettest-deny should still not be able to reach nettest pods
 assert_raises "! $SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
 
-# allow access for nettest-deny
-run_on $HOST1 "$KUBECTL apply -f -" <<EOF
+function setup_create_k8s_networkpolicy_allowing_nettest_deny {
+    # allow access for nettest-deny
+    run_on $HOST1 "$KUBECTL apply -f -" <<EOF
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -187,17 +212,22 @@ spec:
             matchLabels:
               access: deny
 EOF
+}
+setup_create_k8s_networkpolicy_allowing_nettest_deny
 
 assert_raises "$SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
 
-# remove the access for nettest-deny
-run_on $HOST1 "$KUBECTL delete netpol allow-nettest-deny"
+function setup_remove_k8s_networkpolicy_allowing_nettest_deny {
+    # remove the access for nettest-deny
+    run_on $HOST1 "$KUBECTL delete netpol allow-nettest-deny"
+}
 
 # nettest-deny should still not be able to reach nettest pods
 assert_raises "! $SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
 
-# allow access for all
-run_on $HOST1 "$KUBECTL apply -f -" <<EOF
+function setup_create_k8s_networkpolicy_allowing_all {
+    # allow access for all
+    run_on $HOST1 "$KUBECTL apply -f -" <<EOF
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -208,6 +238,7 @@ spec:
   ingress:
     - {}
 EOF
+}
 
 assert_raises "$SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
 

--- a/test/840_weave_kube_3_test.sh
+++ b/test/840_weave_kube_3_test.sh
@@ -10,8 +10,6 @@ tear_down_kubeadm() {
 
 howmany() { echo $#; }
 
-
-
 TOKEN=112233.4455667788990000
 HOST1IP=$($SSH $HOST1 "getent hosts $HOST1 | cut -f 1 -d ' '")
 NUM_HOSTS=$(howmany $HOSTS)
@@ -43,8 +41,6 @@ setup_kubernetes_cluster () {
         run_on $host "sudo systemctl start kubelet && sudo kubeadm join --token=$TOKEN $HOST1IP:$KUBE_PORT"
         fi
     done
-
-    
 
     # Ensure Kubernetes uses locally built container images and inject code coverage environment variable (or do nothing depending on $COVERAGE):
     sed -e "s%imagePullPolicy: Always%imagePullPolicy: Never%" \
@@ -249,15 +245,7 @@ main () {
     # nettest-deny should still not be able to reach nettest pods
     assert_raises "! $SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
 
-
-    assert_raises "! $SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
-
     setup_create_k8s_networkpolicy_allowing_nettest_deny
-
-    assert_raises "$SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
-
-    # nettest-deny should still not be able to reach nettest pods
-    assert_raises "! $SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
 
     assert_raises "$SSH $HOST1 $KUBECTL exec $denyPodName -- curl -s -S -f -m 2 http://$DOMAIN:8080/status >/dev/null"
 


### PR DESCRIPTION
The integration tests are really hard to read and figure out what's happening and why. I refactored 840 into functions to improve readability, with the intent to

- Extract the common functionality between tests 840 and 860
- Break up 840 into multiple tests

In the future.

This commit supersedes #3144
  