### PR TITLE
3206: Protect against CNI plugin being called with the host namespace

### DIFF
--- a/plugin/net/cni.go
+++ b/plugin/net/cni.go
@@ -117,6 +117,16 @@ func (c *CNIPlugin) CmdAdd(args *skel.CmdArgs) error {
 	}
 	defer ns.Close()
 
+	hostNs, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("error accessing host network namespace: %s", err)
+	}
+	defer hostNs.Close()
+
+	if ns.Equal(hostNs) {
+		return fmt.Errorf("can not specify host network namespace as network namespace to which container should be added")
+	}
+
 	id := args.ContainerID
 	if len(id) < 5 {
 		data := make([]byte, 5)


### PR DESCRIPTION
adding a check to verify if network namespace is not host network namespace

Fixes #3206