### PR TITLE
Build with Go 1.12.7; Added support for crossbuilding s390x binaries and images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ QEMU_VERSION=v2.7.0
 
 # A list of all supported architectures here. Should be named as Go is naming platforms
 # All supported architectures must have an "ifeq" block below that customizes the parameters
-ALL_ARCHITECTURES=amd64 arm arm64 ppc64le
-ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le
+ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
+ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 
 ifeq ($(ARCH),amd64)
 # The architecture to use when downloading the docker binary
@@ -94,6 +94,26 @@ ifeq ($(ARCH),ppc64le)
 	QEMUARCH=ppc64le
 
 # In the weaveworks/build image; libpcap libraries for ppc64le are placed here
+# Tell the gcc linker to search for libpcap here
+	CGO_LDFLAGS="-L/usr/local/lib/$(CC)"
+endif
+ifeq ($(ARCH),s390x)
+# The architecture to use when downloading the docker binary
+	WEAVEEXEC_DOCKER_ARCH?=s390x
+
+# Using the (semi-)official alpine image
+	ALPINE_BASEIMAGE?=s390x/alpine:3.6
+
+# s390x images have the -s390x suffix, for instance weaveworks/weave-s390x:latest
+	ARCH_EXT?=-s390x
+
+# The name of the gcc binary
+	CC=s390x-linux-gnu-gcc
+
+# The architecture name to use when downloading a prebuilt QEMU binary
+	QEMUARCH=s390x
+
+# In the weaveworks/build image; libpcap libraries for s390x are placed here
 # Tell the gcc linker to search for libpcap here
 	CGO_LDFLAGS="-L/usr/local/lib/$(CC)"
 endif

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.1-stretch
+FROM golang:1.12.7-buster
 
 # Support Raspberry Pi 2 and newer
 ENV GOARM 7
@@ -7,25 +7,25 @@ ENV GOARM 7
 ENV DEB_CROSSPLATFORMS \
 	armhf \
 	arm64 \
-	ppc64el
+	ppc64el \
+	s390x
 
 # The go platforms we are supporting to cross-compile
 ENV GO_CROSSPLATFORMS \
 	linux/arm \
 	linux/arm64 \
-	linux/ppc64le
+	linux/ppc64le \
+	linux/s390x
 
 # The names of the gcc cross-compilers we have installed
 ENV GCC_CROSSCOMPILERS \
 	arm-linux-gnueabihf \
 	aarch64-linux-gnu \
-	powerpc64le-linux-gnu
+	powerpc64le-linux-gnu \
+	s390x-linux-gnu
 
-# Temporarily add the Debian repositories, because we're going to install gcc cross-compilers from there
 # Install the build-essential and crossbuild-essential-ARCH packages
-RUN echo "deb http://emdebian.org/tools/debian/ jessie main" > /etc/apt/sources.list.d/cgocrosscompiling.list \
-  && curl http://emdebian.org/tools/debian/emdebian-toolchain-archive.key | apt-key add - \
-  && for platform in ${DEB_CROSSPLATFORMS}; do dpkg --add-architecture $platform; done \
+RUN for platform in ${DEB_CROSSPLATFORMS}; do dpkg --add-architecture $platform; done \
   && apt-get update \
   && apt-get install -y build-essential \
   && for platform in ${DEB_CROSSPLATFORMS}; do apt-get install -y crossbuild-essential-${platform}; done \


### PR DESCRIPTION
Changes details:
1) In Makefile have added cross build support w.r.t s390x .

2) Updated the build/Dockerfile to substitute  `golang:1.10.1-stretch` with `golang:1.12.7-buster` . As the debian:buster image already  has crossbuild-essential-${platform} binaries in it's repo, so I have removed the addition of emdebian repository in the repolists which was used  earlier that referred to the crossbuild-essential binaries.

I have verified and tested native and cross ARCH build of binaries and Images with these changes.