### PR TITLE
Raise weave-kube default connection limit from 30 to 100

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -29,7 +29,7 @@ IPALLOC_RANGE=${IPALLOC_RANGE:-10.32.0.0/12}
 HTTP_ADDR=${WEAVE_HTTP_ADDR:-127.0.0.1:6784}
 STATUS_ADDR=${WEAVE_STATUS_ADDR:-0.0.0.0:6782}
 HOST_ROOT=${HOST_ROOT:-/host}
-CONN_LIMIT=${CONN_LIMIT:-30}
+CONN_LIMIT=${CONN_LIMIT:-100}
 DB_PREFIX=${DB_PREFIX:-/weavedb/weave-net}
 
 # Check if the IP range overlaps anything existing on the host


### PR DESCRIPTION
This was missed from #3234 