### PR TITLE
own action to reclaim when peer does not exist

### DIFF
--- a/prog/kube-utils/main.go
+++ b/prog/kube-utils/main.go
@@ -140,14 +140,10 @@ func reclaimPeer(weave weaveClient, cml *configMapAnnotations, storedPeerList *p
 		} else {
 			// handle an edge case where peer claimed to own the action to reclaim but no longer
 			// exists hence lock persists foever
-			peerExists := false
-			for _, peer := range storedPeerList.Peers {
-				if existingAnnotation == peer.PeerName {
-					peerExists = true
-					break
-				}
+			if !storedPeerList.contains(existingAnnotation) {
+				nonExistentPeer = true
+				common.Log.Debugln("[kube-peers] Existing annotation", existingAnnotation, " has a non-existent peer so owning the reclaim action")
 			}
-			nonExistentPeer = !peerExists
 		}
 	}
 	if !found || nonExistentPeer {

--- a/prog/kube-utils/peerlist.go
+++ b/prog/kube-utils/peerlist.go
@@ -26,7 +26,7 @@ type peerInfo struct {
 	NodeName string // Kubernetes node name
 }
 
-func (pl peerList) contains(peerName string) bool {
+func (pl *peerList) contains(peerName string) bool {
 	for _, peer := range pl.Peers {
 		if peer.PeerName == peerName {
 			return true

--- a/prog/kube-utils/peerlist_test.go
+++ b/prog/kube-utils/peerlist_test.go
@@ -137,7 +137,7 @@ func TestPeerListFuzz(t *testing.T) {
 		found := storedPeerList.contains(peerName(i))
 		require.True(t, found, "peer %d not found in stored list", i)
 
-		_, err = reclaimPeer(mockWeave{}, cml, peerName(i), fmt.Sprintf("deleter-%d", i))
+		_, err = reclaimPeer(mockWeave{}, cml, storedPeerList, peerName(i), fmt.Sprintf("deleter-%d", i))
 		require.NoError(t, err)
 
 		storedPeerList, err = cml.GetPeerList()


### PR DESCRIPTION
handles an edge case where peer claimed to own the action to reclaim but no longer exists hence lock persists forever, fix makes a peer own the reclaim when nonexistent node found

Fixes #3386