### PR TITLE
Add org.opencontainers.image.* labels to Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ endif
 # The name of the user that this Makefile should produce image artifacts for. Can/should be overridden
 DOCKERHUB_USER?=weaveworks
 # The default version that's chosen when pushing the images. Can/should be overridden
+GIT_REVISION=$(shell git rev-parse HEAD)
 WEAVE_VERSION?=git-$(shell git rev-parse --short=12 HEAD)
 # Docker Store does not allow the "latest" tag.
 NET_PLUGIN_LATEST=latest_release
@@ -274,7 +275,7 @@ endif
 $(WEAVER_UPTODATE): prog/weaver/Dockerfile.$(DOCKERHUB_USER) $(WEAVER_EXE) weave $(WEAVEUTIL_EXE)
 	cp $(WEAVEUTIL_EXE) prog/weaver/weaveutil
 	cp weave prog/weaver/weave
-	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -f prog/weaver/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVER_IMAGE) prog/weaver
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build --build-arg=revision=$(GIT_REVISION) -f prog/weaver/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVER_IMAGE) prog/weaver
 	touch $@
 
 $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile.$(DOCKERHUB_USER) prog/weaveexec/symlink $(SIGPROXY_EXE) $(WEAVEWAIT_EXE) $(WEAVEWAIT_NOOP_EXE) $(WEAVEWAIT_NOMCAST_EXE) $(WEAVER_UPTODATE)
@@ -282,7 +283,7 @@ $(WEAVEEXEC_UPTODATE): prog/weaveexec/Dockerfile.$(DOCKERHUB_USER) prog/weaveexe
 	cp $(WEAVEWAIT_EXE) prog/weaveexec/weavewait
 	cp $(WEAVEWAIT_NOOP_EXE) prog/weaveexec/weavewait_noop
 	cp $(WEAVEWAIT_NOMCAST_EXE) prog/weaveexec/weavewait_nomcast
-	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build -f prog/weaveexec/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVEEXEC_IMAGE) prog/weaveexec
+	$(SUDO) DOCKER_HOST=$(DOCKER_HOST) docker build --build-arg=revision=$(GIT_REVISION) -f prog/weaveexec/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVEEXEC_IMAGE) prog/weaveexec
 	touch $@
 
 # Builds Docker plugin.
@@ -304,15 +305,15 @@ $(PLUGIN_UPTODATE): prog/net-plugin/launch.sh prog/net-plugin/config.json $(WEAV
 
 $(WEAVEKUBE_UPTODATE): prog/weave-kube/Dockerfile.$(DOCKERHUB_USER) prog/weave-kube/launch.sh $(KUBEPEERS_EXE) $(WEAVER_UPTODATE)
 	cp $(KUBEPEERS_EXE) prog/weave-kube/
-	$(SUDO) docker build -f prog/weave-kube/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVEKUBE_IMAGE) prog/weave-kube
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) -f prog/weave-kube/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVEKUBE_IMAGE) prog/weave-kube
 	touch $@
 
 $(WEAVENPC_UPTODATE): prog/weave-npc/Dockerfile.$(DOCKERHUB_USER) $(WEAVENPC_EXE) prog/weave-npc/ulogd.conf
-	$(SUDO) docker build -f prog/weave-npc/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVENPC_IMAGE) prog/weave-npc
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) -f prog/weave-npc/Dockerfile.$(DOCKERHUB_USER) -t $(WEAVENPC_IMAGE) prog/weave-npc
 	touch $@
 
 $(WEAVEDB_UPTODATE): prog/weavedb/Dockerfile
-	$(SUDO) docker build -t $(WEAVEDB_IMAGE) prog/weavedb
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) -t $(WEAVEDB_IMAGE) prog/weavedb
 	touch $@
 
 $(NETWORKTESTER_UPTODATE): test/images/network-tester/Dockerfile $(NETWORKTESTER_EXE)

