### PR TITLE
Add instructions for 'seeded by different peers' message

### DIFF
--- a/site/tasks/ipam/troubleshooting-ipam.md
+++ b/site/tasks/ipam/troubleshooting-ipam.md
@@ -67,3 +67,18 @@ Columns are as follows:
   partition, it may be because the peer has failed and needs to be
   removed administratively - see [Starting, Stopping and Removing
   Peers](/site/tasks/ipam/stop-remove-peers-ipam.md) for more details.
+
+
+### <a name="seeded-different-peers"></a>Seeded by Different Peers
+
+If you see the message: `IP allocation was seeded by different peers`,
+this means that some Weave Net peers were initialized into one cluster
+and some into another cluster; Weave Net cannot operate in this state.
+
+To recover, you need to eliminate the IPAM data from the affected
+nodes and restart.  If you installed via the Kubernetes Addon, this
+data will be in a file under `/var/lib/weave` on the node - delete
+this file and restart the node.
+
+For other installations, run `weave reset` and restart. Any existing
+connections to containers will be lost.

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -157,6 +157,9 @@ The columns are as follows:
    the encryption mode, data transport method, remote peer name and
    nickname for pending and established connections, mtu if known
 
+Specific error messages:
+* `IP allocation was seeded by different peers` - [more details here](/site/ipam/troubleshooting-ipam.md#seeded-different-peers)
+
 ### <a name="weave-status-peers"></a>List Peers
 
 Detailed information on peers can be obtained with `weave status
@@ -329,5 +332,6 @@ and the container image versions as git hashes.
 
 **See Also**
 
+ * [Troubleshooting the Kubernetes Addon](/site/kubernetes/kube-addon/#troubleshooting)
  * [Troubleshooting IPAM](/site/tasks/ipam/troubleshooting-ipam.md)
  * [Troubleshooting the Proxy](/site/tasks/weave-docker-api/using-proxy.md)


### PR DESCRIPTION
I put full instructions on the 'troubleshooting ipam' page, and a pointer from the 'troubleshooting' page.

Maybe we should also have a pointer from the Kubernetes Addon page.