### PR TITLE
net: Do not set bridge hw addr when creating it

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -304,7 +304,10 @@ func (b bridgeImpl) initPrep(config *BridgeConfig) error {
 
 	linkAttrs := netlink.NewLinkAttrs()
 	linkAttrs.Name = config.WeaveBridgeName
-	linkAttrs.HardwareAddr = mac
+	// NB: Do not set MAC addr when creating the bridge, set it manually
+	// afterwards instead. Otherwise, on an older than 3.14 kernel FDB
+	// entry won't be created which results in containers not being able to
+	// reach the bridge w/o promiscuous mode.
 	if config.MTU == 0 {
 		config.MTU = 65535
 	}


### PR DESCRIPTION
Prior ["bridge: Change local fdb entries whenever mac address of bridge device changes"][1], FDB entry for a bridge was not inserted when creating the bridge and it could only be inserted when a hw address of the bridge was changed. Therefore, on an older than the 3.14 kernel containers were not able to reach the `weave` bridge w/o setting the promiscuous mode on.

This should have hit hard Kubernetes users as the weave bridge in their case is used as a default gateway, and thus it works only after manually enabling the promiscuous mode.

Additionally, w/o the promiscuous mode a packet sent from a container and destined to the gateway is flooded on all ports, so it can reach the `datapath` device resulting in the `"Vetoed installation of hairpin flow"` error.

Fix #3336 #3297 #3239 (and probably more)

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a4b816d8ba1c1917842dc3de97cbf8ef116e043e