### PR TITLE
Fix subnet isolation and bump build-tools to latest

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -449,7 +449,9 @@ func configureIPTables(config *BridgeConfig) error {
 		// If WEAVE-NPC chain doesn't exist then creating a rule in the chain will fail
 		fwdRules = append(fwdRules,
 			[][]string{
-				{"-o", config.WeaveBridgeName, "-j", "WEAVE-NPC"},
+				{"-o", config.WeaveBridgeName,
+					"-m", "comment", "--comment", "NOTE: this must go before '-j KUBE-FORWARD'",
+					"-j", "WEAVE-NPC"},
 				{"-o", config.WeaveBridgeName, "-m", "state", "--state", "NEW", "-j", "NFLOG", "--nflog-group", "86"},
 				{"-o", config.WeaveBridgeName, "-j", "DROP"},
 			}...)

--- a/net/bridge.go
+++ b/net/bridge.go
@@ -470,7 +470,7 @@ func configureIPTables(config *BridgeConfig) error {
 	// and allow replies back
 	fwdRules = append(fwdRules, []string{"-o", config.WeaveBridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"})
 
-	if err := ensureRules("filter", "FORWARD", fwdRules, ipt); err != nil {
+	if err := ensureRulesAtTop("filter", "FORWARD", fwdRules, ipt); err != nil {
 		return err
 	}
 
@@ -491,11 +491,11 @@ func linkSetUpByName(linkName string) error {
 	return netlink.LinkSetUp(link)
 }
 
-// ensureRules ensures the presence of given iptables rules.
+// ensureRulesAtTop ensures the presence of given iptables rules.
 //
 // If any rule from the list is missing, the function deletes all given
-// rules and re-inserts them to ensure the order of the rules.
-func ensureRules(table, chain string, rulespecs [][]string, ipt *iptables.IPTables) error {
+// rules and re-inserts them at the top of the chain to ensure the order of the rules.
+func ensureRulesAtTop(table, chain string, rulespecs [][]string, ipt *iptables.IPTables) error {
 	allFound := true
 
 	for _, rs := range rulespecs {

--- a/test/191_create_bridge_2_test.sh
+++ b/test/191_create_bridge_2_test.sh
@@ -48,7 +48,7 @@ IPT_BEFORE=$(mktemp)
 IPT_AFTER=$(mktemp)
 run_on $HOST1 "sudo iptables-save | grep -i weave | grep -v '\[.*:.*\]' > $IPT_BEFORE"
 
-run_on $HOST1 sudo iptables -t filter -D FORWARD -o weave -j WEAVE-NPC
+run_on $HOST1 "sudo iptables -t filter -D FORWARD -o weave -m comment --comment \"NOTE: this must go before '-j KUBE-FORWARD'\" -j WEAVE-NPC"
 run_on $HOST1 sudo iptables -t nat -D POSTROUTING -j WEAVE
 kill_weaver # should re-create the bridge and iptables friends
 


### PR DESCRIPTION
* The "-i docker0 -o weave -j DROP" filter/FORWARD rule used to be inserted after the "-j WEAVE-EXPOSE" rule, so the subnet isolation has been broken for exposed subnets. This was the reason for the 130 smoke test failure.
* Add comment to note the importance of the order of the "-j WEAVE-NPC" rule.
* Improve naming of `ensureRules` function.
* ~Update k8s to 1.9.2 in CI.~
* Update build tools fix flaky tests due to the defunct process.