### PR TITLE
Wait 5 seconds to let pod connect before rolling next pod

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
@@ -101,6 +101,8 @@ items:
         name: weave-net
       namespace: kube-system
     spec:
+      # Wait 5 seconds to let pod connect before rolling next pod
+      minReadySeconds: 5
       template:
         metadata:
           labels:


### PR DESCRIPTION
During a rolling update we don't want Kubernetes to go as fast as it can across nodes, because each node will have a short interruption as iptables rules are recreated.

I think this will also have the effect of slowing down a first install, but hopefully people can wait a few extra seconds.

I picked 5 seconds somewhat arbitrarily; the setting may need more experimentation.

Note we don't specify a readiness check at the moment, so Kubernetes equates "running" with "ready".  If the pod crashes immediately it will not be ready.