### PR TITLE
handle single node case where return peer list from kube-utils is empty

### DIFF
--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -85,7 +85,7 @@ router_bridge_opts() {
 }
 
 if [ -z "$KUBE_PEERS" ]; then
-    if ! KUBE_PEERS=$(/home/weave/kube-utils) || [ -z "$KUBE_PEERS" ]; then
+    if ! KUBE_PEERS=$(/home/weave/kube-utils); then
         echo Failed to get peers >&2
         exit 1
     fi


### PR DESCRIPTION
handle single node case where return peer list from kube-utils is empty resulting in launch.sh failing to launch weaver

fixes side affect introduced in #3454