### PR TITLE
Add logic to re-try chooseBest() (which will select best forwarder)

### DIFF
--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -736,8 +736,6 @@ func (fwd *fastDatapathForwarder) doHeartbeats() {
 
 			if fwd.healthy {
 				fwd.healthy = false
-			} else {
-				err = fmt.Errorf("timed out waiting for vxlan heartbeat")
 			}
 
 		case <-fwd.stopChan:

--- a/router/network_overlay.go
+++ b/router/network_overlay.go
@@ -31,6 +31,8 @@ type OverlayForwarder interface {
 	// Confirm().  The return value nil means the key could not be
 	// handled by this forwarder.
 	Forward(ForwardPacketKey) FlowOp
+
+	HealthChannel() <-chan bool
 }
 
 type NullNetworkOverlay struct{ mesh.NullOverlay }

--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -336,11 +336,13 @@ func (fwd *overlaySwitchForwarder) healthCheck(index int, healthy bool) {
 	defer fwd.lock.Unlock()
 
 	if healthy == true && fwd.forwarders[index].onHold {
+		log.Debug(fwd.logPrefix(), "Adding "+fwd.forwarders[index].overlayName+" to the list of forwarders")
 		fwd.forwarders[index].onHold = false
 		fwd.chooseBest()
 	}
 
 	if healthy == false && !fwd.forwarders[index].onHold {
+		log.Debug(fwd.logPrefix(), "Removing "+fwd.forwarders[index].overlayName+" from the list of forwarders")
 		fwd.forwarders[index].onHold = true
 		fwd.chooseBest()
 	}

--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -142,6 +142,7 @@ type overlaySwitchForwarder struct {
 	alreadyEstablished bool
 	establishedChan    chan struct{}
 	errorChan          chan error
+	healthChan         chan bool
 }
 
 // A subsidiary forwarder
@@ -154,6 +155,9 @@ type subForwarder struct {
 
 	// closed to tell the forwarder monitor goroutine to stop
 	stopChan chan<- struct{}
+
+	// set to true to skip this forwarder in chooseBest()
+	onHold bool
 }
 
 // An event from a subsidiary forwarder
@@ -166,6 +170,9 @@ type subForwarderEvent struct {
 
 	// is this an error event?
 	err error
+
+	// event to indicate if forwarder is in healthy state to be considered for best forwarded
+	healthy bool
 }
 
 func (osw *OverlaySwitch) PrepareConnection(params mesh.OverlayConnectionParams) (mesh.OverlayConnection, error) {
@@ -239,6 +246,7 @@ func (osw *OverlaySwitch) PrepareConnection(params mesh.OverlayConnectionParams)
 
 func monitorForwarder(index int, eventsChan chan<- subForwarderEvent, stopChan <-chan struct{}, fwd OverlayForwarder) {
 	establishedChan := fwd.EstablishedChannel()
+	healthChan := fwd.HealthChannel()
 loop:
 	for {
 		e := subForwarderEvent{index: index}
@@ -247,6 +255,9 @@ loop:
 		case <-establishedChan:
 			e.established = true
 			establishedChan = nil
+
+		case healthy := <-healthChan:
+			e.healthy = healthy
 
 		case err := <-fwd.ErrorChannel():
 			e.err = err
@@ -282,6 +293,8 @@ loop:
 				fwd.established(e.index)
 			case e.err != nil:
 				fwd.error(e.index, e.err)
+			default:
+				fwd.healthCheck(e.index, e.healthy)
 			}
 		}
 	}
@@ -318,6 +331,21 @@ func (fwd *overlaySwitchForwarder) error(index int, err error) {
 	fwd.chooseBest()
 }
 
+func (fwd *overlaySwitchForwarder) healthCheck(index int, healthy bool) {
+	fwd.lock.Lock()
+	defer fwd.lock.Unlock()
+
+	if healthy == true && fwd.forwarders[index].onHold {
+		fwd.forwarders[index].onHold = false
+		fwd.chooseBest()
+	}
+
+	if healthy == false && !fwd.forwarders[index].onHold {
+		fwd.forwarders[index].onHold = true
+		fwd.chooseBest()
+	}
+}
+
 func (fwd *overlaySwitchForwarder) stopFrom(index int) {
 	for index < len(fwd.forwarders) {
 		subFwd := &fwd.forwarders[index]
@@ -337,7 +365,7 @@ func (fwd *overlaySwitchForwarder) chooseBest() {
 
 	for i := range fwd.forwarders {
 		subFwd := &fwd.forwarders[i]
-		if subFwd.fwd == nil {
+		if subFwd.fwd == nil || subFwd.onHold {
 			continue
 		}
 
@@ -413,6 +441,10 @@ func (fwd *overlaySwitchForwarder) EstablishedChannel() <-chan struct{} {
 
 func (fwd *overlaySwitchForwarder) ErrorChannel() <-chan error {
 	return fwd.errorChan
+}
+
+func (fwd *overlaySwitchForwarder) HealthChannel() <-chan bool {
+	return fwd.healthChan
 }
 
 func (fwd *overlaySwitchForwarder) Stop() {

--- a/router/sleeve.go
+++ b/router/sleeve.go
@@ -326,6 +326,7 @@ type sleeveForwarder struct {
 	// listener channels
 	establishedChan chan struct{}
 	errorChan       chan error
+	healthChan      chan bool
 
 	// Explicitly locked state
 	lock       sync.RWMutex
@@ -443,6 +444,10 @@ func (fwd *sleeveForwarder) EstablishedChannel() <-chan struct{} {
 
 func (fwd *sleeveForwarder) ErrorChannel() <-chan error {
 	return fwd.errorChan
+}
+
+func (fwd *sleeveForwarder) HealthChannel() <-chan bool {
+	return fwd.healthChan
 }
 
 type curriedForward struct {


### PR DESCRIPTION
changes differentiate beteween fatal errors (for e.g. ipsec init)
from transient errors (heartbeast misses). In case of transient
errors OverlayForwarder is marked to be unhealty. When overlay forwarder
is unhealty its kept on hold so chooseBest() will skip selecting the forwarder

Once OverlayForwarder is considered healthy run chooseBest() again so the
forwarder can be selected if its the best forwarder

Fixes #1737