### PR TITLE
Parse labels

### DIFF
--- a/prog/weaveutil/container.go
+++ b/prog/weaveutil/container.go
@@ -89,7 +89,7 @@ func containerFQDN(args []string) error {
 	return nil
 }
 
-func runContainer(args []string) error {
+func parseContainerArgs(args []string) docker.CreateContainerOptions {
 	env := []string{}
 	labels := map[string]string{}
 	name := ""
@@ -166,19 +166,25 @@ func runContainer(args []string) error {
 	image := args[0]
 	cmds := args[1:]
 
+	config := docker.Config{Image: image, Env: env, Cmd: cmds, Labels: labels}
+	hostConfig := docker.HostConfig{NetworkMode: net, PidMode: pid, Privileged: privileged, RestartPolicy: restart, Binds: volumes, VolumesFrom: volumesFrom}
+	return docker.CreateContainerOptions{Name: name, Config: &config, HostConfig: &hostConfig}
+}
+
+func runContainer(args []string) error {
+	containerOptions := parseContainerArgs(args)
+
 	c, err := docker.NewVersionedClientFromEnv("1.18")
 	if err != nil {
 		return fmt.Errorf("unable to connect to docker: %s", err)
 	}
 
-	config := docker.Config{Image: image, Env: env, Cmd: cmds, Labels: labels}
-	hostConfig := docker.HostConfig{NetworkMode: net, PidMode: pid, Privileged: privileged, RestartPolicy: restart, Binds: volumes, VolumesFrom: volumesFrom}
-	container, err := c.CreateContainer(docker.CreateContainerOptions{Name: name, Config: &config, HostConfig: &hostConfig})
+	container, err := c.CreateContainer(containerOptions)
 	if err != nil {
 		return fmt.Errorf("unable to create container: %s", err)
 	}
 
-	err = c.StartContainer(container.ID, &hostConfig)
+	err = c.StartContainer(container.ID, containerOptions.HostConfig)
 	if err != nil {
 		return fmt.Errorf("unable to start container: %s", err)
 	}

--- a/prog/weaveutil/container_test.go
+++ b/prog/weaveutil/container_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseContainerArgs(t *testing.T) {
+	args := []string{"--name", "weave", "--privileged", "--net", "host",
+		"-l", "foo=bar", "-l", "foobar",
+		"-v", "/var/run/docker.sock:/var/run/docker.sock", "-v", "/etc:/host/etc",
+		"--restart", "always", "--pid", "host", "--volumes-from", "weavedb",
+		"-e", "WEAVE_DEBUG", "-e", "EXEC_IMAGE=weaveworks/weaveexec:latest",
+		"weaveworks/weave:latest", "cmd", "arg1", "arg2"}
+	expected := docker.CreateContainerOptions{
+		Name: "weave",
+		Config: &docker.Config{
+			Image:  "weaveworks/weave:latest",
+			Env:    []string{"WEAVE_DEBUG", "EXEC_IMAGE=weaveworks/weaveexec:latest"},
+			Cmd:    []string{"cmd", "arg1", "arg2"},
+			Labels: map[string]string{"foo": "bar", "foobar": ""},
+		},
+		HostConfig: &docker.HostConfig{
+			NetworkMode:   "host",
+			PidMode:       "host",
+			Privileged:    true,
+			RestartPolicy: docker.RestartPolicy{Name: "always"},
+			Binds:         []string{"/var/run/docker.sock:/var/run/docker.sock", "/etc:/host/etc"},
+			VolumesFrom:   []string{"weavedb"},
+		},
+	}
+	have := parseContainerArgs(args)
+	require.Equal(t, expected, have)
+}


### PR DESCRIPTION
Allows `-l` or `--label` flag to be passed to the `run-container` command which starts Weave.

Fixes #3370 

Also a test.
