### PR TITLE
Add interface name to veth pair name

### DIFF
--- a/net/veth_test.go
+++ b/net/veth_test.go
@@ -1,0 +1,19 @@
+package net
+
+import (
+	"testing"
+)
+
+func TestIfShorten(t *testing.T) {
+
+	shortIfName := getShortIfName("foobar0", 4)
+	if shortIfName != "bar0" {
+		t.Errorf("Sum was incorrect, got: %s, want: %s.", shortIfName, "bar0")
+	}
+
+	shortIfName = getShortIfName("foobar0", 3)
+	if shortIfName != "ar0" {
+		t.Errorf("Sum was incorrect, got: %s, want: %s.", shortIfName, "ar0")
+	}
+
+}


### PR DESCRIPTION
## TL;DR

Adding a shortened network interface name to the naming scheme for veth pairs, to allow for multiple Weave networks off of the same container ID

## Explanation of Changes

I have been working with the [`multus`](https://github.com/intel/multus-cni/) plugin to get multiple weave networks connected to my Kubernetes pods. Other plugins seem to work, but for some reason [I was getting a strange error](https://github.com/intel/multus-cni/issues/91) when using multiple Weave networks:

```
could not create veth pair vethweplf979bd1-vethwepgf979bd1: file exists
```

After poking around the Weave code, I noticed that the creation of veth pair names is mostly static, with the exception of the container id (the `f979bd1` shown above in this case). This is great, unless the same container has multiple interfaces for which to create veth pairs. In this case, the first one will succeed, and any further ones will fail because they'll try to create another one with the same name, since both network interfaces are connected to the same container ID.

I started playing with ways to inject the interface name into the pair name as well, to allow for more uniqueness.

I like that the current naming scheme preserves 7 characters worth of container ID, and my first attempt was to preserve this by replacing some of the text in the prefix with the interface name:

```
   (old) - vethwepl0abcdef
   (new) - venet0pl0abcdef
```

While this preserves the number of container IDs, that's only if the interface name is reasonably short, and based on some of the references I looked up, there are a few other places in the code that rely on `VethName`. Doing this didn't seem to break anything for me, but I didn't do that much testing, so I assume this isn't quite the way to go.

The only other way I can think to go is to append the network interface before the "pg" or "pl", which will end up eating into the available characters for the container ID.

To help mitigate this, I added a new function that lets us predictably use the last N digits of the network interface name in this use case, so we can preserve as many digits for the container ID as possible. Keeping it to 3 or 4 should be reasonable, since if there is ever a conflict, Kubernetes for instance will keep trying to schedule it, and ideally the next container won't conflict - and this is already the case. However I am open to suggestions to alternatives, especially considering Kubernetes isn't the only use case.