--- a/prog/weave-kube/Dockerfile.template
+++ b/prog/weave-kube/Dockerfile.template
@@ -1,3 +1,14 @@
 FROM DOCKERHUB_USER/weaveARCH_EXT
+
+# These labels are pretty static, and can therefore be added early on:
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="weave-kube" \
+      org.opencontainers.image.source="https://github.com/weaveworks/weave" \
+      org.opencontainers.image.vendor="Weaveworks"
+
 ADD ./launch.sh ./kube-peers /home/weave/
 ENTRYPOINT ["/home/weave/launch.sh"]
+
+# This label will change for every build, and should therefore be the last layer of the image:
+ARG revision
+LABEL org.opencontainers.image.revision="${revision}"

--- a/prog/weave-npc/Dockerfile.template
+++ b/prog/weave-npc/Dockerfile.template
@@ -1,16 +1,23 @@
 FROM ALPINE_BASEIMAGE
 
-# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
-# If we're building normally, for amd64, CROSS_BUILD lines are removed
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
-LABEL maintainer "Weaveworks Inc <help@weave.works>"
-LABEL works.weave.role=system \
+# These labels are pretty static, and can therefore be added early on:
+LABEL works.weave.role="system" \
+      maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="Weave Net" \
+      org.opencontainers.image.description="Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery" \
+      org.opencontainers.image.url="https://weave.works" \
+      org.opencontainers.image.source="https://github.com/weaveworks/weave" \
+      org.opencontainers.image.vendor="Weaveworks" \
+      org.label-schema.schema-version="1.0" \
       org.label-schema.name="Weave Net" \
       org.label-schema.description="Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery" \
       org.label-schema.url="https://weave.works" \
       org.label-schema.vcs-url="https://github.com/weaveworks/weave" \
       org.label-schema.vendor="Weaveworks"
+
+# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
+# If we're building normally, for amd64, CROSS_BUILD lines are removed
+CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
 RUN apk add --update \
     iptables \
@@ -21,3 +28,8 @@ RUN apk add --update \
 COPY ./weave-npc /usr/bin/weave-npc
 COPY ./ulogd.conf /etc/ulogd.conf
 ENTRYPOINT ["/usr/bin/weave-npc"]
+
+# These labels will change for every build, and should therefore be the last layer of the image:
+ARG revision
+LABEL org.opencontainers.image.revision="${revision}" \
+      org.label-schema.vcs-ref="${revision}"

--- a/prog/weavedb/Dockerfile
+++ b/prog/weavedb/Dockerfile
@@ -1,7 +1,17 @@
 # This is a nearly-empty image that we use to create a data-only container for persistence
 FROM scratch
-LABEL maintainer "Weaveworks Inc <help@weave.works>"
-LABEL works.weave.role=system
+
+# These labels are pretty static, and can therefore be added early on:
+LABEL works.weave.role="system" \
+      maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="weavedb" \
+      org.opencontainers.image.source="https://github.com/weaveworks/weave" \
+      org.opencontainers.image.vendor="Weaveworks"
+
 ENTRYPOINT ["data-only"]
 # Work round Docker refusing to save an empty image
 COPY Dockerfile /
+
+# This label will change for every build, and should therefore be the last layer of the image:
+ARG revision
+LABEL org.opencontainers.image.revision="${revision}"

--- a/prog/weaveexec/Dockerfile.template
+++ b/prog/weaveexec/Dockerfile.template
@@ -1,5 +1,11 @@
 FROM DOCKERHUB_USER/weaveARCH_EXT
 
+# These labels are pretty static, and can therefore be added early on:
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="weaveexec" \
+      org.opencontainers.image.source="https://github.com/weaveworks/weave" \
+      org.opencontainers.image.vendor="Weaveworks"
+
 ENTRYPOINT ["/home/weave/sigproxy", "/home/weave/weave"]
 
 ADD ./sigproxy ./symlink /home/weave/
@@ -7,3 +13,7 @@ ADD ./weavewait /w/w
 ADD ./weavewait_noop /w-noop/w
 ADD ./weavewait_nomcast /w-nomcast/w
 WORKDIR /home/weave
