### PR TITLE
Bump go-odp dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -671,11 +671,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:96b0adb40f5818192dd016ca387c722cc02c190cb7399294cb0d80f7b0fd8501"
+  digest = "1:fe397579b11f84d3a36ad3d8e5d9f144705d2416e1cd4550d475584ef6e2e25c"
   name = "github.com/weaveworks/go-odp"
   packages = ["odp"]
   pruneopts = "UT"
-  revision = "eec09c2fbfb96be47bfe11165ce300ad9a60bef5"
+  revision = "6b0aa22550d9325eb8f43418185859e13dc0de1d"
 
 [[projects]]
   digest = "1:277e090a58afaeb00fb9fd04e2b2f3466ff8fb327a331e0e531a3399a72697e3"

--- a/vendor/github.com/weaveworks/go-odp/odp/datapath.go
+++ b/vendor/github.com/weaveworks/go-odp/odp/datapath.go
@@ -13,8 +13,8 @@ type datapathInfo struct {
 	name    string
 }
 
-func (dpif *Dpif) parseDatapathInfo(msg *NlMsgParser) (res datapathInfo, err error) {
-	_, ovshdr, err := dpif.checkNlMsgHeaders(msg, DATAPATH, OVS_DP_CMD_NEW)
+func (dpif *Dpif) parseDatapathInfo(msg *NlMsgParser, cmd int) (res datapathInfo, err error) {
+	_, ovshdr, err := dpif.checkNlMsgHeaders(msg, DATAPATH, cmd)
 	if err != nil {
 		return
 	}
@@ -58,7 +58,7 @@ func (dpif *Dpif) CreateDatapath(name string) (DatapathHandle, error) {
 		return DatapathHandle{}, err
 	}
 
-	dpi, err := dpif.parseDatapathInfo(resp)
+	dpi, err := dpif.parseDatapathInfo(resp, OVS_DP_CMD_NEW)
 	if err != nil {
 		return DatapathHandle{}, err
 	}
@@ -81,7 +81,7 @@ func (dpif *Dpif) LookupDatapath(name string) (DatapathHandle, error) {
 		return DatapathHandle{}, err
 	}
 
-	dpi, err := dpif.parseDatapathInfo(resp)
+	dpi, err := dpif.parseDatapathInfo(resp, OVS_DP_CMD_GET)
 	if err != nil {
 		return DatapathHandle{}, err
 	}
@@ -104,7 +104,7 @@ func (dpif *Dpif) LookupDatapathByID(ifindex DatapathID) (Datapath, error) {
 		return Datapath{}, err
 	}
 
-	dpi, err := dpif.parseDatapathInfo(resp)
+	dpi, err := dpif.parseDatapathInfo(resp, OVS_DP_CMD_GET)
 	if err != nil {
 		return Datapath{}, err
 	}
@@ -127,7 +127,7 @@ func (dpif *Dpif) EnumerateDatapaths() (map[string]DatapathHandle, error) {
 	req.putOvsHeader(0)
 
 	consumer := func(resp *NlMsgParser) error {
-		dpi, err := dpif.parseDatapathInfo(resp)
+		dpi, err := dpif.parseDatapathInfo(resp, OVS_DP_CMD_GET)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/weaveworks/go-odp/odp/dpif.go
+++ b/vendor/github.com/weaveworks/go-odp/odp/dpif.go
@@ -155,7 +155,22 @@ func (dpif *Dpif) checkNlMsgHeaders(msg *NlMsgParser, family int, cmd int) (*Gen
 		return nil, nil, err
 	}
 
-	genlhdr, err := msg.CheckGenlMsghdr(cmd)
+	// Until Linux Kernel v4.19, generic netlink command in reply message
+	// for some of ovs requests had incorrectly been set to OVS_*_CMD_NEW.
+	// For details, see: http://patchwork.ozlabs.org/patch/975343/
+	// ("openvswitch: Use correct reply values in datapath and vport ops")
+	var genlhdr *GenlMsghdr
+	var err error
+	switch family {
+	case DATAPATH:
+		genlhdr, err = msg.CheckGenlMsghdr(cmd, OVS_DP_CMD_NEW)
+	case VPORT:
+		genlhdr, err = msg.CheckGenlMsghdr(cmd, OVS_VPORT_CMD_NEW)
+	case FLOW:
+		genlhdr, err = msg.CheckGenlMsghdr(cmd, OVS_FLOW_CMD_NEW)
+	default:
+		genlhdr, err = msg.CheckGenlMsghdr(cmd, -1)
+	}
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/weaveworks/go-odp/odp/flow.go
+++ b/vendor/github.com/weaveworks/go-odp/odp/flow.go
@@ -840,7 +840,7 @@ func (key TunnelFlowKey) Ignored() bool {
 		AllBytes(m.Ipv4Dst[:], 0) &&
 		m.Tos == 0 &&
 		m.Ttl == 0 &&
-		!m.Csum && !m.Csum &&
+		!m.Csum &&
 		m.TpSrc == 0 && m.TpDst == 0
 }
 
@@ -1236,8 +1236,8 @@ func (a FlowSpec) Equals(b FlowSpec) bool {
 	return true
 }
 
-func (dp DatapathHandle) parseFlowMsg(msg *NlMsgParser) (Attrs, error) {
-	if err := dp.checkNlMsgHeaders(msg, FLOW, OVS_FLOW_CMD_NEW); err != nil {
+func (dp DatapathHandle) parseFlowMsg(msg *NlMsgParser, cmd int) (Attrs, error) {
+	if err := dp.checkNlMsgHeaders(msg, FLOW, cmd); err != nil {
 		return nil, err
 	}
 
@@ -1375,7 +1375,7 @@ func (dp DatapathHandle) EnumerateFlows() ([]FlowInfo, error) {
 	req.putOvsHeader(dp.ifindex)
 
 	consumer := func(resp *NlMsgParser) error {
-		attrs, err := dp.parseFlowMsg(resp)
+		attrs, err := dp.parseFlowMsg(resp, OVS_FLOW_CMD_GET)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/weaveworks/go-odp/odp/vport.go
+++ b/vendor/github.com/weaveworks/go-odp/odp/vport.go
@@ -242,7 +242,7 @@ func lookupVport(dpif *Dpif, dpifindex DatapathID, name string) (DatapathID, Vpo
 		return 0, Vport{}, err
 	}
 
-	_, ovshdr, err := dpif.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_NEW)
+	_, ovshdr, err := dpif.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_GET)
 	if err != nil {
 		return 0, Vport{}, err
 	}
@@ -276,7 +276,7 @@ func (dp DatapathHandle) LookupVport(id VportID) (Vport, error) {
 		return Vport{}, err
 	}
 
-	err = dp.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_NEW)
+	err = dp.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_GET)
 	if err != nil {
 		return Vport{}, err
 	}
@@ -311,7 +311,7 @@ func (dp DatapathHandle) EnumerateVports() ([]Vport, error) {
 
 	var res []Vport
 	consumer := func(resp *NlMsgParser) error {
-		err := dp.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_NEW)
+		err := dp.checkNlMsgHeaders(resp, VPORT, OVS_VPORT_CMD_GET)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
To include the fix https://github.com/weaveworks/go-odp/pull/7.

TL;DR: without this fix, `fastdp` would fail to work on the 4.19 kernel.

Thanks @lkpdn for spotting and providing the fix.

