### PR TITLE
Update weaveworks/mesh to v0.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -686,12 +686,12 @@
   revision = "6b0aa22550d9325eb8f43418185859e13dc0de1d"
 
 [[projects]]
-  digest = "1:277e090a58afaeb00fb9fd04e2b2f3466ff8fb327a331e0e531a3399a72697e3"
+  digest = "1:ef8d0a1f90a33a968984ba2159a02304c591bbe964ad13e6408bf361975b3a58"
   name = "github.com/weaveworks/mesh"
   packages = ["."]
   pruneopts = "UT"
-  revision = "38e8100dfbc7b28ae8ffde5a2bbeceec57ffa52a"
-  version = "v0.1"
+  revision = "8889a805f7f6fe19a40dd175575d7f5efb7eda79"
+  version = "v0.3"
 
 [[projects]]
   branch = "master"

--- a/test/150_connect_forget_2_test.sh
+++ b/test/150_connect_forget_2_test.sh
@@ -26,10 +26,15 @@ start_container $HOST2 $C2/24 --name=c2
 assert_raises "weave_on $HOST2 connect 10.2.2.1 10.2.2.2"
 assert_peers $HOST2 "10.2.2.1\n10.2.2.2"
 
+sleep 2  # Allow topology to propagate
+
 # Replace bogus hosts with real hosts
 assert_raises "exec_on $HOST1 c1 sh -c '! $PING $C2'"
 assert_raises "weave_on $HOST2 connect --replace $HOST1 $HOST2"
 assert_peers $HOST2 "$HOST1\n$HOST2"
+
+sleep 2  # Allow topology to propagate
+
 assert_raises "exec_on $HOST1 c1 $PING $C2"
 
 # Forget everyone and disconnect
@@ -37,6 +42,9 @@ assert_raises "weave_on $HOST2 forget $HOST1 $HOST2"
 assert_raises "stop_weave_on $HOST1"
 assert_raises "weave_on $HOST1 launch"
 assert_peers $HOST2 ""
+
+sleep 2  # Allow topology to propagate
+
 assert_raises "exec_on $HOST1 c1 sh -c '! $PING $C2'"
 
 end_suite

--- a/test/191_create_bridge_2_test.sh
+++ b/test/191_create_bridge_2_test.sh
@@ -9,7 +9,7 @@ kill_weaver() {
     run_on $HOST1 sudo ip link set weave down
     WEAVER_PID=$(container_pid $HOST1 weave)
     run_on $HOST1 sudo kill -9 $WEAVER_PID
-    sleep 3
+    sleep 5
 }
 
 start_suite "Re-create bridge after restart"
@@ -20,6 +20,7 @@ WEAVE_NO_FASTDP=1 weave_on $HOST2 launch $HOST1
 
 start_container $HOST1 $C1/24 --name=c1
 start_container $HOST2 $C2/24 --name=c2
+sleep 2 # give topology gossip some time to propagate
 assert_raises "exec_on $HOST1 c1 $PING $C2"
 
 kill_weaver # should re-create the bridge
@@ -30,6 +31,7 @@ assert_raises "exec_on $HOST1 c1 $PING $C2"
 weave_on $HOST1 reset
 weave_on $HOST1 launch $HOST2
 weave_on $HOST1 attach $C1/24 c1
+sleep 2 # give topology gossip some time to propagate
 assert_raises "exec_on $HOST1 c1 $PING $C2"
 
 kill_weaver # should re-create the bridge

--- a/test/210_dns_cross_hosts_3_test.sh
+++ b/test/210_dns_cross_hosts_3_test.sh
@@ -16,6 +16,8 @@ for host in $HOSTS; do
     weave_on $host launch --ipalloc-range $UNIVERSE $HOSTS
 done
 
+sleep 2  # Allow topology updates to propagate
+
 # Basic test
 start_container          $HOST2 $C2/24 --name=c2 -h $NAME2
 start_container_with_dns $HOST1 $C1/24 --name=c1

--- a/test/215_stale_dns_3_test.sh
+++ b/test/215_stale_dns_3_test.sh
@@ -8,6 +8,8 @@ weave_on $HOST1 launch --no-discovery
 weave_on $HOST2 launch --no-discovery $HOST1
 weave_on $HOST3 launch --no-discovery $HOST2
 
+sleep 2  # Allow topology updates to propagate
+
 start_container $HOST1 --name=c1
 C1=$(container_ip $HOST1 c1)
 start_container_with_dns $HOST3 --name=c3
