### PR TITLE
Fix bug when dstSelector is overwritten by srcSelector

### DIFF
--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -108,7 +108,12 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	podSelectors[dstSelector.key] = dstSelector
+
+	// To prevent dstSelector being overwritten by a subsequent selector with
+	// the same key, addIfNotExist MUST be used when adding to podSelectors.
+	// Otherwise, dstSelector' "dst" property might be lost resulting in
+	// an invalid content of the "default-allow" ipset.
+	addIfNotExist(dstSelector, podSelectors)
 
 	// If ingress is empty then this NetworkPolicy does not allow any traffic
 	if policy.Spec.Ingress == nil || len(policy.Spec.Ingress) == 0 {
@@ -142,7 +147,7 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 					if err != nil {
 						return nil, nil, nil, err
 					}
-					podSelectors[srcSelector.key] = srcSelector
+					addIfNotExist(srcSelector, podSelectors)
 
 				} else if peer.NamespaceSelector != nil {
 					srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, "", ipset.ListSet)
@@ -166,6 +171,12 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 	}
 
 	return rules, nsSelectors, podSelectors, nil
+}
+
+func addIfNotExist(s *selectorSpec, ss map[string]*selectorSpec) {
+	if _, ok := ss[s.key]; !ok {
+		ss[s.key] = s
+	}
 }
 
 func withNormalisedProtoAndPortLegacy(npps []extnapi.NetworkPolicyPort, f func(proto, port string)) {


### PR DESCRIPTION
There was a bug in the npc analyser when adding a netpol with dstSelector == srcSelector. The analyser was overwriting dstSelector with srcSelector which resulted in Pod selected by dstSelector not being removed from a corresponding "default-allow" ipset.

This applies only to non-legacy netpols.

Fix #3222