### PR TITLE
Add tolerations for nodes tainted with NoExecute

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -156,6 +156,8 @@ items:
           tolerations:
             - effect: NoSchedule
               operator: Exists
+            - effect: NoExecute
+              operator: Exists
           volumes:
             - name: weavedb
               hostPath:

--- a/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
@@ -172,6 +172,8 @@ items:
           tolerations:
             - effect: NoSchedule
               operator: Exists
+            - effect: NoExecute
+              operator: Exists
           volumes:
             - name: weavedb
               hostPath:

--- a/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
@@ -181,6 +181,8 @@ items:
           tolerations:
             - effect: NoSchedule
               operator: Exists
+            - effect: NoExecute
+              operator: Exists
           volumes:
             - name: weavedb
               hostPath:


### PR DESCRIPTION
If you add nodes with the following taint:
```
kubectl taint nodes node1 key1=value1:NoExecute
```
Weave is evicted from the node, and thus, the node will not be able to start any new pods due to it not being able to resolve network endpoints. By allowing the Weave DaemonSet to tolerate a `NoExecute` taint, Weave will run on these tainted nodes marked to avoid execution, as it should.

---

This is was found because I have a set of nodes that are marked with `NoExecute` so only certain applications that tolerate the taint can run on them. Turns out one of those certain applications became Weave. Pods that were running before I applied the taint were fine, but pods that were schedule after Weave was evicted from the node were unable to start and left in a `Pending` state.