### PR TITLE
Remove mention of Kubernetes 1.6 from docs: it's very old now

### DIFF
--- a/site/install.md
+++ b/site/install.md
@@ -31,7 +31,6 @@ Install Weave Net from the command line on its own or if you are using Docker, K
 * [Integrating Kubernetes and Mesos via the CNI Plugin](https://www.weave.works/docs/net/latest/kubernetes/)
 * [Integrating Kubernetes via the Addon](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/)
      * [Installation](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#install)
-     * [Upgrading Kubernetes to version 1.6](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#kube-1.6-upgrade)
      * [Upgrading the Daemon Sets](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#daemon-sets)
      * [CPU and Memory Requirements](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#resources)
      * [Pod Eviction](https://www.weave.works/docs/net/latest/kubernetes/kube-addon/#eviction)

--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -7,7 +7,6 @@ search_type: Documentation
 The following topics are discussed:
 
 * [Installation](#install)
-   * [Upgrading Kubernetes to version 1.6](#kube-1.6-upgrade)
    * [Upgrading the Daemon Sets](#daemon-sets)
    * [CPU and Memory Requirements](#resources)
    * [Pod Eviction](#eviction)
@@ -60,37 +59,12 @@ Shut down Kubernetes, and _on all nodes_ perform the following:
 Then relaunch Kubernetes and install the addon as described
 above.
 
-## <a name="kube-1.6-upgrade"></a> Upgrading Kubernetes to version 1.6
-
-In version 1.6, Kubernetes has increased security, so we need to
-create a special service account to run Weave Net. This is done in
-the file `weave-daemonset-k8s-1.6.yaml` attached to the [Weave Net
-release](https://github.com/weaveworks/weave/releases/latest).
-
-Also, the
-[toleration](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/taint-toleration-dedicated.md)
-required to let Weave Net run on master nodes has moved from an
-annotation to a field on the DaemonSet spec object.
-
-If you have edited the Weave Net DaemonSet from a previous release,
-you will need to re-make your changes against the new version.
-
 ### <a name="daemon-sets"></a> Upgrading the Daemon Sets
 
-For Kubernetes 1.6 and above the DaemonSet definition specifies
-[Rolling Updates](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/),
+The DaemonSet definition specifies [Rolling
+Updates](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/),
 so when you apply a new version Kubernetes will automatically restart
 the Weave Net pods one by one.
-
-Kubernetes v1.5 and below does not support rolling upgrades of daemon sets,
-and so you will need to perform the procedure manually:
-
-* Apply the updated addon manifest `kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"`
-* Kill each Weave Net pod with `kubectl delete` and then wait for it to reboot before moving on to the next pod.
-
-**Note:** In versions prior to Weave Net 2.0, deleting all Weave Net pods at the same time
-  will result in them losing track of IP address range ownership, possibly leading to
-  duplicate IP addresses if you then start a new copy of Weave Net.
 
 ## <a name="resources"></a>CPU and Memory Requirements
 


### PR DESCRIPTION
The Kubernetes project only supports three versions back, which is 1.8, 1.9 and 1.10 as of today.

The text I have removed is for people upgrading from 1.5 to 1.6, so well beyond that policy.  It's unnecessary and possibly confusing.

cc @abuehrle for interest