### PR TITLE
Implement Egress NPC

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -457,11 +457,24 @@ func configureIPTables(config *BridgeConfig, ips ipset.Interface) error {
 	}
 
 	if config.NPC {
-		// Steer traffic via the NPC
-		_ = ipt.NewChain("filter", "WEAVE-NPC") // ignore error because it might already exist
+		// Steer traffic via the NPC.
+		// Ignore error because chains might already exist
+		// TODO(brb): use constants for WEAVE-NPC* chains
+		_ = ipt.NewChain("filter", "WEAVE-NPC")
+		_ = ipt.NewChain("filter", "WEAVE-NPC-EGRESS")
+
+		// TODO(brb): this rule might slow down packet processing; consider removing at it applies only
+		// to node-local traffic.
+		if err = ipt.AppendUnique("filter", "INPUT", "-i", config.WeaveBridgeName, "-j", "WEAVE-NPC-EGRESS"); err != nil {
+			return err
+		}
+
 		// If WEAVE-NPC chain doesn't exist then creating a rule in the chain will fail
 		fwdRules = append(fwdRules,
 			[][]string{
+				{"-i", config.WeaveBridgeName,
+					"-m", "comment", "--comment", "NOTE: this must go before '-j KUBE-FORWARD'",
+					"-j", "WEAVE-NPC-EGRESS"},
 				{"-o", config.WeaveBridgeName,
 					"-m", "comment", "--comment", "NOTE: this must go before '-j KUBE-FORWARD'",
 					"-j", "WEAVE-NPC"},

--- a/net/iptables.go
+++ b/net/iptables.go
@@ -1,0 +1,65 @@
+package net
+
+import (
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/pkg/errors"
+)
+
+// ensureChains creates given chains if they do not exist.
+func ensureChains(ipt *iptables.IPTables, table string, chains ...string) error {
+	existingChains, err := ipt.ListChains(table)
+	if err != nil {
+		return errors.Wrapf(err, "ipt.ListChains(%s)", table)
+	}
+	chainMap := make(map[string]struct{})
+	for _, c := range existingChains {
+		chainMap[c] = struct{}{}
+	}
+
+	for _, c := range chains {
+		if _, found := chainMap[c]; !found {
+			if err := ipt.NewChain(table, c); err != nil {
+				return errors.Wrapf(err, "ipt.NewChain(%s, %s)", table, c)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ensureRulesAtTop ensures the presence of given iptables rules.
+//
+// If any rule from the list is missing, the function deletes all given
+// rules and re-inserts them at the top of the chain to ensure the order of the rules.
+func ensureRulesAtTop(table, chain string, rulespecs [][]string, ipt *iptables.IPTables) error {
+	allFound := true
+
+	for _, rs := range rulespecs {
+		found, err := ipt.Exists(table, chain, rs...)
+		if err != nil {
+			return errors.Wrapf(err, "ipt.Exists(%s, %s, %s)", table, chain, rs)
+		}
+		if !found {
+			allFound = false
+			break
+		}
+	}
+
+	// All rules exist, do nothing.
+	if allFound {
+		return nil
+	}
+
+	for pos, rs := range rulespecs {
+		// If any is missing, then delete all, as we need to preserve the order of
+		// given rules. Ignore errors, as rule might not exist.
+		if !allFound {
+			ipt.Delete(table, chain, rs...)
+		}
+		if err := ipt.Insert(table, chain, pos+1, rs...); err != nil {
+			return errors.Wrapf(err, "ipt.Append(%s, %s, %s)", table, chain, rs)
+		}
+	}
+
+	return nil
+}

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -136,7 +136,7 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 						nsSelectors[dstSelector.key] = dstSelector
 						dstRuleHost = dstSelector
 					} else if peer.IPBlock != nil {
-						ipBlock := newIPBlockSpec(peer.IPBlock)
+						ipBlock := newIPBlockSpec(peer.IPBlock, ns.name)
 						ipBlocks[ipBlock.key] = ipBlock
 						dstRuleHost = ipBlock
 					}

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -25,7 +25,7 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 	rules = make(map[string]*ruleSpec)
 
 	policyTypes := []policyType{ingressPolicy}
-	targetSelector, err := newSelectorSpec(&policy.Spec.PodSelector, true, policyTypes, ns.name, ipset.HashIP)
+	targetSelector, err := newSelectorSpec(&policy.Spec.PodSelector, policyTypes, ns.name, ipset.HashIP)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -62,14 +62,14 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 			for _, peer := range ingressRule.From {
 				var srcSelector *selectorSpec
 				if peer.PodSelector != nil {
-					srcSelector, err = newSelectorSpec(peer.PodSelector, false, nil, ns.name, ipset.HashIP)
+					srcSelector, err = newSelectorSpec(peer.PodSelector, nil, ns.name, ipset.HashIP)
 					if err != nil {
 						return nil, nil, nil, err
 					}
 					podSelectors[srcSelector.key] = srcSelector
 				}
 				if peer.NamespaceSelector != nil {
-					srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, nil, "", ipset.ListSet)
+					srcSelector, err = newSelectorSpec(peer.NamespaceSelector, nil, "", ipset.ListSet)
 					if err != nil {
 						return nil, nil, nil, err
 					}
@@ -114,7 +114,7 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 		}
 	}
 	// If empty, matches all pods in a namespace
-	targetSelector, err := newSelectorSpec(&policy.Spec.PodSelector, true, policyTypes, ns.name, ipset.HashIP)
+	targetSelector, err := newSelectorSpec(&policy.Spec.PodSelector, policyTypes, ns.name, ipset.HashIP)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -150,14 +150,14 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 					// NetworkPolicyPeer describes a peer to allow traffic from.
 					// Exactly one of its fields must be specified.
 					if peer.PodSelector != nil {
-						srcSelector, err = newSelectorSpec(peer.PodSelector, false, nil, ns.name, ipset.HashIP)
+						srcSelector, err = newSelectorSpec(peer.PodSelector, nil, ns.name, ipset.HashIP)
 						if err != nil {
 							return nil, nil, nil, err
 						}
 						addIfNotExist(srcSelector, podSelectors)
 
 					} else if peer.NamespaceSelector != nil {
-						srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, nil, "", ipset.ListSet)
+						srcSelector, err = newSelectorSpec(peer.NamespaceSelector, nil, "", ipset.ListSet)
 						if err != nil {
 							return nil, nil, nil, err
 						}
@@ -203,14 +203,14 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 					// NetworkPolicyPeer describes a peer to allow traffic from.
 					// Exactly one of its fields must be specified.
 					if peer.PodSelector != nil {
-						dstSelector, err = newSelectorSpec(peer.PodSelector, false, nil, ns.name, ipset.HashIP)
+						dstSelector, err = newSelectorSpec(peer.PodSelector, nil, ns.name, ipset.HashIP)
 						if err != nil {
 							return nil, nil, nil, err
 						}
 						addIfNotExist(dstSelector, podSelectors)
 
 					} else if peer.NamespaceSelector != nil {
-						dstSelector, err = newSelectorSpec(peer.NamespaceSelector, false, nil, "", ipset.ListSet)
+						dstSelector, err = newSelectorSpec(peer.NamespaceSelector, nil, "", ipset.ListSet)
 						if err != nil {
 							return nil, nil, nil, err
 						}

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -45,13 +45,13 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 			// From is not provided, this rule matches all sources (traffic not restricted by source).
 			if ingressRule.Ports == nil {
 				// Ports is not provided, this rule matches all ports (traffic not restricted by port).
-				rule := newRuleSpec(nil, nil, dstSelector, nil)
+				rule := newRuleSpec(ingress, nil, nil, dstSelector, nil)
 				rules[rule.key] = rule
 			} else {
 				// Ports is present and contains at least one item, then this rule allows traffic
 				// only if the traffic matches at least one port in the ports list.
 				withNormalisedProtoAndPortLegacy(ingressRule.Ports, func(proto, port string) {
-					rule := newRuleSpec(&proto, nil, dstSelector, &port)
+					rule := newRuleSpec(ingress, &proto, nil, dstSelector, &port)
 					rules[rule.key] = rule
 				})
 			}
@@ -77,13 +77,13 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 
 				if ingressRule.Ports == nil {
 					// Ports is not provided, this rule matches all ports (traffic not restricted by port).
-					rule := newRuleSpec(nil, srcSelector, dstSelector, nil)
+					rule := newRuleSpec(ingress, nil, srcSelector, dstSelector, nil)
 					rules[rule.key] = rule
 				} else {
 					// Ports is present and contains at least one item, then this rule allows traffic
 					// only if the traffic matches at least one port in the ports list.
 					withNormalisedProtoAndPortLegacy(ingressRule.Ports, func(proto, port string) {
-						rule := newRuleSpec(&proto, srcSelector, dstSelector, &port)
+						rule := newRuleSpec(ingress, &proto, srcSelector, dstSelector, &port)
 						rules[rule.key] = rule
 					})
 				}
@@ -128,11 +128,11 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 
 		if allSources {
 			if allPorts {
-				rule := newRuleSpec(nil, nil, dstSelector, nil)
+				rule := newRuleSpec(ingress, nil, nil, dstSelector, nil)
 				rules[rule.key] = rule
 			} else {
 				withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
-					rule := newRuleSpec(&proto, nil, dstSelector, &port)
+					rule := newRuleSpec(ingress, &proto, nil, dstSelector, &port)
 					rules[rule.key] = rule
 				})
 			}
@@ -158,11 +158,11 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 				}
 
 				if allPorts {
-					rule := newRuleSpec(nil, srcSelector, dstSelector, nil)
+					rule := newRuleSpec(ingress, nil, srcSelector, dstSelector, nil)
 					rules[rule.key] = rule
 				} else {
 					withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
-						rule := newRuleSpec(&proto, srcSelector, dstSelector, &port)
+						rule := newRuleSpec(ingress, &proto, srcSelector, dstSelector, &port)
 						rules[rule.key] = rule
 					})
 				}

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -125,56 +125,108 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 	// an invalid content of the "default-allow" ipset.
 	addIfNotExist(dstSelector, podSelectors)
 
-	// If ingress is empty then this NetworkPolicy does not allow any traffic
-	if policy.Spec.Ingress == nil || len(policy.Spec.Ingress) == 0 {
-		return
-	}
+	// If ingress is empty then this NetworkPolicy does not allow any ingress traffic
+	if policy.Spec.Ingress != nil && len(policy.Spec.Ingress) != 0 {
+		for _, ingressRule := range policy.Spec.Ingress {
+			// If Ports is empty or missing, this rule matches all ports
+			allPorts := ingressRule.Ports == nil || len(ingressRule.Ports) == 0
+			// If From is empty or missing, this rule matches all sources
+			allSources := ingressRule.From == nil || len(ingressRule.From) == 0
 
-	for _, ingressRule := range policy.Spec.Ingress {
-		// If Ports is empty or missing, this rule matches all ports
-		allPorts := ingressRule.Ports == nil || len(ingressRule.Ports) == 0
-		// If From is empty or missing, this rule matches all sources
-		allSources := ingressRule.From == nil || len(ingressRule.From) == 0
-
-		if allSources {
-			if allPorts {
-				rule := newRuleSpec(ingressPolicy, nil, nil, dstSelector, nil)
-				rules[rule.key] = rule
-			} else {
-				withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
-					rule := newRuleSpec(ingressPolicy, &proto, nil, dstSelector, &port)
-					rules[rule.key] = rule
-				})
-			}
-		} else {
-			for _, peer := range ingressRule.From {
-				var srcSelector *selectorSpec
-
-				// NetworkPolicyPeer describes a peer to allow traffic from.
-				// Exactly one of its fields must be specified.
-				if peer.PodSelector != nil {
-					srcSelector, err = newSelectorSpec(peer.PodSelector, false, nil, ns.name, ipset.HashIP)
-					if err != nil {
-						return nil, nil, nil, err
-					}
-					addIfNotExist(srcSelector, podSelectors)
-
-				} else if peer.NamespaceSelector != nil {
-					srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, nil, "", ipset.ListSet)
-					if err != nil {
-						return nil, nil, nil, err
-					}
-					nsSelectors[srcSelector.key] = srcSelector
-				}
-
+			if allSources {
 				if allPorts {
-					rule := newRuleSpec(ingressPolicy, nil, srcSelector, dstSelector, nil)
+					rule := newRuleSpec(ingressPolicy, nil, nil, dstSelector, nil)
 					rules[rule.key] = rule
 				} else {
 					withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
-						rule := newRuleSpec(ingressPolicy, &proto, srcSelector, dstSelector, &port)
+						rule := newRuleSpec(ingressPolicy, &proto, nil, dstSelector, &port)
 						rules[rule.key] = rule
 					})
+				}
+			} else {
+				for _, peer := range ingressRule.From {
+					var srcSelector *selectorSpec
+
+					// NetworkPolicyPeer describes a peer to allow traffic from.
+					// Exactly one of its fields must be specified.
+					if peer.PodSelector != nil {
+						srcSelector, err = newSelectorSpec(peer.PodSelector, false, nil, ns.name, ipset.HashIP)
+						if err != nil {
+							return nil, nil, nil, err
+						}
+						addIfNotExist(srcSelector, podSelectors)
+
+					} else if peer.NamespaceSelector != nil {
+						srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, nil, "", ipset.ListSet)
+						if err != nil {
+							return nil, nil, nil, err
+						}
+						nsSelectors[srcSelector.key] = srcSelector
+					}
+
+					if allPorts {
+						rule := newRuleSpec(ingressPolicy, nil, srcSelector, dstSelector, nil)
+						rules[rule.key] = rule
+					} else {
+						withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
+							rule := newRuleSpec(ingressPolicy, &proto, srcSelector, dstSelector, &port)
+							rules[rule.key] = rule
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// If egress is empty then this NetworkPolicy does not allow any egress traffic
+	if policy.Spec.Egress != nil && len(policy.Spec.Egress) != 0 {
+		for _, egressRule := range policy.Spec.Egress {
+			// If Ports is empty or missing, this rule matches all ports
+			allPorts := egressRule.Ports == nil || len(egressRule.Ports) == 0
+			// If To is empty or missing, this rule matches all destinations
+			allDestinations := egressRule.To == nil || len(egressRule.To) == 0
+
+			if allDestinations {
+				if allPorts {
+					rule := newRuleSpec(egressPolicy, nil, dstSelector, nil, nil)
+					rules[rule.key] = rule
+				} else {
+					withNormalisedProtoAndPort(egressRule.Ports, func(proto, port string) {
+						rule := newRuleSpec(egressPolicy, &proto, dstSelector, nil, &port)
+						rules[rule.key] = rule
+					})
+				}
+			} else {
+				for _, peer := range egressRule.To {
+					// TODO(brb) s/selector/dstSelector/ after s/dstSelector/targetSelector/
+					var selector *selectorSpec
+
+					// NetworkPolicyPeer describes a peer to allow traffic from.
+					// Exactly one of its fields must be specified.
+					if peer.PodSelector != nil {
+						selector, err = newSelectorSpec(peer.PodSelector, false, nil, ns.name, ipset.HashIP)
+						if err != nil {
+							return nil, nil, nil, err
+						}
+						addIfNotExist(selector, podSelectors)
+
+					} else if peer.NamespaceSelector != nil {
+						selector, err = newSelectorSpec(peer.NamespaceSelector, false, nil, "", ipset.ListSet)
+						if err != nil {
+							return nil, nil, nil, err
+						}
+						nsSelectors[selector.key] = selector
+					}
+
+					if allPorts {
+						rule := newRuleSpec(egressPolicy, nil, dstSelector, selector, nil)
+						rules[rule.key] = rule
+					} else {
+						withNormalisedProtoAndPort(egressRule.Ports, func(proto, port string) {
+							rule := newRuleSpec(egressPolicy, &proto, dstSelector, selector, &port)
+							rules[rule.key] = rule
+						})
+					}
 				}
 			}
 		}

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -24,7 +24,8 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 	podSelectors = make(map[string]*selectorSpec)
 	rules = make(map[string]*ruleSpec)
 
-	dstSelector, err := newSelectorSpec(&policy.Spec.PodSelector, true, ns.name, ipset.HashIP)
+	policyTypes := []policyType{ingressPolicy}
+	dstSelector, err := newSelectorSpec(&policy.Spec.PodSelector, true, policyTypes, ns.name, ipset.HashIP)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -61,14 +62,14 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 			for _, peer := range ingressRule.From {
 				var srcSelector *selectorSpec
 				if peer.PodSelector != nil {
-					srcSelector, err = newSelectorSpec(peer.PodSelector, false, ns.name, ipset.HashIP)
+					srcSelector, err = newSelectorSpec(peer.PodSelector, false, nil, ns.name, ipset.HashIP)
 					if err != nil {
 						return nil, nil, nil, err
 					}
 					podSelectors[srcSelector.key] = srcSelector
 				}
 				if peer.NamespaceSelector != nil {
-					srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, "", ipset.ListSet)
+					srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, nil, "", ipset.ListSet)
 					if err != nil {
 						return nil, nil, nil, err
 					}
@@ -104,7 +105,8 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 	rules = make(map[string]*ruleSpec)
 
 	// If empty, matches all pods in a namespace
-	dstSelector, err := newSelectorSpec(&policy.Spec.PodSelector, true, ns.name, ipset.HashIP)
+	policyTypes := []policyType{ingressPolicy}
+	dstSelector, err := newSelectorSpec(&policy.Spec.PodSelector, true, policyTypes, ns.name, ipset.HashIP)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -143,14 +145,14 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 				// NetworkPolicyPeer describes a peer to allow traffic from.
 				// Exactly one of its fields must be specified.
 				if peer.PodSelector != nil {
-					srcSelector, err = newSelectorSpec(peer.PodSelector, false, ns.name, ipset.HashIP)
+					srcSelector, err = newSelectorSpec(peer.PodSelector, false, nil, ns.name, ipset.HashIP)
 					if err != nil {
 						return nil, nil, nil, err
 					}
 					addIfNotExist(srcSelector, podSelectors)
 
 				} else if peer.NamespaceSelector != nil {
-					srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, "", ipset.ListSet)
+					srcSelector, err = newSelectorSpec(peer.NamespaceSelector, false, nil, "", ipset.ListSet)
 					if err != nil {
 						return nil, nil, nil, err
 					}

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -103,9 +103,17 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 	nsSelectors = make(map[string]*selectorSpec)
 	podSelectors = make(map[string]*selectorSpec)
 	rules = make(map[string]*ruleSpec)
+	policyTypes := make([]policyType, 0)
 
+	for _, pt := range policy.Spec.PolicyTypes {
+		if pt == networkingv1.PolicyTypeIngress {
+			policyTypes = append(policyTypes, ingressPolicy)
+		}
+		if pt == networkingv1.PolicyTypeEgress {
+			policyTypes = append(policyTypes, egressPolicy)
+		}
+	}
 	// If empty, matches all pods in a namespace
-	policyTypes := []policyType{ingressPolicy}
 	dstSelector, err := newSelectorSpec(&policy.Spec.PodSelector, true, policyTypes, ns.name, ipset.HashIP)
 	if err != nil {
 		return nil, nil, nil, err

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -46,13 +46,13 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 			// From is not provided, this rule matches all sources (traffic not restricted by source).
 			if ingressRule.Ports == nil {
 				// Ports is not provided, this rule matches all ports (traffic not restricted by port).
-				rule := newRuleSpec(ingress, nil, nil, dstSelector, nil)
+				rule := newRuleSpec(ingressPolicy, nil, nil, dstSelector, nil)
 				rules[rule.key] = rule
 			} else {
 				// Ports is present and contains at least one item, then this rule allows traffic
 				// only if the traffic matches at least one port in the ports list.
 				withNormalisedProtoAndPortLegacy(ingressRule.Ports, func(proto, port string) {
-					rule := newRuleSpec(ingress, &proto, nil, dstSelector, &port)
+					rule := newRuleSpec(ingressPolicy, &proto, nil, dstSelector, &port)
 					rules[rule.key] = rule
 				})
 			}
@@ -78,13 +78,13 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 
 				if ingressRule.Ports == nil {
 					// Ports is not provided, this rule matches all ports (traffic not restricted by port).
-					rule := newRuleSpec(ingress, nil, srcSelector, dstSelector, nil)
+					rule := newRuleSpec(ingressPolicy, nil, srcSelector, dstSelector, nil)
 					rules[rule.key] = rule
 				} else {
 					// Ports is present and contains at least one item, then this rule allows traffic
 					// only if the traffic matches at least one port in the ports list.
 					withNormalisedProtoAndPortLegacy(ingressRule.Ports, func(proto, port string) {
-						rule := newRuleSpec(ingress, &proto, srcSelector, dstSelector, &port)
+						rule := newRuleSpec(ingressPolicy, &proto, srcSelector, dstSelector, &port)
 						rules[rule.key] = rule
 					})
 				}
@@ -138,11 +138,11 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 
 		if allSources {
 			if allPorts {
-				rule := newRuleSpec(ingress, nil, nil, dstSelector, nil)
+				rule := newRuleSpec(ingressPolicy, nil, nil, dstSelector, nil)
 				rules[rule.key] = rule
 			} else {
 				withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
-					rule := newRuleSpec(ingress, &proto, nil, dstSelector, &port)
+					rule := newRuleSpec(ingressPolicy, &proto, nil, dstSelector, &port)
 					rules[rule.key] = rule
 				})
 			}
@@ -168,11 +168,11 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 				}
 
 				if allPorts {
-					rule := newRuleSpec(ingress, nil, srcSelector, dstSelector, nil)
+					rule := newRuleSpec(ingressPolicy, nil, srcSelector, dstSelector, nil)
 					rules[rule.key] = rule
 				} else {
 					withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
-						rule := newRuleSpec(ingress, &proto, srcSelector, dstSelector, &port)
+						rule := newRuleSpec(ingressPolicy, &proto, srcSelector, dstSelector, &port)
 						rules[rule.key] = rule
 					})
 				}

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -38,8 +38,8 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 
 	// To prevent targetSelector being overwritten by a subsequent selector with
 	// the same key, addIfNotExist MUST be used when adding to podSelectors.
-	// Otherwise, targetSelector' "dst" property might be lost resulting in
-	// an invalid content of the "default-allow" ipset.
+	// Otherwise, policyTypes of the selector might be lost resulting in
+	// an invalid content in any "default-allow" ipset.
 	addIfNotExist(targetSelector, podSelectors)
 
 	// If ingress is empty then this NetworkPolicy does not allow any ingress traffic
@@ -118,7 +118,7 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 					var dstSelector *selectorSpec
 					var dstRuleHost ruleHost
 
-					// NetworkPolicyPeer describes a peer to allow traffic from.
+					// NetworkPolicyPeer describes a peer to allow traffic to.
 					// Exactly one of its fields must be specified.
 					if peer.PodSelector != nil {
 						dstSelector, err = newSelectorSpec(peer.PodSelector, nil, ns.name, ipset.HashIP)

--- a/npc/analyser.go
+++ b/npc/analyser.go
@@ -24,7 +24,7 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 	podSelectors = make(map[string]*selectorSpec)
 	rules = make(map[string]*ruleSpec)
 
-	policyTypes := []policyType{ingressPolicy}
+	policyTypes := []policyType{policyTypeIngress}
 	targetSelector, err := newSelectorSpec(&policy.Spec.PodSelector, policyTypes, ns.name, ipset.HashIP)
 	if err != nil {
 		return nil, nil, nil, err
@@ -46,13 +46,13 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 			// From is not provided, this rule matches all sources (traffic not restricted by source).
 			if ingressRule.Ports == nil {
 				// Ports is not provided, this rule matches all ports (traffic not restricted by port).
-				rule := newRuleSpec(ingressPolicy, nil, nil, targetSelector, nil)
+				rule := newRuleSpec(policyTypeIngress, nil, nil, targetSelector, nil)
 				rules[rule.key] = rule
 			} else {
 				// Ports is present and contains at least one item, then this rule allows traffic
 				// only if the traffic matches at least one port in the ports list.
 				withNormalisedProtoAndPortLegacy(ingressRule.Ports, func(proto, port string) {
-					rule := newRuleSpec(ingressPolicy, &proto, nil, targetSelector, &port)
+					rule := newRuleSpec(policyTypeIngress, &proto, nil, targetSelector, &port)
 					rules[rule.key] = rule
 				})
 			}
@@ -78,13 +78,13 @@ func (ns *ns) analysePolicyLegacy(policy *extnapi.NetworkPolicy) (
 
 				if ingressRule.Ports == nil {
 					// Ports is not provided, this rule matches all ports (traffic not restricted by port).
-					rule := newRuleSpec(ingressPolicy, nil, srcSelector, targetSelector, nil)
+					rule := newRuleSpec(policyTypeIngress, nil, srcSelector, targetSelector, nil)
 					rules[rule.key] = rule
 				} else {
 					// Ports is present and contains at least one item, then this rule allows traffic
 					// only if the traffic matches at least one port in the ports list.
 					withNormalisedProtoAndPortLegacy(ingressRule.Ports, func(proto, port string) {
-						rule := newRuleSpec(ingressPolicy, &proto, srcSelector, targetSelector, &port)
+						rule := newRuleSpec(policyTypeIngress, &proto, srcSelector, targetSelector, &port)
 						rules[rule.key] = rule
 					})
 				}
@@ -109,10 +109,10 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 
 	for _, pt := range policy.Spec.PolicyTypes {
 		if pt == networkingv1.PolicyTypeIngress {
-			policyTypes = append(policyTypes, ingressPolicy)
+			policyTypes = append(policyTypes, policyTypeIngress)
 		}
 		if pt == networkingv1.PolicyTypeEgress {
-			policyTypes = append(policyTypes, egressPolicy)
+			policyTypes = append(policyTypes, policyTypeEgress)
 		}
 	}
 	// If empty, matches all pods in a namespace
@@ -137,11 +137,11 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 
 			if allSources {
 				if allPorts {
-					rule := newRuleSpec(ingressPolicy, nil, nil, targetSelector, nil)
+					rule := newRuleSpec(policyTypeIngress, nil, nil, targetSelector, nil)
 					rules[rule.key] = rule
 				} else {
 					withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
-						rule := newRuleSpec(ingressPolicy, &proto, nil, targetSelector, &port)
+						rule := newRuleSpec(policyTypeIngress, &proto, nil, targetSelector, &port)
 						rules[rule.key] = rule
 					})
 				}
@@ -167,11 +167,11 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 					}
 
 					if allPorts {
-						rule := newRuleSpec(ingressPolicy, nil, srcSelector, targetSelector, nil)
+						rule := newRuleSpec(policyTypeIngress, nil, srcSelector, targetSelector, nil)
 						rules[rule.key] = rule
 					} else {
 						withNormalisedProtoAndPort(ingressRule.Ports, func(proto, port string) {
-							rule := newRuleSpec(ingressPolicy, &proto, srcSelector, targetSelector, &port)
+							rule := newRuleSpec(policyTypeIngress, &proto, srcSelector, targetSelector, &port)
 							rules[rule.key] = rule
 						})
 					}
@@ -190,11 +190,11 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 
 			if allDestinations {
 				if allPorts {
-					rule := newRuleSpec(egressPolicy, nil, targetSelector, nil, nil)
+					rule := newRuleSpec(policyTypeEgress, nil, targetSelector, nil, nil)
 					rules[rule.key] = rule
 				} else {
 					withNormalisedProtoAndPort(egressRule.Ports, func(proto, port string) {
-						rule := newRuleSpec(egressPolicy, &proto, targetSelector, nil, &port)
+						rule := newRuleSpec(policyTypeEgress, &proto, targetSelector, nil, &port)
 						rules[rule.key] = rule
 					})
 				}
@@ -227,11 +227,11 @@ func (ns *ns) analysePolicy(policy *networkingv1.NetworkPolicy) (
 					}
 
 					if allPorts {
-						rule := newRuleSpec(egressPolicy, nil, targetSelector, dstRuleHost, nil)
+						rule := newRuleSpec(policyTypeEgress, nil, targetSelector, dstRuleHost, nil)
 						rules[rule.key] = rule
 					} else {
 						withNormalisedProtoAndPort(egressRule.Ports, func(proto, port string) {
-							rule := newRuleSpec(egressPolicy, &proto, targetSelector, dstRuleHost, &port)
+							rule := newRuleSpec(policyTypeEgress, &proto, targetSelector, dstRuleHost, &port)
 							rules[rule.key] = rule
 						})
 					}

--- a/npc/constants.go
+++ b/npc/constants.go
@@ -10,6 +10,7 @@ const (
 	EgressChain        = "WEAVE-NPC-EGRESS"
 	EgressDefaultChain = "WEAVE-NPC-EGRESS-DEFAULT"
 	EgressCustomChain  = "WEAVE-NPC-EGRESS-CUSTOM"
+	EgressMarkChain    = "WEAVE-NPC-EGRESS-ACCEPT"
 	EgressMark         = "0x40000/0x40000"
 
 	IpsetNamePrefix = "weave-"

--- a/npc/constants.go
+++ b/npc/constants.go
@@ -7,6 +7,11 @@ const (
 	DefaultChain = "WEAVE-NPC-DEFAULT"
 	IngressChain = "WEAVE-NPC-INGRESS"
 
+	EgressChain        = "WEAVE-NPC-EGRESS"
+	EgressDefaultChain = "WEAVE-NPC-EGRESS-DEFAULT"
+	EgressCustomChain  = "WEAVE-NPC-EGRESS-CUSTOM"
+	EgressMark         = "0x40000/0x40000"
+
 	IpsetNamePrefix = "weave-"
 
 	LocalIpset = IpsetNamePrefix + "local-pods"

--- a/npc/controller.go
+++ b/npc/controller.go
@@ -49,7 +49,7 @@ func New(nodeName string, legacy bool, ipt iptables.Interface, ips ipset.Interfa
 		ips:      ips,
 		nss:      make(map[string]*ns)}
 
-	doNothing := func(*selector) error { return nil }
+	doNothing := func(*selector, policyType) error { return nil }
 	c.nsSelectors = newSelectorSet(ips, c.onNewNsSelector, doNothing, doNothing)
 
 	return c

--- a/npc/controller.go
+++ b/npc/controller.go
@@ -37,14 +37,11 @@ type controller struct {
 
 	nss         map[string]*ns // ns name -> ns struct
 	nsSelectors *selectorSet   // selector string -> nsSelector
-
-	legacy bool // use legacy network policy semantics (k8s pre-1.7)
 }
 
-func New(nodeName string, legacy bool, ipt iptables.Interface, ips ipset.Interface) NetworkPolicyController {
+func New(nodeName string, ipt iptables.Interface, ips ipset.Interface) NetworkPolicyController {
 	c := &controller{
 		nodeName: nodeName,
-		legacy:   legacy,
 		ipt:      ipt,
 		ips:      ips,
 		nss:      make(map[string]*ns)}
@@ -71,7 +68,7 @@ func (npc *controller) onNewNsSelector(selector *selector) error {
 func (npc *controller) withNS(name string, f func(ns *ns) error) error {
 	ns, found := npc.nss[name]
 	if !found {
-		newNs, err := newNS(name, npc.nodeName, npc.legacy, npc.ipt, npc.ips, npc.nsSelectors)
+		newNs, err := newNS(name, npc.nodeName, npc.ipt, npc.ips, npc.nsSelectors)
 		if err != nil {
 			return err
 		}

--- a/npc/controller_test.go
+++ b/npc/controller_test.go
@@ -386,7 +386,7 @@ func TestOutOfOrderPodEvents(t *testing.T) {
 }
 
 // Test case for https://github.com/weaveworks/weave/issues/3222
-func TestNewDstSelector(t *testing.T) {
+func TestNewTargetSelector(t *testing.T) {
 	const (
 		ingressDefaultAllowIPSetName = "weave-;rGqyMIl1HN^cfDki~Z$3]6!N"
 		podIP                        = "10.32.0.10"
@@ -431,7 +431,7 @@ func TestNewDstSelector(t *testing.T) {
 	}
 	controller.AddNetworkPolicy(netpolBar)
 
-	// netpolBar dst selector selects podFoo
+	// netpolBar target selector selects podFoo
 	require.False(t, m.entryExists(ingressDefaultAllowIPSetName, podIP))
 
 	netpolFoo := &networkingv1.NetworkPolicy{
@@ -453,9 +453,9 @@ func TestNewDstSelector(t *testing.T) {
 	controller.AddNetworkPolicy(netpolFoo)
 
 	controller.DeleteNetworkPolicy(netpolBar)
-	// netpolFoo dst-selects podFoo
+	// netpolFoo target-selects podFoo
 	require.False(t, m.entryExists(ingressDefaultAllowIPSetName, podIP))
 	controller.DeleteNetworkPolicy(netpolFoo)
-	// No netpol dst-selects podFoo
+	// No netpol target-selects podFoo
 	require.True(t, m.entryExists(ingressDefaultAllowIPSetName, podIP))
 }

--- a/npc/controller_test.go
+++ b/npc/controller_test.go
@@ -144,6 +144,7 @@ func TestRegressionPolicyNamespaceOrdering3059(t *testing.T) {
 			Namespace: "destination",
 		},
 		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{
 				{
 					From: []networkingv1.NetworkPolicyPeer{
@@ -249,6 +250,7 @@ func TestDefaultAllow(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"run": "foo"}},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
@@ -299,7 +301,6 @@ func TestDefaultAllow(t *testing.T) {
 	controller.DeleteNamespace(defaultNamespace)
 	// Should remove default ipset
 	require.NotContains(t, m.sets, ingressDefaultAllowIPSetName)
-
 }
 
 func TestOutOfOrderPodEvents(t *testing.T) {
@@ -337,6 +338,7 @@ func TestOutOfOrderPodEvents(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"run": "foo"}},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
@@ -418,6 +420,7 @@ func TestNewDstSelector(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			PodSelector: metav1.LabelSelector{},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{
@@ -438,6 +441,7 @@ func TestNewDstSelector(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: networkingv1.NetworkPolicySpec{
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			PodSelector: metav1.LabelSelector{},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
 				From: []networkingv1.NetworkPolicyPeer{{

--- a/npc/controller_test.go
+++ b/npc/controller_test.go
@@ -236,6 +236,7 @@ func TestDefaultAllow(t *testing.T) {
 		Status: coreapi.PodStatus{PodIP: barPodIP}}
 	podBarNoIP := &coreapi.Pod{ObjectMeta: podBar.ObjectMeta}
 	controller.AddPod(podBarNoIP)
+
 	controller.UpdatePod(podBarNoIP, podBar)
 
 	// Should add the bar pod to default-allow

--- a/npc/controller_test.go
+++ b/npc/controller_test.go
@@ -198,7 +198,7 @@ func TestRegressionPolicyNamespaceOrdering3059(t *testing.T) {
 
 	// Namespaces first
 	m := newMockIPSet()
-	controller := New("foo", false, newMockIPTables(), &m)
+	controller := New("foo", newMockIPTables(), &m)
 
 	const (
 		selectorIPSetName = "weave-I239Zp%sCvoVt*D6u=A!2]YEk"
@@ -214,7 +214,7 @@ func TestRegressionPolicyNamespaceOrdering3059(t *testing.T) {
 
 	// NetworkPolicy first
 	m = newMockIPSet()
-	controller = New("foo", false, newMockIPTables(), &m)
+	controller = New("foo", newMockIPTables(), &m)
 
 	controller.AddNetworkPolicy(networkPolicy)
 
@@ -224,7 +224,7 @@ func TestRegressionPolicyNamespaceOrdering3059(t *testing.T) {
 	require.Equal(t, true, len(m.sets[selectorIPSetName].subSets[sourceIPSetName]) > 0)
 }
 
-// Tests default-allow ipset behavior when running in non-legacy mode.
+// Tests default-allow ipset behavior
 func TestDefaultAllow(t *testing.T) {
 	const (
 		ingressDefaultAllowIPSetName = "weave-;rGqyMIl1HN^cfDki~Z$3]6!N"
@@ -235,7 +235,7 @@ func TestDefaultAllow(t *testing.T) {
 	)
 
 	m := newMockIPSet()
-	controller := New("bar", false, newMockIPTables(), &m)
+	controller := New("bar", newMockIPTables(), &m)
 
 	defaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -363,7 +363,7 @@ func TestOutOfOrderPodEvents(t *testing.T) {
 	)
 
 	m := newMockIPSet()
-	controller := New("qux", false, newMockIPTables(), &m)
+	controller := New("qux", newMockIPTables(), &m)
 
 	defaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -445,7 +445,7 @@ func TestNewTargetSelector(t *testing.T) {
 	)
 
 	m := newMockIPSet()
-	controller := New("baz", false, newMockIPTables(), &m)
+	controller := New("baz", newMockIPTables(), &m)
 
 	defaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -520,7 +520,7 @@ func TestEgressPolicyWithIPBlock(t *testing.T) {
 
 	m := newMockIPSet()
 	ipt := newMockIPTables()
-	controller := New("foo", false, ipt, &m)
+	controller := New("foo", ipt, &m)
 
 	netpol := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/npc/ipblock.go
+++ b/npc/ipblock.go
@@ -16,15 +16,16 @@ type ipBlockSpec struct {
 	key       string
 	ipsetName ipset.Name // ipset for storing excepted CIDRs
 	ipBlock   *networkingv1.IPBlock
+	nsName    string // Namespace name
 }
 
-func newIPBlockSpec(ipb *networkingv1.IPBlock) *ipBlockSpec {
-	spec := &ipBlockSpec{ipBlock: ipb}
+func newIPBlockSpec(ipb *networkingv1.IPBlock, nsName string) *ipBlockSpec {
+	spec := &ipBlockSpec{ipBlock: ipb, nsName: nsName}
 
 	if len(ipb.Except) > 0 {
 		sort.Strings(ipb.Except)
 		spec.key = strings.Join(ipb.Except, " ")
-		spec.ipsetName = ipset.Name(IpsetNamePrefix + shortName("ipblock-except:"+spec.key))
+		spec.ipsetName = ipset.Name(IpsetNamePrefix + shortName(nsName+":"+"ipblock-except:"+spec.key))
 	}
 
 	return spec

--- a/npc/ipblock.go
+++ b/npc/ipblock.go
@@ -1,0 +1,120 @@
+package npc
+
+import (
+	"github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/npc/ipset"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net"
+	"sort"
+	"strings"
+)
+
+type ipBlock struct {
+	ipsetName ipset.Name // generated ipset name
+	spec      *networkingv1.IPBlock
+}
+
+func newIPBlock(ipb *networkingv1.IPBlock, ns string) (b *ipBlock, err error) {
+	if _, _, err = net.ParseCIDR(ipb.CIDR); err != nil {
+		return
+	}
+
+	for _, ex := range ipb.Except {
+		if _, _, err = net.ParseCIDR(ex); err != nil {
+			return
+		}
+	}
+
+	b = &ipBlock{spec: ipb}
+
+	if len(ipb.Except) > 0 {
+		sortedExcept := ipb.Except
+		sort.Strings(sortedExcept)
+		b.ipsetName = ipset.Name(IpsetNamePrefix + shortName("except:"+strings.Join(sortedExcept, "")))
+	}
+
+	return
+}
+
+//func (ipb ipBlock) GetRuleSpec() (spec *ruleSpec) {
+//	spec = &ruleSpec{
+//		chain: IngressIPBlockChain,
+//	}
+//
+//	if len(ipb.spec.Except) == 0 {
+//		spec.args = append(spec.args, "-s", ipb.spec.CIDR)
+//		spec.comment = fmt.Sprintf("cidr: %s", ipb.spec.CIDR)
+//	} else {
+//		spec.args = append(spec.args, "-s", ipb.spec.CIDR, "-m", "set", "!", "--match-set",
+//			string(ipb.ipsetName), "src")
+//		spec.comment = fmt.Sprintf("cidr: %s except [%s]", ipb.spec.CIDR,
+//			strings.Join(ipb.spec.Except, `,`))
+//	}
+//	return
+//}
+
+type ipBlockSet struct {
+	ips   ipset.Interface
+	users map[string]int
+}
+
+func newIPBlockSet(ips ipset.Interface) *ipBlockSet {
+	return &ipBlockSet{
+		ips:   ips,
+		users: make(map[string]int),
+	}
+}
+
+func (s *ipBlockSet) deprovision(uid types.UID, current *ipBlock) (err error) {
+	if current == nil || len(current.ipsetName) == 0 {
+		return
+	}
+
+	key := string(current.ipsetName)
+	if _, found := s.users[key]; !found {
+		return
+	}
+
+	s.users[key]--
+	if s.users[key] == 0 {
+		if err = s.ips.Destroy(current.ipsetName); err != nil {
+			return
+		}
+
+		delete(s.users, key)
+	}
+
+	return
+}
+
+func (s *ipBlockSet) provision(uid types.UID, desired *ipBlock) (err error) {
+	if desired == nil || len(desired.ipsetName) == 0 {
+		return
+	}
+
+	key := string(desired.ipsetName)
+	if _, found := s.users[key]; found {
+		common.Log.Debug()
+		s.users[key]++
+		return
+	}
+
+	err = s.ips.Create(desired.ipsetName, ipset.HashNet)
+	if err != nil {
+		return
+	}
+
+	comment := `excepted from ` + desired.spec.CIDR
+	for _, excepted := range desired.spec.Except {
+		if err = s.ips.AddEntry(uid, desired.ipsetName, excepted, comment); err != nil {
+			if details := s.ips.Destroy(desired.ipsetName); details != nil {
+				common.Log.Warn("can't destroy ipset ", desired.ipsetName, ":", details)
+			}
+			return
+		}
+	}
+
+	s.users[key] = 1
+	return
+}

--- a/npc/ipblock.go
+++ b/npc/ipblock.go
@@ -1,40 +1,32 @@
 package npc
 
 import (
-	"github.com/weaveworks/weave/common"
-	"github.com/weaveworks/weave/npc/ipset"
-	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"net"
 	"sort"
 	"strings"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/weaveworks/weave/common"
+	"github.com/weaveworks/weave/npc/ipset"
 )
 
-type ipBlock struct {
-	ipsetName ipset.Name // generated ipset name
-	spec      *networkingv1.IPBlock
+type ipBlockSpec struct {
+	key       string
+	ipsetName ipset.Name // ipset for storing excepted CIDRs
+	ipBlock   *networkingv1.IPBlock
 }
 
-func newIPBlock(ipb *networkingv1.IPBlock, ns string) (b *ipBlock, err error) {
-	if _, _, err = net.ParseCIDR(ipb.CIDR); err != nil {
-		return
-	}
-
-	for _, ex := range ipb.Except {
-		if _, _, err = net.ParseCIDR(ex); err != nil {
-			return
-		}
-	}
-
-	b = &ipBlock{spec: ipb}
+func newIPBlockSpec(ipb *networkingv1.IPBlock) *ipBlockSpec {
+	spec := &ipBlockSpec{ipBlock: ipb}
 
 	if len(ipb.Except) > 0 {
-		sortedExcept := ipb.Except
-		sort.Strings(sortedExcept)
-		b.ipsetName = ipset.Name(IpsetNamePrefix + shortName("except:"+strings.Join(sortedExcept, "")))
+		sort.Strings(ipb.Except)
+		spec.key = strings.Join(ipb.Except, " ")
+		spec.ipsetName = ipset.Name(IpsetNamePrefix + shortName("ipblock-except:"+spec.key))
 	}
 
-	return
+	return spec
 }
 
 //func (ipb ipBlock) GetRuleSpec() (spec *ruleSpec) {
@@ -56,65 +48,66 @@ func newIPBlock(ipb *networkingv1.IPBlock, ns string) (b *ipBlock, err error) {
 
 type ipBlockSet struct {
 	ips   ipset.Interface
-	users map[string]int
+	users map[string]map[types.UID]struct{}
 }
 
 func newIPBlockSet(ips ipset.Interface) *ipBlockSet {
 	return &ipBlockSet{
 		ips:   ips,
-		users: make(map[string]int),
+		users: make(map[string]map[types.UID]struct{}),
 	}
 }
 
-func (s *ipBlockSet) deprovision(uid types.UID, current *ipBlock) (err error) {
-	if current == nil || len(current.ipsetName) == 0 {
-		return
-	}
-
-	key := string(current.ipsetName)
-	if _, found := s.users[key]; !found {
-		return
-	}
-
-	s.users[key]--
-	if s.users[key] == 0 {
-		if err = s.ips.Destroy(current.ipsetName); err != nil {
-			return
+func (s *ipBlockSet) deprovision(user types.UID, current, desired map[string]*ipBlockSpec) error {
+	for key, spec := range current {
+		if key == "" {
+			continue
 		}
 
-		delete(s.users, key)
-	}
+		if _, found := desired[key]; !found {
+			delete(s.users[key], user)
+			if len(s.users[key]) == 0 {
+				common.Log.Infof("destroying ipset: %#v", spec)
+				if err := s.ips.Destroy(spec.ipsetName); err != nil {
+					return err
+				}
 
-	return
-}
-
-func (s *ipBlockSet) provision(uid types.UID, desired *ipBlock) (err error) {
-	if desired == nil || len(desired.ipsetName) == 0 {
-		return
-	}
-
-	key := string(desired.ipsetName)
-	if _, found := s.users[key]; found {
-		common.Log.Debug()
-		s.users[key]++
-		return
-	}
-
-	err = s.ips.Create(desired.ipsetName, ipset.HashNet)
-	if err != nil {
-		return
-	}
-
-	comment := `excepted from ` + desired.spec.CIDR
-	for _, excepted := range desired.spec.Except {
-		if err = s.ips.AddEntry(uid, desired.ipsetName, excepted, comment); err != nil {
-			if details := s.ips.Destroy(desired.ipsetName); details != nil {
-				common.Log.Warn("can't destroy ipset ", desired.ipsetName, ":", details)
+				delete(s.users, key)
 			}
-			return
 		}
 	}
 
-	s.users[key] = 1
-	return
+	return nil
+}
+
+func (s *ipBlockSet) provision(user types.UID, current, desired map[string]*ipBlockSpec) (err error) {
+	for key, spec := range desired {
+		if key == "" {
+			// No need to provision an ipBlock with empty list of excepted CIDRs
+			// (i.e. no ipset is needed for the related iptables rule).
+			continue
+		}
+
+		if _, found := current[key]; !found {
+			if _, found := s.users[key]; !found {
+				common.Log.Infof("creating ipset: %#v", spec)
+				if err := s.ips.Create(spec.ipsetName, ipset.HashNet); err != nil {
+					return err
+				}
+
+				// TODO(brb) Pass comment to ips.Create instead.
+				comment := "excepted from " + spec.ipBlock.CIDR
+				for _, cidr := range spec.ipBlock.Except {
+					if err = s.ips.AddEntry(user, spec.ipsetName, cidr, comment); err != nil {
+						return err
+					}
+				}
+
+				s.users[key] = make(map[types.UID]struct{})
+			}
+			s.users[key][user] = struct{}{}
+		}
+	}
+
+	return nil
 }

--- a/npc/ipblock.go
+++ b/npc/ipblock.go
@@ -48,6 +48,10 @@ func (spec *ipBlockSpec) getRuleSpec(src bool) ([]string, string) {
 	return rule, comment
 }
 
+func (spec *ipBlockSpec) isNil() bool {
+	return spec == nil
+}
+
 type ipBlockSet struct {
 	ips   ipset.Interface
 	users map[string]map[types.UID]struct{}

--- a/npc/ipblock.go
+++ b/npc/ipblock.go
@@ -48,10 +48,6 @@ func (spec *ipBlockSpec) getRuleSpec(src bool) ([]string, string) {
 	return rule, comment
 }
 
-func (spec *ipBlockSpec) isNil() bool {
-	return spec == nil
-}
-
 type ipBlockSet struct {
 	ips   ipset.Interface
 	users map[string]map[types.UID]struct{}

--- a/npc/ipblock.go
+++ b/npc/ipblock.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/weaveworks/weave/common"
-	"github.com/weaveworks/weave/npc/ipset"
+	"github.com/weaveworks/weave/net/ipset"
 )
 
 type ipBlockSpec struct {

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -46,7 +46,7 @@ type ns struct {
 }
 
 func newNS(name, nodeName string, legacy bool, ipt iptables.Interface, ips ipset.Interface, nsSelectors *selectorSet) (*ns, error) {
-	allPods, err := newSelectorSpec(&metav1.LabelSelector{}, false, nil, name, ipset.HashIP)
+	allPods, err := newSelectorSpec(&metav1.LabelSelector{}, nil, name, ipset.HashIP)
 	if err != nil {
 		return nil, err
 	}

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -449,7 +449,7 @@ func bypassRuleIngress(nsIpsetName ipset.Name, namespace string) []string {
 
 func bypassRuleEgress(nsIpsetName ipset.Name, namespace string) [][]string {
 	return [][]string{
-		{"-m", "set", "--match-set", string(nsIpsetName), "src", "-j", "MARK", "--set-xmark", EgressMark, "-m", "comment", "--comment", "DefaultAllow isolation for namespace: " + namespace},
+		{"-m", "set", "--match-set", string(nsIpsetName), "src", "-j", EgressMarkChain, "-m", "comment", "--comment", "DefaultAllow isolation for namespace: " + namespace},
 		{"-m", "set", "--match-set", string(nsIpsetName), "src", "-j", "RETURN", "-m", "comment", "--comment", "DefaultAllow isolation for namespace: " + namespace},
 	}
 }

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -288,10 +288,10 @@ func (ns *ns) updatePod(oldObj, newObj *coreapi.Pod) error {
 			}
 
 			if !ns.legacy {
-				if err := ns.addOrRemoveToDefaultAllowIPSet(ps, oldObj, newObj, oldMatch, newMatch, ingressPolicy); err != nil {
+				if err := ns.addOrRemoveToDefaultAllowIPSet(ps, oldObj, newObj, oldMatch, newMatch, policyTypeIngress); err != nil {
 					return err
 				}
-				if err := ns.addOrRemoveToDefaultAllowIPSet(ps, oldObj, newObj, oldMatch, newMatch, egressPolicy); err != nil {
+				if err := ns.addOrRemoveToDefaultAllowIPSet(ps, oldObj, newObj, oldMatch, newMatch, policyTypeEgress); err != nil {
 					return err
 				}
 			}
@@ -645,7 +645,7 @@ func podComment(pod *coreapi.Pod) string {
 
 func (ns *ns) defaultAllowIPSetName(pt policyType) ipset.Name {
 	ipset := ns.ingressDefaultAllowIPSet
-	if pt == egressPolicy {
+	if pt == policyTypeEgress {
 		ipset = ns.egressDefaultAllowIPSet
 	}
 	return ipset

--- a/npc/rule.go
+++ b/npc/rule.go
@@ -39,8 +39,9 @@ func newRuleSpec(policyType policyType, proto *string, srcHost *selectorSpec, ds
 		args = append(args, "--dport", *dstPort)
 	}
 	args = append(args, "-j", "ACCEPT")
-	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("%s -> %s", srcComment, dstComment))
-	// TODO(brb) embed policyType into key
+	// NOTE: if you remove the comment bellow, then embed `policyType` into `key`.
+	// Otherwise, the rule won't be provisioned if it exists for other policy type.
+	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("%s -> %s (%s)", srcComment, dstComment, policyTypeStr(policyType)))
 	key := strings.Join(args, " ")
 
 	return &ruleSpec{key, args, policyType}

--- a/npc/rule.go
+++ b/npc/rule.go
@@ -55,21 +55,21 @@ func newRuleSpec(policyType policyType, proto *string, srcHost, dstHost ruleHost
 }
 
 func (spec *ruleSpec) iptChain() string {
-	if spec.policyType == egressPolicy {
+	if spec.policyType == policyTypeEgress {
 		return EgressCustomChain
 	}
 	return IngressChain
 }
 
 func (spec *ruleSpec) iptRuleSpecs() [][]string {
-	if spec.policyType == ingressPolicy {
+	if spec.policyType == policyTypeIngress {
 		rule := make([]string, len(spec.args))
 		copy(rule, spec.args)
 		rule = append(rule, "-j", "ACCEPT")
 		return [][]string{rule}
 	}
 
-	// egressPolicy
+	// policyTypeEgress
 	ruleMark := make([]string, len(spec.args))
 	copy(ruleMark, spec.args)
 	ruleMark = append(ruleMark, "-j", EgressMarkChain)

--- a/npc/rule.go
+++ b/npc/rule.go
@@ -16,6 +16,8 @@ type ruleHost interface {
 	//
 	// If src=true then the rulespec is for source, otherwise - for destination.
 	getRuleSpec(src bool) ([]string, string)
+	// TODO(brb) Get rid
+	isNil() bool
 }
 
 type ruleSpec struct {
@@ -30,13 +32,13 @@ func newRuleSpec(policyType policyType, proto *string, srcHost, dstHost ruleHost
 		args = append(args, "-p", *proto)
 	}
 	srcComment := "anywhere"
-	if srcHost != nil {
+	if srcHost != nil && !srcHost.isNil() {
 		rule, comment := srcHost.getRuleSpec(true)
 		args = append(args, rule...)
 		srcComment = comment
 	}
 	dstComment := "anywhere"
-	if dstHost != nil {
+	if dstHost != nil && !dstHost.isNil() {
 		rule, comment := dstHost.getRuleSpec(false)
 		args = append(args, rule...)
 		dstComment = comment

--- a/npc/rule.go
+++ b/npc/rule.go
@@ -2,6 +2,7 @@ package npc
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -16,8 +17,6 @@ type ruleHost interface {
 	//
 	// If src=true then the rulespec is for source, otherwise - for destination.
 	getRuleSpec(src bool) ([]string, string)
-	// TODO(brb) Get rid
-	isNil() bool
 }
 
 type ruleSpec struct {
@@ -32,13 +31,13 @@ func newRuleSpec(policyType policyType, proto *string, srcHost, dstHost ruleHost
 		args = append(args, "-p", *proto)
 	}
 	srcComment := "anywhere"
-	if srcHost != nil && !srcHost.isNil() {
+	if srcHost != nil && !reflect.ValueOf(srcHost).IsNil() {
 		rule, comment := srcHost.getRuleSpec(true)
 		args = append(args, rule...)
 		srcComment = comment
 	}
 	dstComment := "anywhere"
-	if dstHost != nil && !dstHost.isNil() {
+	if dstHost != nil && !reflect.ValueOf(dstHost).IsNil() {
 		rule, comment := dstHost.getRuleSpec(false)
 		args = append(args, rule...)
 		dstComment = comment

--- a/npc/rule.go
+++ b/npc/rule.go
@@ -10,30 +10,36 @@ import (
 	"github.com/weaveworks/weave/npc/iptables"
 )
 
+type ruleHost interface {
+	// getRuleSpec returns source or destination specification and comment which
+	// are used in an iptables rule.
+	//
+	// If src=true then the rulespec is for source, otherwise - for destination.
+	getRuleSpec(src bool) ([]string, string)
+}
+
 type ruleSpec struct {
 	key        string
 	args       []string
 	policyType policyType
 }
 
-func newRuleSpec(policyType policyType, proto *string, srcHost *selectorSpec, dstHost *selectorSpec, dstPort *string) *ruleSpec {
+func newRuleSpec(policyType policyType, proto *string, srcHost, dstHost ruleHost, dstPort *string) *ruleSpec {
 	args := []string{}
 	if proto != nil {
 		args = append(args, "-p", *proto)
 	}
 	srcComment := "anywhere"
 	if srcHost != nil {
-		args = append(args, "-m", "set", "--match-set", string(srcHost.ipsetName), "src")
-		if srcHost.nsName != "" {
-			srcComment = fmt.Sprintf("pods: namespace: %s, selector: %s", srcHost.nsName, srcHost.key)
-		} else {
-			srcComment = fmt.Sprintf("namespaces: selector: %s", srcHost.key)
-		}
+		rule, comment := srcHost.getRuleSpec(true)
+		args = append(args, rule...)
+		srcComment = comment
 	}
 	dstComment := "anywhere"
 	if dstHost != nil {
-		args = append(args, "-m", "set", "--match-set", string(dstHost.ipsetName), "dst")
-		dstComment = fmt.Sprintf("pods: namespace: %s, selector: %s", dstHost.nsName, dstHost.key)
+		rule, comment := dstHost.getRuleSpec(false)
+		args = append(args, rule...)
+		dstComment = comment
 	}
 	if dstPort != nil {
 		args = append(args, "--dport", *dstPort)

--- a/npc/rule.go
+++ b/npc/rule.go
@@ -72,7 +72,7 @@ func (spec *ruleSpec) iptRuleSpecs() [][]string {
 	// egressPolicy
 	ruleMark := make([]string, len(spec.args))
 	copy(ruleMark, spec.args)
-	ruleMark = append(ruleMark, "-j", "MARK", "--set-xmark", EgressMark)
+	ruleMark = append(ruleMark, "-j", EgressMarkChain)
 	ruleReturn := make([]string, len(spec.args))
 	copy(ruleReturn, spec.args)
 	ruleReturn = append(ruleReturn, "-j", "RETURN")

--- a/npc/rule_test.go
+++ b/npc/rule_test.go
@@ -9,7 +9,7 @@ func TestRegressionHandleNil3095(t *testing.T) {
 	// Test for handling nil values
 	// https://github.com/weaveworks/weave/issues/3095
 
-	rs := newRuleSpec(nil, nil, nil, nil)
+	rs := newRuleSpec(ingress, nil, nil, nil, nil)
 
 	require.NotEqual(t, rs.key, "")
 

--- a/npc/rule_test.go
+++ b/npc/rule_test.go
@@ -9,7 +9,7 @@ func TestRegressionHandleNil3095(t *testing.T) {
 	// Test for handling nil values
 	// https://github.com/weaveworks/weave/issues/3095
 
-	rs := newRuleSpec(ingress, nil, nil, nil, nil)
+	rs := newRuleSpec(ingressPolicy, nil, nil, nil, nil)
 
 	require.NotEqual(t, rs.key, "")
 

--- a/npc/rule_test.go
+++ b/npc/rule_test.go
@@ -9,7 +9,7 @@ func TestRegressionHandleNil3095(t *testing.T) {
 	// Test for handling nil values
 	// https://github.com/weaveworks/weave/issues/3095
 
-	rs := newRuleSpec(ingressPolicy, nil, nil, nil, nil)
+	rs := newRuleSpec(policyTypeIngress, nil, nil, nil, nil)
 
 	require.NotEqual(t, rs.key, "")
 

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -13,7 +13,7 @@ type selectorSpec struct {
 	key         string          // string representation (for hash keying/equality comparison)
 	selector    labels.Selector // k8s Selector object (for matching)
 	dst         bool            // destination selector TODO(brb) not relevant
-	policyTypes []policyType    // TODO(brb) repharse: netpol types (egress, ingress or both) which initiated the dst selector
+	policyTypes []policyType    // TODO(brb) repharse: netpol types (egress, ingress or both) which initiated the target selector
 
 	ipsetType ipset.Type // type of ipset to provision
 	ipsetName ipset.Name // generated ipset name
@@ -63,30 +63,29 @@ type selectorSet struct {
 	ips           ipset.Interface
 	onNewSelector selectorFn
 
-	// invoked after dst selector has been provisioned for the first time
-	onNewDstSelector selectorWithPolicyTypeFn
-	// invoked after the last instance of dst selector has been deprovisioned
-	onDestroyDstSelector selectorWithPolicyTypeFn
+	// invoked after target selector has been provisioned for the first time
+	onNewTargetSelector selectorWithPolicyTypeFn
+	// invoked after the last instance of target selector has been deprovisioned
+	onDestroyTargetSelector selectorWithPolicyTypeFn
 
 	users   map[string]map[types.UID]struct{} // list of users per selector
 	entries map[string]*selector
 
-	// We need to keep track of dst selector instances to be able to invoke
-	// onNewDstSelector and onDestroyDstSelector callbacks at the right time;
+	// We need to keep track of target selector instances to be able to invoke
+	// onNewTargetSelector and onDestroyTargetSelector callbacks at the right time;
 	// selectorSpec.Key -> policyType -> count
-	// TODO(brb) dst -> target?
-	dstSelectorsCount map[string]map[policyType]int
+	targetSelectorsCount map[string]map[policyType]int
 }
 
-func newSelectorSet(ips ipset.Interface, onNewSelector selectorFn, onNewDstSelector, onDestroyDstSelector selectorWithPolicyTypeFn) *selectorSet {
+func newSelectorSet(ips ipset.Interface, onNewSelector selectorFn, onNewTargetSelector, onDestroyTargetSelector selectorWithPolicyTypeFn) *selectorSet {
 	return &selectorSet{
-		ips:                  ips,
-		onNewSelector:        onNewSelector,
-		onNewDstSelector:     onNewDstSelector,
-		onDestroyDstSelector: onDestroyDstSelector,
+		ips:                     ips,
+		onNewSelector:           onNewSelector,
+		onNewTargetSelector:     onNewTargetSelector,
+		onDestroyTargetSelector: onDestroyTargetSelector,
 		users:                make(map[string]map[types.UID]struct{}),
 		entries:              make(map[string]*selector),
-		dstSelectorsCount:    make(map[string]map[policyType]int)}
+		targetSelectorsCount: make(map[string]map[policyType]int)}
 }
 
 func (ss *selectorSet) addToMatching(user types.UID, labelMap map[string]string, entry string, comment string) (bool, bool, error) {
@@ -94,10 +93,10 @@ func (ss *selectorSet) addToMatching(user types.UID, labelMap map[string]string,
 	foundEgress := false
 	for _, s := range ss.entries {
 		if s.matches(labelMap) {
-			if ss.dstSelectorExist(s, ingressPolicy) {
+			if ss.targetSelectorExist(s, ingressPolicy) {
 				foundIngress = true
 			}
-			if ss.dstSelectorExist(s, egressPolicy) {
+			if ss.targetSelectorExist(s, egressPolicy) {
 				foundEgress = true
 			}
 			if err := s.addEntry(user, entry, comment); err != nil {
@@ -119,8 +118,8 @@ func (ss *selectorSet) delFromMatching(user types.UID, labelMap map[string]strin
 	return nil
 }
 
-func (ss *selectorSet) dstSelectorExist(s *selector, policyType policyType) bool {
-	return ss.dstSelectorsCount[s.spec.key][policyType] > 0
+func (ss *selectorSet) targetSelectorExist(s *selector, policyType policyType) bool {
+	return ss.targetSelectorsCount[s.spec.key][policyType] > 0
 }
 
 func (ss *selectorSet) deprovision(user types.UID, current, desired map[string]*selectorSpec) error {
@@ -138,9 +137,9 @@ func (ss *selectorSet) deprovision(user types.UID, current, desired map[string]*
 			}
 
 			for _, policyType := range spec.policyTypes {
-				ss.dstSelectorsCount[key][policyType]--
-				if ss.dstSelectorsCount[key][policyType] == 0 {
-					if err := ss.onDestroyDstSelector(&selector{ss.ips, spec}, policyType); err != nil {
+				ss.targetSelectorsCount[key][policyType]--
+				if ss.targetSelectorsCount[key][policyType] == 0 {
+					if err := ss.onDestroyTargetSelector(&selector{ss.ips, spec}, policyType); err != nil {
 						return err
 					}
 				}
@@ -170,12 +169,12 @@ func (ss *selectorSet) provision(user types.UID, current, desired map[string]*se
 			ss.users[key][user] = struct{}{}
 
 			for _, pt := range spec.policyTypes {
-				if _, found := ss.dstSelectorsCount[key]; !found {
-					ss.dstSelectorsCount[key] = make(map[policyType]int)
+				if _, found := ss.targetSelectorsCount[key]; !found {
+					ss.targetSelectorsCount[key] = make(map[policyType]int)
 				}
-				ss.dstSelectorsCount[key][pt]++
-				if ss.dstSelectorsCount[key][pt] == 1 {
-					if err := ss.onNewDstSelector(selector, pt); err != nil {
+				ss.targetSelectorsCount[key][pt]++
+				if ss.targetSelectorsCount[key][pt] == 1 {
+					if err := ss.onNewTargetSelector(selector, pt); err != nil {
 						return err
 					}
 				}

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -89,20 +89,23 @@ func newSelectorSet(ips ipset.Interface, onNewSelector selectorFn, onNewDstSelec
 		dstSelectorsCount:    make(map[string]map[policyType]int)}
 }
 
-func (ss *selectorSet) addToMatching(user types.UID, labelMap map[string]string, entry string, comment string) (bool, error) {
+func (ss *selectorSet) addToMatching(user types.UID, labelMap map[string]string, entry string, comment string) (bool, bool, error) {
 	foundIngress := false
-	// TODO(brb) foundEgress
+	foundEgress := false
 	for _, s := range ss.entries {
 		if s.matches(labelMap) {
 			if ss.dstSelectorExist(s, ingressPolicy) {
 				foundIngress = true
 			}
+			if ss.dstSelectorExist(s, egressPolicy) {
+				foundEgress = true
+			}
 			if err := s.addEntry(user, entry, comment); err != nil {
-				return foundIngress, err
+				return foundIngress, foundEgress, err
 			}
 		}
 	}
-	return foundIngress, nil
+	return foundIngress, foundEgress, nil
 }
 
 func (ss *selectorSet) delFromMatching(user types.UID, labelMap map[string]string, entry string) error {

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -1,6 +1,8 @@
 package npc
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +37,23 @@ func newSelectorSpec(json *metav1.LabelSelector, policyType []policyType, nsName
 		ipsetName: ipset.Name(IpsetNamePrefix + shortName(nsName+":"+key)),
 		ipsetType: ipsetType,
 		nsName:    nsName}, nil
+}
+
+func (spec *selectorSpec) getRuleSpec(src bool) ([]string, string) {
+	dir := "dst"
+	if src {
+		dir = "src"
+	}
+	rule := []string{"-m", "set", "--match-set", string(spec.ipsetName), dir}
+
+	comment := "anywhere"
+	if spec.nsName != "" {
+		comment = fmt.Sprintf("pods: namespace: %s, selector: %s", spec.nsName, spec.key)
+	} else {
+		comment = fmt.Sprintf("namespaces: selector: %s", spec.key)
+	}
+
+	return rule, comment
 }
 
 type selector struct {

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -56,6 +56,10 @@ func (spec *selectorSpec) getRuleSpec(src bool) ([]string, string) {
 	return rule, comment
 }
 
+func (spec *selectorSpec) isNil() bool {
+	return spec == nil
+}
+
 type selector struct {
 	ips  ipset.Interface
 	spec *selectorSpec

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -114,10 +114,10 @@ func (ss *selectorSet) addToMatching(user types.UID, labelMap map[string]string,
 	foundEgress := false
 	for _, s := range ss.entries {
 		if s.matches(labelMap) {
-			if ss.targetSelectorExist(s, ingressPolicy) {
+			if ss.targetSelectorExist(s, policyTypeIngress) {
 				foundIngress = true
 			}
-			if ss.targetSelectorExist(s, egressPolicy) {
+			if ss.targetSelectorExist(s, policyTypeEgress) {
 				foundEgress = true
 			}
 			if err := s.addEntry(user, entry, comment); err != nil {

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -56,10 +56,6 @@ func (spec *selectorSpec) getRuleSpec(src bool) ([]string, string) {
 	return rule, comment
 }
 
-func (spec *selectorSpec) isNil() bool {
-	return spec == nil
-}
-
 type selector struct {
 	ips  ipset.Interface
 	spec *selectorSpec

--- a/npc/selector.go
+++ b/npc/selector.go
@@ -12,15 +12,14 @@ import (
 type selectorSpec struct {
 	key         string          // string representation (for hash keying/equality comparison)
 	selector    labels.Selector // k8s Selector object (for matching)
-	dst         bool            // destination selector TODO(brb) not relevant
-	policyTypes []policyType    // TODO(brb) repharse: netpol types (egress, ingress or both) which initiated the target selector
+	policyTypes []policyType    // If non-empty, then selectorSpec is a target selector for given policyTypes.
 
 	ipsetType ipset.Type // type of ipset to provision
 	ipsetName ipset.Name // generated ipset name
 	nsName    string     // Namespace name
 }
 
-func newSelectorSpec(json *metav1.LabelSelector, dst bool, policyType []policyType, nsName string, ipsetType ipset.Type) (*selectorSpec, error) {
+func newSelectorSpec(json *metav1.LabelSelector, policyType []policyType, nsName string, ipsetType ipset.Type) (*selectorSpec, error) {
 	selector, err := metav1.LabelSelectorAsSelector(json)
 	if err != nil {
 		return nil, err
@@ -29,7 +28,6 @@ func newSelectorSpec(json *metav1.LabelSelector, dst bool, policyType []policyTy
 	return &selectorSpec{
 		key:         key,
 		selector:    selector,
-		dst:         dst,
 		policyTypes: policyType,
 		// We prefix the selector string with the namespace name when generating
 		// the shortname because you can specify the same selector in multiple

--- a/npc/types.go
+++ b/npc/types.go
@@ -1,0 +1,15 @@
+package npc
+
+type policyType byte
+
+const (
+	ingressPolicy policyType = iota
+	egressPolicy
+)
+
+func policyTypeStr(policyType policyType) string {
+	if policyType == egressPolicy {
+		return "egress"
+	}
+	return "ingress"
+}

--- a/npc/types.go
+++ b/npc/types.go
@@ -3,12 +3,12 @@ package npc
 type policyType byte
 
 const (
-	ingressPolicy policyType = iota
-	egressPolicy
+	policyTypeIngress policyType = iota
+	policyTypeEgress
 )
 
 func policyTypeStr(policyType policyType) string {
-	if policyType == egressPolicy {
+	if policyType == policyTypeEgress {
 		return "egress"
 	}
 	return "ingress"

--- a/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
@@ -26,14 +26,6 @@ items:
           - list
           - watch
       - apiGroups:
-          - extensions
-        resources:
-          - networkpolicies
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
           - 'networking.k8s.io'
         resources:
           - networkpolicies
@@ -163,7 +155,6 @@ items:
                       fieldPath: spec.nodeName
               image: 'weaveworks/weave-npc:latest'
               imagePullPolicy: Always
-#npc-args
               resources:
                 requests:
                   cpu: 10m

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -158,7 +158,7 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 
 	// Egress rules:
 	//
-	// -A WEAVE-NPC-EGRESS -m state --state RELATED,ESTABLISHED -j RETURN
+	// -A WEAVE-NPC-EGRESS -m state --state RELATED,ESTABLISHED -j ACCEPT
 	// -A WEAVE-NPC-EGRESS -m set ! --match-set weave-local-pods src -j RETURN
 	// -A WEAVE-NPC-EGRESS -d 224.0.0.0/4 -j RETURN
 	// -A WEAVE-NPC-EGRESS -m state --state NEW -j WEAVE-NPC-EGRESS-DEFAULT
@@ -179,7 +179,7 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 	// check both chains).
 
 	ruleSpecs := [][]string{
-		{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "RETURN"},
+		{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
 		{"-m", "state", "--state", "NEW", "-m", "set", "!", "--match-set", npc.LocalIpset, "src", "-j", "RETURN"},
 	}
 	if allowMcast {

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -57,6 +57,10 @@ func resetIPTables(ipt *iptables.IPTables) error {
 		return err
 	}
 
+	if err := ipt.ClearChain(npc.TableFilter, npc.EgressMarkChain); err != nil {
+		return err
+	}
+
 	if err := ipt.ClearChain(npc.TableFilter, npc.EgressCustomChain); err != nil {
 		return err
 	}
@@ -133,6 +137,11 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 	}
 	if err := ipt.Append(npc.TableFilter, npc.MainChain,
 		"-m", "set", "!", "--match-set", npc.LocalIpset, "dst", "-j", "ACCEPT"); err != nil {
+		return err
+	}
+
+	if err := ipt.Append(npc.TableFilter, npc.EgressMarkChain,
+		"-j", "MARK", "--set-xmark", npc.EgressMark); err != nil {
 		return err
 	}
 

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -182,6 +182,7 @@ func main() {
 	mflag.StringVar(&bridgeConfig.WeaveBridgeName, []string{"-weave-bridge"}, "weave", "name of weave bridge")
 	mflag.StringVar(&bridgeConfig.DockerBridgeName, []string{"-docker-bridge"}, "", "name of Docker bridge")
 	mflag.BoolVar(&bridgeConfig.NPC, []string{"-expect-npc"}, false, "set up iptables rules for npc")
+	mflag.BoolVar(&bridgeConfig.LegacyNPC, []string{"-use-legacy-netpol"}, false, "use legacy network policies (pre k8s 1.7 vsn)")
 	mflag.StringVar(&routerName, []string{"-name"}, "", "name of router (defaults to MAC of interface)")
 	mflag.StringVar(&nickName, []string{"-nickname"}, "", "nickname of peer (defaults to hostname)")
 	mflag.StringVar(&password, []string{"-password"}, "", "network password")

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -182,7 +182,6 @@ func main() {
 	mflag.StringVar(&bridgeConfig.WeaveBridgeName, []string{"-weave-bridge"}, "weave", "name of weave bridge")
 	mflag.StringVar(&bridgeConfig.DockerBridgeName, []string{"-docker-bridge"}, "", "name of Docker bridge")
 	mflag.BoolVar(&bridgeConfig.NPC, []string{"-expect-npc"}, false, "set up iptables rules for npc")
-	mflag.BoolVar(&bridgeConfig.LegacyNPC, []string{"-use-legacy-netpol"}, false, "use legacy network policies (pre k8s 1.7 vsn)")
 	mflag.StringVar(&routerName, []string{"-name"}, "", "name of router (defaults to MAC of interface)")
 	mflag.StringVar(&nickName, []string{"-nickname"}, "", "nickname of peer (defaults to hostname)")
 	mflag.StringVar(&password, []string{"-password"}, "", "network password")

--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -370,7 +370,6 @@ You can customise the YAML you get from `cloud.weave.works` by passing some of W
   - `disable-npc`: boolean (`true|false`). Default: `false`.
   - `env.NAME=VALUE`: add environment variable `NAME` and set it to `VALUE`.
   - `seLinuxOptions.NAME=VALUE`: add SELinux option `NAME` and set it to `VALUE`, e.g. `seLinuxOptions.type=spc_t`
-  - `use-legacy-netpol`: use [legacy NetworkPolicy semantics](https://v1-6.docs.kubernetes.io/docs/api-reference/v1.6/#networkpolicy-v1beta1-extensions), boolean (`true|false`). Default: `true` for Kubernetes version <= 1.6, `false` for > 1.6.
 
 The list of variables you can set is:
 

--- a/test/images/network-tester/Dockerfile
+++ b/test/images/network-tester/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM bash
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl bind-tools
 ADD webserver webserver
 EXPOSE 8080
 ENTRYPOINT ["/webserver"]

--- a/weave
+++ b/weave
@@ -496,6 +496,10 @@ destroy_bridge() {
     run_iptables -t filter -D FORWARD -o $BRIDGE -m state --state NEW -j NFLOG --nflog-group 86 2>/dev/null || true
     run_iptables -t filter -D FORWARD -o $BRIDGE -j DROP 2>/dev/null || true
     run_iptables -X WEAVE-NPC >/dev/null 2>&1 || true
+    run_iptables -F WEAVE-NPC-EGRESS >/dev/null 2>&1 || true
+    run_iptables -t filter -D FORWARD -o $BRIDGE -j WEAVE-NPC-EGRESS 2>/dev/null || true
+    run_iptables -t filter -D INPUT -i $BRIDGE -j WEAVE-NPC-EGRESS 2>/dev/null || true
+    run_iptables -X WEAVE-NPC-EGRESS >/dev/null 2>&1 || true
 
     run_iptables -F WEAVE-EXPOSE >/dev/null 2>&1 || true
     run_iptables -t filter -D FORWARD -o $BRIDGE -j WEAVE-EXPOSE 2>/dev/null || true

--- a/weave
+++ b/weave
@@ -492,14 +492,20 @@ destroy_bridge() {
     run_iptables -t filter -D FORWARD -o $BRIDGE -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || true
     run_iptables -t filter -D FORWARD -i $BRIDGE -o $BRIDGE -j ACCEPT 2>/dev/null || true
     run_iptables -F WEAVE-NPC >/dev/null 2>&1 || true
-    run_iptables -t filter -D FORWARD -o $BRIDGE -j WEAVE-NPC 2>/dev/null || true
+    run_iptables -t filter -D FORWARD -o $BRIDGE -m comment --comment "NOTE: this must go before '-j KUBE-FORWARD'" -j WEAVE-NPC 2>/dev/null || true
     run_iptables -t filter -D FORWARD -o $BRIDGE -m state --state NEW -j NFLOG --nflog-group 86 2>/dev/null || true
     run_iptables -t filter -D FORWARD -o $BRIDGE -j DROP 2>/dev/null || true
     run_iptables -X WEAVE-NPC >/dev/null 2>&1 || true
     run_iptables -F WEAVE-NPC-EGRESS >/dev/null 2>&1 || true
-    run_iptables -t filter -D FORWARD -o $BRIDGE -j WEAVE-NPC-EGRESS 2>/dev/null || true
+    run_iptables -t filter -D FORWARD -i $BRIDGE -m comment --comment "NOTE: this must go before '-j KUBE-FORWARD'" -j WEAVE-NPC-EGRESS 2>/dev/null || true
     run_iptables -t filter -D INPUT -i $BRIDGE -j WEAVE-NPC-EGRESS 2>/dev/null || true
     run_iptables -X WEAVE-NPC-EGRESS >/dev/null 2>&1 || true
+    run_iptables -F WEAVE-NPC-EGRESS-DEFAULT >/dev/null 2>&1 || true
+    run_iptables -X WEAVE-NPC-EGRESS-DEFAULT >/dev/null 2>&1 || true
+    run_iptables -F WEAVE-NPC-EGRESS-CUSTOM >/dev/null 2>&1 || true
+    run_iptables -X WEAVE-NPC-EGRESS-CUSTOM >/dev/null 2>&1 || true
+    run_iptables -F WEAVE-NPC-EGRESS-ACCEPT >/dev/null 2>&1 || true
+    run_iptables -X WEAVE-NPC-EGRESS-ACCEPT >/dev/null 2>&1 || true
 
     run_iptables -F WEAVE-EXPOSE >/dev/null 2>&1 || true
     run_iptables -t filter -D FORWARD -o $BRIDGE -j WEAVE-EXPOSE 2>/dev/null || true


### PR DESCRIPTION
This PR implements Kubernetes Egress Network Policy (defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#networkpolicyspec-v1-networking-k8s-io).

Some important changes are mentioned/explained below.

### Rules

Each "weave" packet (=sent over the `weave` bridge) is first checked against egress and then against ingress rules. 

For Egress NPC we introduce the following rules:

```
    -A WEAVE-NPC-EGRESS -m state --state RELATED,ESTABLISHED -j RETURN
    -A WEAVE-NPC-EGRESS -m set ! --match-set weave-local-pods src -j RETURN
    -A WEAVE-NPC-EGRESS -d 224.0.0.0/4 -j RETURN
    -A WEAVE-NPC-EGRESS -m state --state NEW -j WEAVE-NPC-EGRESS-DEFAULT
    -A WEAVE-NPC-EGRESS -m state --state NEW -m mark ! --mark 0x40000/0x40000 -j WEAVE-NPC-EGRESS-CUSTOM
    -A WEAVE-NPC-EGRESS -m state --state NEW -m mark ! --mark 0x40000/0x40000 -j NFLOG --nflog-group 86
    -A WEAVE-NPC-EGRESS -m mark ! --mark 0x40000/0x40000 -j DROP

    -A WEAVE-NPC-EGRESS-CUSTOM <rulespec> -j MARK --set-xmark 0x40000/0x40000
    -A WEAVE-NPC-EGRESS-CUSTOM <rulespec> -j RETURN

    -A WEAVE-NPC-EGRESS-DEFAULT <rulespec> -j MARK --set-xmark 0x40000/0x40000
    -A WEAVE-NPC-EGRESS-DEFAULT <rulespec> -j RETURN
```

When a rule which matches an egress packet is found, we mark the packet instead of ACCEPT'ing. This is because the same packet need to traverse the `WEAVE-NPC` chain (Ingress), so we cannot just accept the packet.

Also, in opposite to the ingress rules, we move the logging and dropping into the `WEAVE-NPC-EGRESS` chain. We ensure that the rules are not flushed upon a restart of weave-npc, so that no time window is created when all egress traffic is allowed.

### Traffic Steering

To steer the traffic for the egress NPC processing we create two rules:

- `-A INPUT -i weave -j WEAVE-NPC-EGRESS`: applies to packets destined to a local node.
- `-A FORWARD -i weave -j WEAVE-NPC-EGRESS`: the rest. It can match an ingress packet.

### ipBlock

The Egress NPC supports the ipBlock selector. Some of its implementation has been cherry-picked from https://github.com/weaveworks/weave/pull/3233. Note, that we still do not support the selector in ingress!

### Renaming dstSelector to targetSelector
 
We have renamed "dstSelector" to "targetSelector" because "dstSelector" becomes ambiguous in the context of egress. Just to recall, we call a selector a "targetSelector" if it selects pods to which a network policy applies (=`.NetworkPolicySpec.podSelector`).

### Del --use-legacy-netpol

We are no longer supporting the legacy network policies.

Fix #2624 