### PR TITLE
Do not do ipsec.InitSARemote on a stopped fastDatapathForwarder.

### DIFF
--- a/router/fastdp.go
+++ b/router/fastdp.go
@@ -881,6 +881,11 @@ func (fwd *fastDatapathForwarder) handleHeartbeatAck() {
 }
 
 func (fwd *fastDatapathForwarder) handleCryptoInitSARemote(msg []byte) {
+	if fwd.stopped {
+		log.Info(fwd.logPrefix(), "IPSec init SA remote failed: forwarder has already been stopped")
+		return
+	}
+
 	log.Info(fwd.logPrefix(), "IPSec init SA remote")
 	err := fwd.fastdp.ipsec.InitSARemote(
 		msg,


### PR DESCRIPTION
It is possible for ipsec.InitSARemote to be called after ipsec.Destroy.
If an xfrm policy for that source/destination pair exists it will be
updated to the SPI from the Destroyed connection causing IPSEC to stop
working.
Fixes https://github.com/weaveworks/weave/issues/3675