### PR TITLE
kubernetes: Morph the livenessProbe into readinessProbe

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -110,12 +110,11 @@ items:
                       fieldPath: spec.nodeName
               image: 'weaveworks/weave-kube:latest'
               imagePullPolicy: Always
-              livenessProbe:
+              readinessProbe:
                 httpGet:
                   host: 127.0.0.1
                   path: /status
                   port: 6784
-                initialDelaySeconds: 30
               resources:
                 requests:
                   cpu: 10m

--- a/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
@@ -119,12 +119,11 @@ items:
                       fieldPath: spec.nodeName
               image: 'weaveworks/weave-kube:latest'
               imagePullPolicy: Always
-              livenessProbe:
+              readinessProbe:
                 httpGet:
                   host: 127.0.0.1
                   path: /status
                   port: 6784
-                initialDelaySeconds: 30
               resources:
                 requests:
                   cpu: 10m

--- a/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
@@ -127,12 +127,11 @@ items:
                       fieldPath: spec.nodeName
               image: 'weaveworks/weave-kube:latest'
               imagePullPolicy: Always
-              livenessProbe:
+              readinessProbe:
                 httpGet:
                   host: 127.0.0.1
                   path: /status
                   port: 6784
-                initialDelaySeconds: 30
               resources:
                 requests:
                   cpu: 10m

--- a/prog/weave-kube/weave-daemonset.yaml
+++ b/prog/weave-kube/weave-daemonset.yaml
@@ -36,12 +36,11 @@ items:
                       fieldPath: spec.nodeName
               image: 'weaveworks/weave-kube:latest'
               imagePullPolicy: Always
-              livenessProbe:
+              readinessProbe:
                 httpGet:
                   host: 127.0.0.1
                   path: /status
                   port: 6784
-                initialDelaySeconds: 30
               resources:
                 requests:
                   cpu: 10m


### PR DESCRIPTION
The liveness probe has the not-so-great side effect of killing the weave pods
if anything goes wrong, making debugging really difficult.
    
Not only that, we also bumped into the livenessProbe killing pods before they
had a chance to start (see below for the full story).
    
The readinessProbe is only used for Kubernetes Services: no traffic will be
routed to non-Ready pods when using the Service IP. We can use to to signal the
user something in wrong with Weave Net while not having Kubernetes delete the
pods behind our backs.
    
I removed the ininitialDelaySeconds field as Kurbernetes won't kill the pod if
not ready.
    
Notes from a debugging session:
    
Some nodes may have a vast amount of iptables rules, making each iptables
command take a few seconds (~5-10s). At startup, when the weave container
creates its chains, it runs quite a few iptables commands and the total time of
execution was > 30s.
    
It's important to note that, at this point, the weave process hasn't started as
those iptables commands are run by an initial script.
    
Kubernetes was trying to check for the container liveness, was failing, and
then proceeded to kill the weave pods before they had a chance to fully start.

Fixes: #3417