### PR TITLE
Monitor and throw error message in the logs if Weave bridge interface is down

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -627,12 +627,9 @@ func monitorInterface(ifaceName string, log *logrus.Logger) error {
 	}
 
 	go func() {
-		for {
-			select {
-			case update := <-updatesChannel:
-				if update.Link.Attrs().Name == ifaceName && update.IfInfomsg.Flags&syscall.IFF_UP == 0 {
-					log.Errorf("Interface %q which needs to be in UP state for Weave functioning is found to be in DOWN state", ifaceName)
-				}
+		for update := range updatesChannel {
+			if update.Link.Attrs().Name == ifaceName && update.IfInfomsg.Flags&syscall.IFF_UP == 0 {
+				log.Errorf("Interface %q which needs to be in UP state for Weave functioning is found to be in DOWN state", ifaceName)
 			}
 		}
 	}()


### PR DESCRIPTION
Monitor and throw error message in the logs if Weave bridge interface is found to be in DOWN state

Fixes #3133 Do something more useful when the weave bridge is DOWN

On Weave restart there is already logic in place to create the bridge interface
and bring it up, this fix only monotors the weave bridge interface and logs error if
it is in DOWN state