### PR TITLE
Add permissions to set node status

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
@@ -41,6 +41,13 @@ items:
           - get
           - list
           - watch
+      - apiGroups:
+        - ''
+        resources:
+        - nodes/status
+        verbs:
+        - patch
+        - update
   - apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRoleBinding
     metadata:


### PR DESCRIPTION
Fixes #3332

This permission is needed to update the node NetworkUnavailable condition see https://github.com/weaveworks/weave/issues/3249