### PR TITLE
Use go1.10.1 for building

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.0-stretch
+FROM golang:1.10.1-stretch
 
 # Support Raspberry Pi 2 and newer
 ENV GOARM 7


### PR DESCRIPTION
go1.10.1 includes the fix: https://github.com/golang/go/issues/23995