### PR TITLE
Delete defaultAllowIPSet on namespace delete

### DIFF
--- a/npc/controller_test.go
+++ b/npc/controller_test.go
@@ -294,6 +294,11 @@ func TestDefaultAllow(t *testing.T) {
 	controller.DeletePod(podFoo)
 	// Should remove foo pod from default-allow
 	require.False(t, m.entryExists(defaultAllowIPSetName, fooPodIP))
+
+	controller.DeleteNamespace(defaultNamespace)
+	// Should remove default ipset
+	require.NotContains(t, m.sets, defaultAllowIPSetName)
+
 }
 
 func TestOutOfOrderPodEvents(t *testing.T) {

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -471,7 +471,16 @@ func (ns *ns) deleteNamespace(obj *coreapi.Namespace) error {
 	}
 
 	// Remove namespace ipset from any matching namespace selectors
-	return ns.nsSelectors.delFromMatching(obj.ObjectMeta.UID, obj.ObjectMeta.Labels, string(ns.allPods.ipsetName))
+	err := ns.nsSelectors.delFromMatching(obj.ObjectMeta.UID, obj.ObjectMeta.Labels, string(ns.allPods.ipsetName))
+	if err != nil {
+		return err
+	}
+
+	if !ns.legacy {
+		return ns.ips.Destroy(ns.defaultAllowIPSet)
+	}
+
+	return nil
 }
 
 func (ns *ns) isDefaultDeny(namespace *coreapi.Namespace) bool {


### PR DESCRIPTION
## What ?
Fix for https://github.com/weaveworks/weave/issues/3247

## What it does?
On namespace deletion default `ipset` will cleaned for the namespace