### PR TITLE
Delete default ipset on namespace termination

### DIFF
--- a/npc/controller_test.go
+++ b/npc/controller_test.go
@@ -89,7 +89,9 @@ func (i *mockIPSet) FlushAll() error {
 func (i *mockIPSet) Destroy(ipsetName ipset.Name) error {
 	if _, ok := i.sets[string(ipsetName)]; !ok {
 		return errors.Errorf("ipset %s does not exist", ipsetName)
-	}
+	} else if len(set.subSets) != 0 {
+		return errors.Errorf("cannot destroy non-empty ipset %s %v", ipsetName, set.subSets)
+    }
 	delete(i.sets, string(ipsetName))
 	return nil
 }
@@ -294,6 +296,11 @@ func TestDefaultAllow(t *testing.T) {
 	controller.DeletePod(podFoo)
 	// Should remove foo pod from default-allow
 	require.False(t, m.entryExists(defaultAllowIPSetName, fooPodIP))
+
+	controller.DeleteNamespace(defaultNamespace)
+	// Should remove the defaultIPSet
+	require.NotContains(t, m.sets, defaultAllowIPSetName)
+
 }
 
 func TestOutOfOrderPodEvents(t *testing.T) {

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -471,7 +471,13 @@ func (ns *ns) deleteNamespace(obj *coreapi.Namespace) error {
 	}
 
 	// Remove namespace ipset from any matching namespace selectors
-	return ns.nsSelectors.delFromMatching(obj.ObjectMeta.UID, obj.ObjectMeta.Labels, string(ns.allPods.ipsetName))
+	err := ns.nsSelectors.delFromMatching(obj.ObjectMeta.UID, obj.ObjectMeta.Labels, string(ns.allPods.ipsetName))
+	if err != nil {
+		return err
+	}
+
+	// Delete default ipSet
+	return ns.ips.Destroy(ns.defaultAllowIPSet)
 }
 
 func (ns *ns) isDefaultDeny(namespace *coreapi.Namespace) bool {


### PR DESCRIPTION
## What ?
Fix for https://github.com/weaveworks/weave/issues/3247

## What it does?
On namespace deletion default `ipset` will cleaned for the namespace

## Status of PR
Test in progress in local cluster