### PR TITLE
Remove some unused tools from the Weave docker containers

### DIFF
--- a/prog/weaver/Dockerfile.template
+++ b/prog/weaver/Dockerfile.template
@@ -21,11 +21,9 @@ CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
 
 RUN apk add --update \
     curl \
-    ethtool \
     iptables \
     ipset \
     iproute2 \
-    util-linux \
     conntrack-tools \
     bind-tools \
     ca-certificates \


### PR DESCRIPTION
Use of `ethtool` was removed in #1958
`util-linux` was needed for `nsenter` which was removed in #3291 

I looked at removing `bind-tools` but we need that for `dig` used in `weave dns-lookup`.

