### PR TITLE
Replace weave-local-pods ipset with physdev iptables rule

### DIFF
--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -169,10 +169,6 @@ func (ns *ns) addPod(obj *coreapi.Pod) error {
 		return nil
 	}
 
-	if ns.checkLocalPod(obj) {
-		ns.ips.AddEntry(obj.ObjectMeta.UID, LocalIpset, obj.Status.PodIP, podComment(obj))
-	}
-
 	foundIngress, foundEgress, err := ns.podSelectors.addToMatching(obj.ObjectMeta.UID, obj.ObjectMeta.Labels, obj.Status.PodIP, podComment(obj))
 	if err != nil {
 		return err
@@ -201,10 +197,6 @@ func (ns *ns) updatePod(oldObj, newObj *coreapi.Pod) error {
 	}
 
 	if hasIP(oldObj) && !hasIP(newObj) {
-		if ns.checkLocalPod(oldObj) {
-			ns.ips.DelEntry(oldObj.ObjectMeta.UID, LocalIpset, oldObj.Status.PodIP)
-		}
-
 		if err := ns.ips.DelEntry(oldObj.ObjectMeta.UID, ns.ingressDefaultAllowIPSet, oldObj.Status.PodIP); err != nil {
 			return err
 		}
@@ -216,9 +208,6 @@ func (ns *ns) updatePod(oldObj, newObj *coreapi.Pod) error {
 	}
 
 	if !hasIP(oldObj) && hasIP(newObj) {
-		if ns.checkLocalPod(newObj) {
-			ns.ips.AddEntry(newObj.ObjectMeta.UID, LocalIpset, newObj.Status.PodIP, podComment(newObj))
-		}
 		foundIngress, foundEgress, err := ns.podSelectors.addToMatching(newObj.ObjectMeta.UID, newObj.ObjectMeta.Labels, newObj.Status.PodIP, podComment(newObj))
 		if err != nil {
 			return err
@@ -301,10 +290,6 @@ func (ns *ns) deletePod(obj *coreapi.Pod) error {
 
 	if !hasIP(obj) {
 		return nil
-	}
-
-	if ns.checkLocalPod(obj) {
-		ns.ips.DelEntry(obj.ObjectMeta.UID, LocalIpset, obj.Status.PodIP)
 	}
 
 	if err := ns.ips.DelEntry(obj.ObjectMeta.UID, ns.ingressDefaultAllowIPSet, obj.Status.PodIP); err != nil {

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -25,13 +25,13 @@ import (
 )
 
 var (
-	version     = "unreleased"
-	metricsAddr string
-	logLevel    string
-	allowMcast  bool
-	nodeName    string
-	maxList     int
-	bridgeName  string
+	version        = "unreleased"
+	metricsAddr    string
+	logLevel       string
+	allowMcast     bool
+	nodeName       string
+	maxList        int
+	bridgePortName string
 )
 
 func handleError(err error) { common.CheckFatal(err) }
@@ -128,7 +128,7 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 
 	// If the destination address is not any of the local pods, let it through
 	if err := ipt.Append(npc.TableFilter, npc.MainChain,
-		"-m", "physdev", "--physdev-out="+bridgeName, "-j", "ACCEPT"); err != nil {
+		"-m", "physdev", "--physdev-out="+bridgePortName, "-j", "ACCEPT"); err != nil {
 		return err
 	}
 
@@ -171,7 +171,7 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 
 	ruleSpecs := [][]string{
 		{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
-		{"-m", "physdev", "--physdev-in=" + bridgeName, "-j", "RETURN"},
+		{"-m", "physdev", "--physdev-in=" + bridgePortName, "-j", "RETURN"},
 	}
 	if allowMcast {
 		ruleSpecs = append(ruleSpecs, []string{"-d", "224.0.0.0/4", "-j", "RETURN"})
@@ -324,7 +324,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&allowMcast, "allow-mcast", true, "allow all multicast traffic")
 	rootCmd.PersistentFlags().StringVar(&nodeName, "node-name", "", "only generate rules that apply to this node")
 	rootCmd.PersistentFlags().IntVar(&maxList, "max-list-size", 1024, "maximum size of ipset list (for namespaces)")
-	rootCmd.PersistentFlags().StringVar(&bridgeName, "bridge-name", "vethwe-bridge", "name of the brige on which packets are received and sent")
+	rootCmd.PersistentFlags().StringVar(&bridgePortName, "bridge-port-name", "vethwe-bridge", "name of the brige port on which packets are received and sent")
 
 	handleError(rootCmd.Execute())
 }

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -186,6 +186,17 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 		return err
 	}
 
+	// delete `weave-local-pods` ipset which is no longer used by weave-npc
+	weaveLocalPodExist, err := ipsetExist(ips, npc.LocalIpset)
+	if err != nil {
+		common.Log.Errorf("Failed to destroy ipset '%s'", npc.LocalIpset)
+	} else if weaveLocalPodExist {
+		common.Log.Debugf("Destroying ipset '%s'", npc.LocalIpset)
+		if err := ips.Destroy(npc.LocalIpset); err != nil {
+			common.Log.Errorf("Failed to destroy ipset '%s'", npc.LocalIpset)
+		}
+	}
+
 	return nil
 }
 

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -189,7 +189,7 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 	// delete `weave-local-pods` ipset which is no longer used by weave-npc
 	weaveLocalPodExist, err := ipsetExist(ips, npc.LocalIpset)
 	if err != nil {
-		common.Log.Errorf("Failed to destroy ipset '%s'", npc.LocalIpset)
+		common.Log.Errorf("Failed to look if ipset '%s' exists", npc.LocalIpset)
 	} else if weaveLocalPodExist {
 		common.Log.Debugf("Destroying ipset '%s'", npc.LocalIpset)
 		if err := ips.Destroy(npc.LocalIpset); err != nil {


### PR DESCRIPTION
by-pass ingress network policy chains and accept the packet if
destination is not one of the local pods

return the packets so the egress network policy chains are skipped
in case packet's source is not one of the local pods

Fixes #3344