### PR TITLE
Fix deletion of interface on container delete in weave docker proxy mode

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -532,7 +532,13 @@ func (proxy *Proxy) attach(containerID string) error {
 // and return nil on success or not needed.
 func (proxy *Proxy) detach(containerID string) error {
 	name, _ := weavenet.GenerateVethPair(containerID)
-	veth := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: name}}
+	veth, err := netlink.LinkByName(name)
+	if err != nil {
+		if err.Error() == weavenet.ErrLinkNotFound.Error() {
+			return nil
+		}
+		return err
+	}
 	if err := netlink.LinkDel(veth); err != nil {
 		return err
 	}


### PR DESCRIPTION
- on container delete perform veth interface delete
- use consistent way to generate the name for veth pair on container create and delete

Fixes #3406 weave not deleting network interfaces