### PR TITLE
bump up the version of entry by large value so that transfer of range takes precedence

### DIFF
--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -565,7 +565,9 @@ func (r *Ring) Transfer(from, to mesh.PeerName) []address.Range {
 	for i, entry := range r.Entries {
 		if entry.Peer == from {
 			entry.Peer = to
-			entry.Version++
+			// bump version by large value so that transfer of range takes precedence (if there is any conflict in merging entry)
+			// over other opertaions on the entry that increments the version
+			entry.Version = entry.Version + 100
 			newRanges = append(newRanges, address.Range{Start: entry.Token, End: r.Entries.entry(i + 1).Token})
 		}
 	}


### PR DESCRIPTION

bump up the version of entry by large value so that transfer of range takes precedence (if there is any conflict in merging entry) over other operations on the entry
that increments the version

Fixes #3612