### PR TITLE
Only expose metrics by default in weave-kube

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -27,7 +27,7 @@ xt_set_exists() {
 # Default if not supplied - same as weave net default
 IPALLOC_RANGE=${IPALLOC_RANGE:-10.32.0.0/12}
 HTTP_ADDR=${WEAVE_HTTP_ADDR:-127.0.0.1:6784}
-STATUS_ADDR=${WEAVE_STATUS_ADDR:-0.0.0.0:6782}
+METRICS_ADDR=${WEAVE_METRICS_ADDR:-0.0.0.0:6782}
 HOST_ROOT=${HOST_ROOT:-/host}
 CONN_LIMIT=${CONN_LIMIT:-100}
 DB_PREFIX=${DB_PREFIX:-/weavedb/weave-net}
@@ -52,6 +52,12 @@ else
     if [ "$BRIDGE_NF_ENABLED" != "1" ]; then
         echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
     fi
+fi
+
+STATUS_OPTS="--metrics-addr=$METRICS_ADDR"
+# --status-addr exposes internal information, so only turn it on if asked to.
+if [ -n "${WEAVE_STATUS_ADDR}" ]; then
+    STATUS_OPTS="$STATUS_OPTS --status-addr=$WEAVE_STATUS_ADDR"
 fi
 
 # Default is that npc will be running; allow caller to override
@@ -144,7 +150,7 @@ post_start_actions &
 /home/weave/weaver $EXTRA_ARGS --port=6783 $(router_bridge_opts) \
      --name="$PEERNAME" \
      --host-root=$HOST_ROOT \
-     --http-addr=$HTTP_ADDR --status-addr=$STATUS_ADDR --docker-api='' --no-dns \
+     --http-addr=$HTTP_ADDR $STATUS_OPTS --docker-api='' --no-dns \
      --db-prefix="$DB_PREFIX" \
      --ipalloc-range=$IPALLOC_RANGE $NICKNAME_ARG \
      --ipalloc-init $IPALLOC_INIT \

--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -346,6 +346,10 @@ The list of variables you can set is:
 * `WEAVE_EXPOSE_IP` - set the IP address used as a gateway from the
   Weave network to the host network - this is useful if you are
   configuring the addon as a static pod.
+* `WEAVE_METRICS_ADDR` - address and port that the Weave Net
+  daemon will serve Prometheus-style metrics on (defaults to 0.0.0.0:6782)
+* `WEAVE_STATUS_ADDR` - address and port that the Weave Net
+  daemon will serve status requests on (defaults to disabled)
 * `WEAVE_MTU` - Weave Net defaults to 1376 bytes, but you can set a
   smaller size if your underlying network has a tighter limit, or set
   a larger size for better performance if your network supports jumbo

--- a/site/tasks/manage/metrics.md
+++ b/site/tasks/manage/metrics.md
@@ -34,7 +34,7 @@ exposed:
 
 When installed as a Kubernetes Addon, the router listens for metrics
 requests on 0.0.0.0:6782 and the Network Policy Controller listens on
-0.0.0.0:6781.  No other requests are served on these endpoints.
+0.0.0.0:6781. No other requests are served on these endpoints.
 
 >Note: If your Kubernetes hosts are exposed to the public internet
 then these metrics endpoints will also be exposed.
@@ -48,9 +48,8 @@ publish your metrics throughout your cluster, you can set
 
 Set it to an empty string to disable.
 
-You can also add `--metrics-addr=X.X.X.X:PORT` to specify an address
-to listen for metrics only.
-
+You can also pass the parameter `--metrics-addr=X.X.X.X:PORT` to
+`weave launch` to specify an address to listen for metrics only.
 
 # Static Configuration for Weave Net
 

--- a/site/tasks/manage/metrics.md
+++ b/site/tasks/manage/metrics.md
@@ -10,9 +10,6 @@ controller](/site/kubernetes/kube-addon.md#npc).
 
 ### Router Metrics
 
-The endpoint address is `localhost:6782`; the following metrics are
-exposed:
-
 * `weave_connections` - Number of peer-to-peer connections.
 * `weave_connection_terminations_total` - Number of peer-to-peer
   connections terminated.
@@ -25,26 +22,35 @@ exposed:
 * `weave_ipam_pending_allocates` - Number of pending allocates.
 * `weave_ipam_pending_claims` - Number of pending claims.
 
-#### Publish Router Metrics Endpoint
-
-By default, when started via `weave launch`, weave listens on its local
-interface to serve metrics. To publish your metrics throughout your cluster,
-e.g. if your prometheus server is installed on a different host machine,
-you need to set `WEAVE_STATUS_ADDR` to your corresponding IP and port.
-Default port is 6782.
-
-`WEAVE_STATUS_ADDR=X.X.X.X:PORT`
-
-You can set `WEAVE_STATUS_ADDR=0.0.0.0:6782` to listen on all interfaces,
-but be aware, this may expose your metrics to the public internet.
-
 ### Kubernetes Network Policy Controller Metrics
 
-The endpoint address is `localhost:6781`; the following metric is
+The following metric is
 exposed:
 
 * `weavenpc_blocked_connections_total` - Connection attempts blocked
   by policy controller.
+
+### Metrics Endpoint Addresses
+
+When installed as a Kubernetes Addon, the router listens for metrics
+requests on 0.0.0.0:6782 and the Network Policy Controller listens on
+0.0.0.0:6781.  No other requests are served on these endpoints.
+
+>Note: If your Kubernetes hosts are exposed to the public internet
+then these metrics endpoints will also be exposed.
+
+When started via `weave launch`, by default weave listens on its local
+interface to serve metrics and other read-only status requests. To
+publish your metrics throughout your cluster, you can set
+`WEAVE_STATUS_ADDR`:
+
+`WEAVE_STATUS_ADDR=X.X.X.X:PORT`
+
+Set it to an empty string to disable.
+
+You can also add `--metrics-addr=X.X.X.X:PORT` to specify an address
+to listen for metrics only.
+
 
 # Static Configuration for Weave Net
 


### PR DESCRIPTION
The handler for `--status-addr` exposes `/metrics`, `/status` and `/report`, and since we listen on 0.0.0.0 by default in weave-kube this could be attacked.

Change the default to only answer `/metrics`, while retaining compatibility for anyone who set the `WEAVE_STATUS_ADDR` variable.