### PR TITLE
issue 3245 - change golang version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.8.7-stretch
 
 # Support Raspberry Pi 2 and newer
 ENV GOARM 7

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.7-stretch
+FROM golang:1.10.0-stretch
 
 # Support Raspberry Pi 2 and newer
 ENV GOARM 7

--- a/ipam/testutils_test.go
+++ b/ipam/testutils_test.go
@@ -117,7 +117,7 @@ func CheckAllExpectedMessagesSent(allocs ...*Allocator) {
 		m := alloc.gossip.(*mockGossipComms)
 		m.RLock()
 		if len(m.messages) > 0 {
-			require.FailNow(m, fmt.Sprintf("%s: Gossip message(s) not sent as expected: \n%x", m.name, m.messages))
+			require.FailNow(m, fmt.Sprintf("%s: Gossip message(s) not sent as expected: \n%v", m.name, m.messages))
 		}
 		m.RUnlock()
 	}

--- a/vagrant-common.rb
+++ b/vagrant-common.rb
@@ -16,7 +16,7 @@ def ansibleize(h)
 end
 
 def get_go_version_from_build_dockerfile()
-  go_regexp = /FROM golang:(\S*).*?/
+  go_regexp = /FROM golang:([\d\.]*).*?/
   dockerfile_path = File.expand_path(File.join(File.dirname(__FILE__), 'build', 'Dockerfile'))
   go_version = File.readlines(dockerfile_path).select { |line| line.match(go_regexp) }.first.match(go_regexp).captures.first
   if go_version.nil?


### PR DESCRIPTION
I have changed the golang image from golang:1.8.1 to golang:1.8.7-stretch.
I have chosen stretch version because the ubuntu version used in vagrant is stretch compliant when we check the ``/etc/debian_version`` file.

Concerning the tests. Some tests failed but I think it does not come from the golang image. I have never built before, I don't know if it is normal in the current state of the project that those tests below failed.
> Ran 73 tests, 4 failed
> Fail /home/vagrant/weave/test/602_proxy_docker_py_test.sh
> Fail /home/vagrant/weave/test/150_connect_forget_2_test.sh
> Fail /home/vagrant/weave/test/870_weave_recovers_unreachable_ips_on_relaunch_3_test.sh
> Fail /home/vagrant/weave/test/840_weave_kube_3_test.sh