### PR TITLE
ipam: Do not deref nil in GET /ipinfo/tracker if tracker doesn't exist

### DIFF
--- a/ipam/http.go
+++ b/ipam/http.go
@@ -199,6 +199,10 @@ func (alloc *Allocator) HandleHTTP(router *mux.Router, defaultSubnet address.CID
 	})
 
 	router.Methods("GET").Path("/ipinfo/tracker").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, alloc.tracker.String())
+		tracker := ""
+		if alloc.tracker != nil {
+			tracker = alloc.tracker.String()
+		}
+		fmt.Fprintf(w, tracker)
 	})
 }


### PR DESCRIPTION
In some cases, we do not create any IPAM tracker, which leads to a panic when GET'ing /ipinfo/tracker.

Fixes #3405.