### PR TITLE
Handle range wrap-around when checking for allocations

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -814,8 +814,14 @@ func (alloc *Allocator) sendRingUpdate(dest mesh.PeerName) {
 	alloc.gossip.GossipUnicast(dest, msg)
 }
 
-func (alloc *Allocator) checkRangeHasAllocations(r address.Range) bool {
-	return alloc.space.NumFreeAddressesInRange(r) != r.Size()
+func (alloc *Allocator) hasAllocations(rs []address.Range) bool {
+	for _, r := range rs {
+		alloc.debugf("hasAllocations: %v %v vs %v", r, alloc.space.NumFreeAddressesInRange(r), r.Size())
+		if alloc.space.NumFreeAddressesInRange(r) != r.Size() {
+			return true
+		}
+	}
+	return false
 }
 
 func (alloc *Allocator) update(sender mesh.PeerName, msg []byte) error {
@@ -836,7 +842,7 @@ func (alloc *Allocator) update(sender mesh.PeerName, msg []byte) error {
 	// If someone sent us a ring, merge it into ours. Note this will move us
 	// out of the awaiting-consensus state if we didn't have a ring already.
 	case data.Ring != nil:
-		updated, err := alloc.ring.Merge(*data.Ring, alloc.checkRangeHasAllocations)
+		updated, err := alloc.ring.Merge(*data.Ring, alloc.hasAllocations)
 		switch err {
 		case nil:
 			if updated {

--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -375,6 +375,11 @@ func (r *Ring) Empty() bool {
 	return len(r.Entries) == 0
 }
 
+// convenience function to normalise a single range that may span zero
+func (r *Ring) makeRanges(start, end address.Address) []address.Range {
+	return r.splitRangesOverZero([]address.Range{{Start: start, End: end}})
+}
+
 // Given a slice of ranges which are all in the right order except
 // possibly the last one spans zero, fix that up and return the slice
 func (r *Ring) splitRangesOverZero(ranges []address.Range) []address.Range {
@@ -425,10 +430,7 @@ type RangeInfo struct {
 
 func (r *Ring) AllRangeInfo() (result []RangeInfo) {
 	for i, entry := range r.Entries {
-		nextEntry := r.Entries.entry(i + 1)
-		ranges := []address.Range{{Start: entry.Token, End: nextEntry.Token}}
-		ranges = r.splitRangesOverZero(ranges)
-		for _, r := range ranges {
+		for _, r := range r.makeRanges(entry.Token, r.Entries.entry(i+1).Token) {
 			result = append(result, RangeInfo{entry.Peer, r, entry.Version})
 		}
 	}

--- a/ipam/ring/ring.go
+++ b/ipam/ring/ring.go
@@ -284,7 +284,7 @@ func (es entries) merge(other entries, ourPeer mesh.PeerName, r *Ring, hasAlloca
 	var i, j int
 	for i < len(es) && j < len(other) {
 		mine, theirs = es[i], other[j]
-		common.Log.Debugln(fmt.Sprintf("[ring %s]: Merge mine.Token=%s theirs.Token=%s mine.Peer=%s theirs.Peer=%s mine.Version=%s theirs.Version=%s", ourPeer, mine.Token, theirs.Token, mine.Peer, theirs.Peer, fmt.Sprint(mine.Version), fmt.Sprint(theirs.Version)))
+		common.Log.Debugf("[ring %s]: Merge mine.Token=%s theirs.Token=%s mine.Peer=%s theirs.Peer=%s mine.Version=%v theirs.Version=%v", ourPeer, mine.Token, theirs.Token, mine.Peer, theirs.Peer, mine.Version, theirs.Version)
 		switch {
 		case mine.Token < theirs.Token:
 			addToResult(*mine)
@@ -302,7 +302,6 @@ func (es entries) merge(other entries, ourPeer mesh.PeerName, r *Ring, hasAlloca
 			addTheirs(*theirs)
 			j++
 		case mine.Token == theirs.Token:
-			common.Log.Debugln(fmt.Sprintf("[ring %s]: Merge token=%s mine.Peer=%s theirs.Peer=%s mine.Version=%s theirs.Version=%s", ourPeer, mine.Token, mine.Peer, theirs.Peer, fmt.Sprint(mine.Version), fmt.Sprint(theirs.Version)))
 			// merge
 			switch {
 			case mine.Version >= theirs.Version:
@@ -333,6 +332,7 @@ func (es entries) merge(other entries, ourPeer mesh.PeerName, r *Ring, hasAlloca
 					// which case we should set our version to the one received plus one,
 					// effectively imposing our existing entry.
 					if theirs.Peer != ourPeer && !hasAllocations(r.makeRanges(mine.Token, es.entry(i+1).Token)) {
+						common.Log.Infof("ring: repair inconsistent data by accepting token %v from %v - no allocations up to %v", theirs.Token, theirs.Peer, es.entry(i+1).Token)
 						addTheirs(*theirs)
 					} else if theirs.Peer == ourPeer {
 						mine.Version = theirs.Version + 1
@@ -528,7 +528,7 @@ func (r *Ring) ReportFree(freespace map[address.Address]address.Count) (updated 
 
 		entries[i].Free = free
 		entries[i].Version++
-		common.Log.Debugln(fmt.Sprintf("[ring %s]: ReportFree token=%s peer=%s version=%s", r.Peer, entries[i].Token, entries[i].Peer, fmt.Sprint(entries[i].Version)))
+		common.Log.Debugf("[ring %s]: ReportFree token=%s peer=%s version=%v", r.Peer, entries[i].Token, entries[i].Peer, entries[i].Version)
 		updated = true
 	}
 	return
@@ -612,7 +612,7 @@ func (r *Ring) Transfer(from, to mesh.PeerName) []address.Range {
 			// bump version by large value so that transfer of range takes precedence (if there is any conflict in merging entry)
 			// over other opertaions on the entry that increments the version
 			entry.Version = entry.Version + 100
-			common.Log.Debugln(fmt.Sprintf("[ring %s]: Transfer token=%s from=%s to=%s version=%s", r.Peer, entry.Token, from, to, fmt.Sprint(entry.Version)))
+			common.Log.Debugf("[ring %s]: Transfer token=%s from=%s to=%s version=%v", r.Peer, entry.Token, from, to, entry.Version)
 			newRanges = append(newRanges, address.Range{Start: entry.Token, End: r.Entries.entry(i + 1).Token})
 		}
 	}

--- a/ipam/ring/ring_test.go
+++ b/ipam/ring/ring_test.go
@@ -38,19 +38,21 @@ func merge(r1, r2 *Ring) error {
 		}
 		return address.Count((r1.End - start) + (end - r1.Start))
 	}
-	checkEntryHasAllocations := func(r address.Range) bool {
-		size := distance(r.Start, r.End)
-		entry, found := r1.Entries.get(r.Start)
-		if !found {
-			return false
-		}
-		if entry.Free < size {
-			return true
+	check := func(rs []address.Range) bool {
+		for _, r := range rs {
+			size := distance(r.Start, r.End)
+			entry, found := r1.Entries.get(r.Start)
+			if !found {
+				continue
+			}
+			if entry.Free < size {
+				return true
+			}
 		}
 		return false
 	}
 
-	_, err := r1.Merge(*r2, checkEntryHasAllocations)
+	_, err := r1.Merge(*r2, check)
 	return err
 }
 


### PR DESCRIPTION
Fixes #3693 

`Ring` wraps around at zero but `Space` doesn't know about this, so we have to normalise ranges coming out of `Ring`.  In turn we may need to split one range into two, across the end of the `Ring`.

The unit tests passed because they are calling `distance` inside the Ring package, which understands the wrap-around.  We may want to make them more realistic, maybe move up to `ipam` package.

Also log the event when we do accept another peer's token, since that should be a rare event, and it's important if we've made a mistake.
