### PR TITLE
Add instruction for validating whether imgs were pushed for all platforms

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -127,6 +127,22 @@ Finally, for **Mainline** releases only:
 
 * Images tagged `latest` are updated on DockerHub
 
+Now, you can validate whether images were published for all platforms:
+
+    # Required platforms for each image:
+    grep '^ML_PLATFORMS=' Makefile
+
+    # Published platforms per image:
+    for img in $(grep '^PUBLISH=' Makefile); do
+        img="weaveworks/$(echo $img | cut -d_ -f2):${TAG#v}"
+        platforms=$(vendor/github.com/estesp/manifest-tool/manifest-tool \
+                inspect --raw "$img" | \
+                jq '.[].Platform | .os + "/" +.architecture' | \
+                tr '\n' ' ')
+        echo "$img: $platforms"
+    done
+
+
 ### Docker Store
 
 Weave Net is [available in Docker Store](https://store.docker.com/plugins/weave-net-plugin) and should also be released there.


### PR DESCRIPTION
Extended docs to prevent such mishaps as #3276.

Perhaps we could automate this step, but it would be good to merge #3268 first, as it changes manifest-tool location.