+
+# This label will change for every build, and should therefore be the last layer of the image:
+ARG revision
+LABEL org.opencontainers.image.revision="${revision}"

--- a/prog/weaver/Dockerfile.template
+++ b/prog/weaver/Dockerfile.template
@@ -1,16 +1,23 @@
 FROM ALPINE_BASEIMAGE
 
-# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
-# If we're building normally, for amd64, CROSS_BUILD lines are removed
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
-
-LABEL maintainer "Weaveworks Inc <help@weave.works>"
-LABEL works.weave.role=system \
+# These labels are pretty static, and can therefore be added early on:
+LABEL works.weave.role="system" \
+      maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="Weave Net" \
+      org.opencontainers.image.description="Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery" \
+      org.opencontainers.image.url="https://weave.works" \
+      org.opencontainers.image.source="https://github.com/weaveworks/weave" \
+      org.opencontainers.image.vendor="Weaveworks" \
+      org.label-schema.schema-version="1.0" \
       org.label-schema.name="Weave Net" \
       org.label-schema.description="Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery" \
       org.label-schema.url="https://weave.works" \
       org.label-schema.vcs-url="https://github.com/weaveworks/weave" \
       org.label-schema.vendor="Weaveworks"
+
+# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
+# If we're building normally, for amd64, CROSS_BUILD lines are removed
+CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
 RUN apk add --update \
     curl \
@@ -29,3 +36,8 @@ ADD ./weaveutil /usr/bin/
 ADD weavedata.db /weavedb/
 ENTRYPOINT ["/home/weave/weaver"]
 WORKDIR /home/weave
+
+# These labels will change for every build, and should therefore be the last layer of the image:
+ARG revision
+LABEL org.opencontainers.image.revision="${revision}" \
+      org.label-schema.vcs-ref="${revision}"


### PR DESCRIPTION
Why? What?

- This should ultimately help for image-to-code back references.
- `org.label-schema.*` labels are now deprecated, in favour of `org.opencontainers.image.*` labels.
  See also: https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema
- Git revision is now injected at `docker build` time.

Testing
```console
$ docker inspect weaveworks/weave
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.label-schema.description": "Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery",
                "org.label-schema.name": "Weave Net",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.url": "https://weave.works",
                "org.label-schema.vcs-ref": "9f207f161a160e1f09f472015c346976547a0dc7",
                "org.label-schema.vcs-url": "https://github.com/weaveworks/weave",
                "org.label-schema.vendor": "Weaveworks",
                "org.opencontainers.image.description": "Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery",
                "org.opencontainers.image.revision": "9f207f161a160e1f09f472015c346976547a0dc7",
                "org.opencontainers.image.source": "https://github.com/weaveworks/weave",
                "org.opencontainers.image.title": "Weave Net",
                "org.opencontainers.image.url": "https://weave.works",
                "org.opencontainers.image.vendor": "Weaveworks",
                "works.weave.role": "system"
            }
[...]
```
```console
$ docker inspect weaveworks/weave-kube
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.label-schema.description": "Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery",
                "org.label-schema.name": "Weave Net",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.url": "https://weave.works",
                "org.label-schema.vcs-ref": "9f207f161a160e1f09f472015c346976547a0dc7",
                "org.label-schema.vcs-url": "https://github.com/weaveworks/weave",
                "org.label-schema.vendor": "Weaveworks",
                "org.opencontainers.image.description": "Weave Net creates a virtual network that connects Docker containers across multiple hosts and enables their automatic discovery",
                "org.opencontainers.image.revision": "9f207f161a160e1f09f472015c346976547a0dc7",
                "org.opencontainers.image.source": "https://github.com/weaveworks/weave",
                "org.opencontainers.image.title": "weave-kube",
                "org.opencontainers.image.url": "https://weave.works",
                "org.opencontainers.image.vendor": "Weaveworks",
                "works.weave.role": "system"
            }
[...]
```

