### PR TITLE
Add 'peer names collision' to FAQ

### DIFF
--- a/site/faq.md
+++ b/site/faq.md
@@ -40,6 +40,15 @@ A simple way to accomplish this would be to run Weave on the host and then run, 
 Yet another option is to expose a port from the container on host B and then connect to it. You can read about exposing ports in [Exporting Services](/site/tasks/manage/service-management.md#exporting).
 
 
+<a name="duplicate-peer"></a>
+**Q: Why am I seeing "peer names collision" and failed connections?**
+
+This sometimes happens when machines are cloned; we require each
+machine in your cluster to have a unique identity.
+
+For more information see [Peer Names](/site/operational-guide/concepts.md#peer-name).
+
+
 <a name="duplicate-ip"></a>
 **Q: Why am I seeing the same IP address assigned to two different containers on different hosts?**
 

--- a/site/faq.md
+++ b/site/faq.md
@@ -48,6 +48,9 @@ machine in your cluster to have a unique identity.
 
 For more information see [Peer Names](/site/operational-guide/concepts.md#peer-name).
 
+Depending on your Linux distribution you may need to [set up
+machine-id](https://www.freedesktop.org/software/systemd/man/machine-id.html)
+or [generate a dbus id](https://dbus.freedesktop.org/doc/dbus-uuidgen.1.html).
 
 <a name="duplicate-ip"></a>
 **Q: Why am I seeing the same IP address assigned to two different containers on different hosts?**


### PR DESCRIPTION
Have seen a couple of these in the last few days.

e.g. https://groups.google.com/a/weave.works/forum/#!forum/weave-users