### PR TITLE
Use buffered chan to avoid losing docker events

### DIFF
--- a/common/docker/client.go
+++ b/common/docker/client.go
@@ -99,7 +99,9 @@ func (c *Client) AddObserver(ob ContainerObserver) error {
 		pending := make(pendingStarts)
 		retryInterval := InitialInterval
 		for {
-			events := make(chan *docker.APIEvents)
+			// Use a buffered chan so the client library can run ahead of the listener
+			// - Docker will drop an event if it is not collected quickly enough.
+			events := make(chan *docker.APIEvents, 1024)
 			if err := c.AddEventListener(events); err != nil {
 				c.errorf("Unable to add listener to Docker API: %s - retrying in %ds", err, retryInterval/time.Second)
 			} else {


### PR DESCRIPTION
Docker [imposes a limit](https://github.com/moby/moby/blob/a6e1502575858cd063b0e75d400e04b6f334e86d/daemon/events/events.go#L107) that events have to be retrieved within 100ms or they are dropped on the sending side. Adding buffer space within the Weave Net process allows those events to be collected from Docker more quickly.

1024 is an arbitrary number, much higher than we expect to need.

Fixes #3432 