### PR TITLE
Fix $HOME usage in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ WEAVEWAIT_NOMCAST_EXE=prog/weavewait/weavewait_nomcast
 WEAVEUTIL_EXE=prog/weaveutil/weaveutil
 RUNNER_EXE=tools/runner/runner
 # manifest-tool needs registry credentials; we assume here that the active user has logged in
-MANIFEST_TOOL_CMD="docker run --rm -v $HOME/.docker:/.docker weshigbee/manifest-tool --docker-cfg=/.docker"
+MANIFEST_TOOL_CMD="docker run --rm -v $(HOME)/.docker:/.docker weshigbee/manifest-tool --docker-cfg=/.docker"
 TEST_TLS_EXE=test/tls/tls
 NETWORKTESTER_EXE=test/images/network-tester/webserver
 


### PR DESCRIPTION
The master branch builds are currently failing with:

```
make DOCKER_HOST= DOCKERHUB_USER=weaveworks WEAVE_VERSION=git-d15439aeac6a UPDATE_LATEST=latest-only push_ml_weave push_ml_weaveexec push_ml_weave-kube push_ml_weave-npc
make[1]: Entering directory `/home/ubuntu/src/github.com/weaveworks/weave'
"docker run --rm -v OME/.docker:/.docker weshigbee/manifest-tool --docker-cfg=/.docker" push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le --template weaveworks/weave-ARCH:latest --target weaveworks/weave:latest
/bin/sh: 1: docker run --rm -v OME/.docker:/.docker weshigbee/manifest-tool --docker-cfg=/.docker: not found
```