### PR TITLE
prevent kubernetes node connecting to self

### DIFF
--- a/prog/kube-utils/main.go
+++ b/prog/kube-utils/main.go
@@ -16,14 +16,15 @@ import (
 	"time"
 
 	"github.com/vishvananda/netlink"
-	weaveapi "github.com/weaveworks/weave/api"
-	"github.com/weaveworks/weave/common"
 	"golang.org/x/sys/unix"
 	api "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+
+	weaveapi "github.com/weaveworks/weave/api"
+	"github.com/weaveworks/weave/common"
 )
 
 type nodeInfo struct {


### PR DESCRIPTION
prevent kubernetes node connecting to self by excluding the node IP from the list of the peers passed to weaver

Fixes #3398