### PR TITLE
Make error "Weave is not running" less confusing when running on Kubernetes

### DIFF
--- a/weave
+++ b/weave
@@ -1248,7 +1248,7 @@ launch() {
 stop() {
     util_op remove-plugin-network weave || true
     warn_if_stopping_proxy_in_env
-    util_op stop-container $CONTAINER_NAME >/dev/null 2>&1 || echo "Weave is not running." >&2
+    util_op stop-container $CONTAINER_NAME >/dev/null 2>&1 || echo "Weave is not running (ignore on Kubernetes)." >&2
     # In case user has upgraded from <v2.0 and left old containers running
     util_op stop-container $OLD_PLUGIN_CONTAINER_NAME >/dev/null 2>&1 || true
     util_op stop-container $OLD_PROXY_CONTAINER_NAME >/dev/null 2>&1 || true


### PR DESCRIPTION
We suggest to run `weave reset` when weaver detects an existing bridge of different type than the requested one.

In case of Kubernetes, if a user runs `weave reset`, it returns `Weave is not running` which might make the user think that `weave reset` was not successful (happened in https://github.com/weaveworks/weave/issues/3318).