### PR TITLE
Change the dnsPolicy for the weave-net pods to ClusterFirstWithHostNet

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.9.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.9.yaml
@@ -176,6 +176,7 @@ items:
                   mountPath: /run/xtables.lock
                   readOnly: false
           hostNetwork: true
+          dnsPolicy: ClusterFirstWithHostNet
           hostPID: true
           restartPolicy: Always
           securityContext:


### PR DESCRIPTION
Currently, there is no explicit `dnsPolicy` specified, thus when the DaemonSet is deployed it gets the `ClusterFirst` policy. However, since the pods run with `hostNetwork: true`, the pods get configured with the DNS coming from the host instead of k8s. This means the out of the box weave pod would not be able to resolve any k8s service FQDNs. The more appropriate dnsPolicy would be `ClusterFirstWithHostNet` as that would ensure that the DNS resolution for any k8s services would be at least possible.