### PR TITLE
Reduce time test script waits for IPs to be reclaimed

### DIFF
--- a/test/870_weave_recovers_unreachable_ips_on_relaunch_3_test.sh
+++ b/test/870_weave_recovers_unreachable_ips_on_relaunch_3_test.sh
@@ -84,7 +84,7 @@ function relaunch_weave_pod {
 # Suite
 #
 function main {
-    local IPAM_RECOVER_DELAY=90
+    local IPAM_RECOVER_DELAY=10
 
     start_suite "Test weave-net deallocates from IPAM on node failure";
 


### PR DESCRIPTION
Now we have a callback when a node is removed, there should be no reason to wait 90 seconds.

The reclaim does wait up to 5 seconds before starting, so allowing 10 seconds in the script should be sufficient.

(I'm puzzled that #3399 put the timeout _up_)