### PR TITLE
Remove .ruby-version which we don't need

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,8 @@ machine:
     # Google Cloud Platorm images for integration tests:
     USE_IMAGE: 1
     DISK_NAME_PREFIX: test-$CIRCLE_BUILD_NUM-0
+  post:
+    - rm $SRCDIR/.ruby-version
 
 dependencies:
   cache_directories:


### PR DESCRIPTION
Just checking what happens when we remove this.  I think it was there for some reason relating to the website, but also I think the website build just copies the doc files out of this repo now.