### PR TITLE
Update to Go 1.13.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 defaults: &defaults
   docker:
-    - image: weaveworks/weavebuild:circle20-2e6504d3
+    - image: weaveworks/weavebuild:go-1-13-1-88d87f8e
   working_directory: /go/src/github.com/weaveworks/weave
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 defaults: &defaults
   docker:
-    - image: weaveworks/weavebuild:go-1-13-1-88d87f8e
+    - image: weaveworks/weavebuild:go-1-13-1-5110a604
   working_directory: /go/src/github.com/weaveworks/weave
 
 jobs:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -57,19 +57,6 @@ RUN go get \
 	github.com/fatih/hclfmt \
 	github.com/client9/misspell/cmd/misspell
 
-# First clean, because we're gonna rebuild the std both with -race enabled and disabled
-# Running go install std twice is intentional and required, as content is written in two different directories
-# (/usr/local/go/pkg/linux_amd64 vs /usr/local/go/pkg/linux_amd64_race)
-# The other architectures do not have support for -race
-RUN go clean -i net \
-	&& go install -tags netgo std \
-	&& go install -race -tags netgo std
-
-# Prebuild std for the other architectures
-RUN for platform in ${GO_CROSSPLATFORMS}; do \
-		GOOS=${platform%/*} GOARCH=${platform##*/} \
-			go install -tags netgo std; done
-
 # Allow full write access to the Go folders for anyone
 RUN chmod -R a+w /usr/local/go
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.1-buster
+FROM golang:1.13.3-buster
 
 # Support Raspberry Pi 2 and newer
 ENV GOARM 7

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.7-buster
+FROM golang:1.13.1-buster
 
 # Support Raspberry Pi 2 and newer
 ENV GOARM 7


### PR DESCRIPTION
After merging #3685 which took us to 1.12.7, I figure we may as well jump to the latest.

Needs an update to the `tools` submodule to cope with changes in `go vet`
