### PR TITLE
Exclude myself when building a list of peers that may need deleted

### DIFF
--- a/prog/kube-utils/main.go
+++ b/prog/kube-utils/main.go
@@ -112,7 +112,9 @@ func reclaimRemovedPeers(kube kubernetes.Interface, cml *configMapAnnotations, m
 		}
 		peerMap := make(map[string]peerInfo, len(storedPeerList.Peers))
 		for _, peer := range storedPeerList.Peers {
-			peerMap[peer.PeerName] = peer
+			if peer.PeerName != myPeerName {
+				peerMap[peer.PeerName] = peer
+			}
 		}
 		// remove entries from the peer map that are current nodes
 		for key, peer := range peerMap {


### PR DESCRIPTION
This is a minor noise reduction - we already avoid actually doing the delete, but adding this check stops the program logging that it was thinking about it.
Also it goes round the loop three times wondering what happened.

```
INFO: 2019/10/10 12:39:39.717889 Our name is ea:46:33:c1:c2:0b(test-12533-0-0)
[...]
INFO: 2019/10/10 12:39:40.731487 [kube-peers] Added myself to peer list &{[{7a:ae:37:39:0e:52 test-12533-0-1} {4e:b7:93:6b:2b:49 test-12533-0-2} {ea:46:33:c1:c2:0b test-12533-0-0}]}
DEBU: 2019/10/10 12:39:40.754070 [kube-peers] Nodes that have disappeared: map[ea:46:33:c1:c2:0b:{ea:46:33:c1:c2:0b test-12533-0-0}]
WARN: 2019/10/10 12:39:40.754200 [kube-peers] not removing myself {ea:46:33:c1:c2:0b test-12533-0-0}
DEBU: 2019/10/10 12:39:40.765571 [kube-peers] Nodes that have disappeared: map[ea:46:33:c1:c2:0b:{ea:46:33:c1:c2:0b test-12533-0-0}]
WARN: 2019/10/10 12:39:40.765677 [kube-peers] not removing myself {ea:46:33:c1:c2:0b test-12533-0-0}
DEBU: 2019/10/10 12:39:40.771195 [kube-peers] Nodes that have disappeared: map[ea:46:33:c1:c2:0b:{ea:46:33:c1:c2:0b test-12533-0-0}]
WARN: 2019/10/10 12:39:40.771284 [kube-peers] not removing myself {ea:46:33:c1:c2:0b test-12533-0-0}
```

I think it would have started doing this after #3454 