@@ -25,7 +27,7 @@ weave_on $HOST1 launch --no-discovery $HOST3
 # Now re-enable gossip from host2 to host3
 run_on $HOST3 "sudo iptables -D INPUT -s $HOST2 -j DROP"
 
-sleep 1
+sleep 2 # allow some time for connections to reform and updates to propagate
 
 assert_no_dns_record $HOST3 c3 c1.weave.local
 

--- a/test/380_ipam_seed_2_test.sh
+++ b/test/380_ipam_seed_2_test.sh
@@ -15,6 +15,9 @@ assert_raises "timeout 10 cat <( start_container $HOST2 --name c2)"
 # Connect routers
 weave_on $HOST2 connect $HOST1
 
+# Allow topology to propagate
+sleep 2
+
 # Check connectivity
 assert_raises "exec_on $HOST1 c1 $PING c2"
 assert_raises "exec_on $HOST2 c2 $PING c1"

--- a/test/800_plugin_cross_hosts_2_test.sh
+++ b/test/800_plugin_cross_hosts_2_test.sh
@@ -15,6 +15,8 @@ weave_on $HOST2 launch $HOST1
 start_container_local_plugin $HOST1 --name=c1 --hostname=$C1_NAME --dns=$DNS_IP
 start_container_local_plugin $HOST2 --name=c2 --hostname=$C2_NAME --dns=$DNS_IP
 
+sleep 2  # Allow topology to propagate
+
 assert_raises "exec_on $HOST1 c1 $PING $C2_NAME"
 assert_raises "exec_on $HOST2 c2 $PING $C1_NAME"
 

--- a/vendor/github.com/weaveworks/mesh/README.md
+++ b/vendor/github.com/weaveworks/mesh/README.md
@@ -77,3 +77,12 @@ All contributions should be made as pull requests that satisfy the guidelines, b
 In addition, several mechanical checks are enforced.
 See [the lint script](/lint) for details.
 
