### PR TITLE
Fix HOWTO for setting weave-kube passwd

### DIFF
--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -311,11 +311,11 @@ UDP connection from 10.32.0.7:56648 to 10.32.0.11:80 blocked by Weave NPC.
 You can customise the YAML you get from `cloud.weave.works` by passing some of Weave Net's options, arguments and environment variables as query parameters:
 
   - `version`: Weave Net's version. Default: `latest`, i.e. latest release. *N.B.*: This only changes the specified version inside the generated YAML file, it does not ensure that the rest of the YAML is compatible with that version. To freeze the YAML version save a copy of the YAML file from the [release page](https://github.com/weaveworks/weave/releases) and use that copy instead of downloading it each time from `cloud.weave.works`.
-  - `password-secret`: name of the Kubernetes secret containing your password.
+  - `password-secret`: name of the Kubernetes secret containing your password.  *N.B*: The Kubernetes secret name must correspond to a name of a file containing your password.
      Example:
 
-        $ echo "s3cr3tp4ssw0rd" > /var/lib/weave/weave-passwd.txt
-        $ kubectl create secret -n kube-system generic weave-passwd --from-file=/var/lib/weave/weave-passwd.txt
+        $ echo "s3cr3tp4ssw0rd" > /var/lib/weave/weave-passwd
+        $ kubectl create secret -n kube-system generic weave-passwd --from-file=/var/lib/weave/weave-passwd
         $ kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&password-secret=weave-passwd"
 
   - `known-peers`: comma-separated list of hosts. Default: empty.


### PR DESCRIPTION
A quick fix.

LG generates secretKeyRef.key w/o the ".txt" extension which makes it inaccessible to weave-kube when passwd is stored in "weave-passwd.txt".