+## <a name="help"></a>Getting Help
+
+If you have any questions about, feedback for or problems with `mesh`:
+
+- Invite yourself to the <a href="https://slack.weave.works/" target="_blank">Weave Users Slack</a>.
+- Ask a question on the [#general](https://weave-community.slack.com/messages/general/) slack channel.
+- [File an issue](https://github.com/weaveworks/mesh/issues/new).
+
+Your feedback is always welcome!

--- a/vendor/github.com/weaveworks/mesh/connection_maker.go
+++ b/vendor/github.com/weaveworks/mesh/connection_maker.go
@@ -93,7 +93,7 @@ func (cm *connectionMaker) InitiateConnections(peers []string, replace bool) []e
 		}
 		if host == "" || !isAlnum(port) {
 			errors = append(errors, fmt.Errorf("invalid peer name %q, should be host[:port]", peer))
-		} else if addr, err := net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%s", host, port)); err != nil {
+		} else if addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%s", host, port)); err != nil {
 			errors = append(errors, err)
 		} else {
 			addrs[peer] = addr

--- a/vendor/github.com/weaveworks/mesh/local_peer.go
+++ b/vendor/github.com/weaveworks/mesh/local_peer.go
@@ -8,13 +8,20 @@ import (
 	"time"
 )
 
+const (
+	deferTopologyUpdateDuration = 1 * time.Second
+)
+
 // localPeer is the only "active" peer in the mesh. It extends Peer with
 // additional behaviors, mostly to retrieve and manage connection state.
 type localPeer struct {
 	sync.RWMutex
 	*Peer
-	router     *Router
-	actionChan chan<- localPeerAction
+	router                *Router
+	actionChan            chan<- localPeerAction
+	topologyUpdates       peerNameSet
+	timer                 *time.Timer
+	pendingTopologyUpdate bool
 }
 
 // The actor closure used by localPeer.
@@ -23,11 +30,15 @@ type localPeerAction func()
 // newLocalPeer returns a usable LocalPeer.
 func newLocalPeer(name PeerName, nickName string, router *Router) *localPeer {
 	actionChan := make(chan localPeerAction, ChannelSize)
+	topologyUpdates := make(peerNameSet)
 	peer := &localPeer{
-		Peer:       newPeer(name, nickName, randomPeerUID(), 0, randomPeerShortID()),
-		router:     router,
-		actionChan: actionChan,
+		Peer:            newPeer(name, nickName, randomPeerUID(), 0, randomPeerShortID()),
+		router:          router,
+		actionChan:      actionChan,
+		topologyUpdates: topologyUpdates,
+		timer:           time.NewTimer(deferTopologyUpdateDuration),
 	}
+	peer.timer.Stop()
 	go peer.actorLoop(actionChan)
 	return peer
 }
@@ -82,15 +93,15 @@ func (peer *localPeer) createConnection(localAddr string, peerAddr string, accep
 	if err := peer.checkConnectionLimit(); err != nil {
 		return err
 	}
-	localTCPAddr, err := net.ResolveTCPAddr("tcp4", localAddr)
+	localTCPAddr, err := net.ResolveTCPAddr("tcp", localAddr)
 	if err != nil {
 		return err
 	}
-	remoteTCPAddr, err := net.ResolveTCPAddr("tcp4", peerAddr)
+	remoteTCPAddr, err := net.ResolveTCPAddr("tcp", peerAddr)
 	if err != nil {
 		return err
 	}
-	tcpConn, err := net.DialTCP("tcp4", localTCPAddr, remoteTCPAddr)
+	tcpConn, err := net.DialTCP("tcp", localTCPAddr, remoteTCPAddr)
 	if err != nil {
 		return err
 	}
@@ -136,6 +147,10 @@ func (peer *localPeer) encode(enc *gob.Encoder) {
 // ACTOR server
 
 func (peer *localPeer) actorLoop(actionChan <-chan localPeerAction) {
+	gossipInterval := defaultGossipInterval
+	if peer.router != nil {
+		gossipInterval = peer.router.gossipInterval()
+	}
 	gossipTimer := time.Tick(gossipInterval)
 	for {
 		select {
@@ -143,8 +158,20 @@ func (peer *localPeer) actorLoop(actionChan <-chan localPeerAction) {
 			action()
 		case <-gossipTimer:
 			peer.router.sendAllGossip()
+		case <-peer.timer.C:
+			peer.broadcastPendingTopologyUpdates()
 		}
 	}
+}
+
+func (peer *localPeer) broadcastPendingTopologyUpdates() {
+	peer.Lock()
+	gossipData := peer.topologyUpdates
+	peer.topologyUpdates = make(peerNameSet)
+	peer.pendingTopologyUpdate = false
+	peer.Unlock()
+	gossipData[peer.Peer.Name] = struct{}{}
+	peer.router.broadcastTopologyUpdate(gossipData)
 }
 
 func (peer *localPeer) handleAddConnection(conn ourConnection, isRestartedPeer bool) error {
@@ -190,7 +217,6 @@ func (peer *localPeer) handleAddConnection(conn ourConnection, isRestartedPeer b
 		conn.logf("connection added (new peer)")
 		peer.router.sendAllGossipDown(conn)
 	}
-
 	peer.router.Routes.recalculate()
 	peer.broadcastPeerUpdate(conn.Remote())
 
@@ -240,7 +266,15 @@ func (peer *localPeer) broadcastPeerUpdate(peers ...*Peer) {
 	// context of a test, but that will involve significant
 	// reworking of tests.
 	if peer.router != nil {
-		peer.router.broadcastTopologyUpdate(append(peers, peer.Peer))
+		peer.Lock()
+		defer peer.Unlock()
+		if !peer.pendingTopologyUpdate {
+			peer.timer.Reset(deferTopologyUpdateDuration)
+			peer.pendingTopologyUpdate = true
+		}
+		for _, p := range peers {
+			peer.topologyUpdates[p.Name] = struct{}{}
+		}
 	}
 }
 

--- a/vendor/github.com/weaveworks/mesh/overlay.go
+++ b/vendor/github.com/weaveworks/mesh/overlay.go
@@ -108,7 +108,11 @@ func (NullOverlay) Diagnostics() interface{} { return nil }
 func (NullOverlay) Confirm() {}
 
 // EstablishedChannel implements OverlayConnection.
-func (NullOverlay) EstablishedChannel() <-chan struct{} { return nil }
+func (NullOverlay) EstablishedChannel() <-chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}
 
 // ErrorChannel implements OverlayConnection.
 func (NullOverlay) ErrorChannel() <-chan error { return nil }

--- a/vendor/github.com/weaveworks/mesh/peers.go
+++ b/vendor/github.com/weaveworks/mesh/peers.go
@@ -6,6 +6,11 @@ import (
 	"io"
 	"math/rand"
 	"sync"
+	"time"
+)
+
+const (
+	gcInterval = 1 * time.Second
 )
 
 // Peers collects all of the known peers in the mesh, including ourself.
@@ -18,6 +23,8 @@ type Peers struct {
 
 	// Called when the mapping from short IDs to peers changes
 	onInvalidateShortIDs []func()
+	timer                *time.Timer
+	pendingGC            bool
 }
 
 type shortIDPeers struct {
@@ -60,8 +67,11 @@ func newPeers(ourself *localPeer) *Peers {
 		ourself:   ourself,
 		byName:    make(map[PeerName]*Peer),
 		byShortID: make(map[PeerShortID]shortIDPeers),
+		timer:     time.NewTimer(gcInterval),
 	}
 	peers.fetchWithDefault(ourself.Peer)
+	peers.timer.Stop()
+	go peers.actorLoop()
 	return peers
 }
 
@@ -339,6 +349,18 @@ func (peers *Peers) forEach(fun func(*Peer)) {
 	}
 }
 
+func (peers *Peers) actorLoop() {
+	for {
+		select {
+		case <-peers.timer.C:
+			peers.GarbageCollect()
+			peers.Lock()
+			peers.pendingGC = false
+			peers.Unlock()
+		}
+	}
+}
+
 // Merge an incoming update with our own topology.
 //
 // We add peers hitherto unknown to us, and update peers for which the
@@ -363,7 +385,6 @@ func (peers *Peers) applyUpdate(update []byte) (peerNameSet, peerNameSet, error)
 
 	// Now apply the updates
 	newUpdate := peers.applyDecodedUpdate(decodedUpdate, decodedConns, &pending)
-	peers.garbageCollect(&pending)
 	for _, peerRemoved := range pending.removed {
 		delete(newUpdate, peerRemoved.Name)
 	}
@@ -371,6 +392,13 @@ func (peers *Peers) applyUpdate(update []byte) (peerNameSet, peerNameSet, error)
 	updateNames := make(peerNameSet)
 	for _, peer := range decodedUpdate {
 		updateNames[peer.Name] = struct{}{}
+	}
+
+	if !peers.pendingGC {
+		// schedule a GarbageCollect() to run after gcInterval time period
+		// corresponding to all topology updates received during the period
+		peers.timer.Reset(gcInterval)
+		peers.pendingGC = true
 	}
 
 	return updateNames, newUpdate, nil

--- a/vendor/github.com/weaveworks/mesh/protocol.go
+++ b/vendor/github.com/weaveworks/mesh/protocol.go
@@ -54,10 +54,10 @@ type protocolIntroConn interface {
 type protocolIntroParams struct {
 	MinVersion byte
 	MaxVersion byte
+	Outbound   bool
 	Features   map[string]string
 	Conn       protocolIntroConn
 	Password   []byte
-	Outbound   bool
 }
 
 // The results from a successful protocol intro.

--- a/vendor/github.com/weaveworks/mesh/status.go
+++ b/vendor/github.com/weaveworks/mesh/status.go
@@ -30,7 +30,7 @@ type Status struct {
 func NewStatus(router *Router) *Status {
 	return &Status{
 		Protocol:           Protocol,
-		ProtocolMinVersion: ProtocolMinVersion,
+		ProtocolMinVersion: int(router.ProtocolMinVersion),
 		ProtocolMaxVersion: ProtocolMaxVersion,
 		Encryption:         router.usingPassword(),
 		PeerDiscovery:      router.PeerDiscovery,

--- a/vendor/github.com/weaveworks/mesh/surrogate_gossiper.go
+++ b/vendor/github.com/weaveworks/mesh/surrogate_gossiper.go
@@ -11,6 +11,7 @@ import (
 type surrogateGossiper struct {
 	sync.Mutex
 	prevUpdates []prevUpdate
+	router      *Router
 }
 
 type prevUpdate struct {
@@ -56,6 +57,10 @@ func (s *surrogateGossiper) OnGossip(update []byte) (GossipData, error) {
 	// (this time limit is arbitrary; surrogateGossiper should pass on new gossip immediately
 	// so there should be no reason for a duplicate to show up after a long time)
 	updateTime := now()
+	gossipInterval := defaultGossipInterval
+	if s.router != nil {
+		gossipInterval = s.router.gossipInterval()
+	}
 	deleteBefore := updateTime.Add(-gossipInterval)
 	keepFrom := len(s.prevUpdates)
 	for i, p := range s.prevUpdates {


### PR DESCRIPTION
This release has a number of changes to defer updates by up to one second, to reduce the cpu usage of route recalculation and reduce network bandwith for topology updates.

The effect is it behaves much better on networks of over 100 nodes.