### PR TITLE
Randomise wait to reclaim IPs on node deletion, and fix flaky test 870

### DIFF
--- a/prog/kube-utils/main.go
+++ b/prog/kube-utils/main.go
@@ -354,6 +354,7 @@ func main() {
 		ch := make(chan os.Signal)
 		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 		stopCh := make(chan struct{})
+		rand.Seed(time.Now().UnixNano())
 		registerForNodeUpdates(c, stopCh, nodeName, peerName)
 		<-ch
 		close(stopCh)

--- a/prog/kube-utils/main.go
+++ b/prog/kube-utils/main.go
@@ -259,6 +259,13 @@ func registerForNodeUpdates(client *kubernetes.Clientset, stopCh <-chan struct{}
 	common.Log.Debugln("registering for updates for node delete events")
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
+			var name string
+			if apiObj, ok := obj.(api.Object); ok {
+				name = apiObj.GetName()
+			} else {
+				name = fmt.Sprintf("%#v", obj)
+			}
+			common.Log.Debugln("Delete event for", name)
 			// add random delay to avoid all nodes acting on node delete event at the same
 			// time leading to contention to use `weave-net` configmap
 			r := rand.Intn(5000)

--- a/prog/kube-utils/main.go
+++ b/prog/kube-utils/main.go
@@ -348,14 +348,6 @@ func main() {
 		}
 		return
 	}
-	peers, err := getKubePeers(c, false)
-	if err != nil {
-		common.Log.Fatalf("[kube-peers] Could not get peers: %v", err)
-	}
-	for _, node := range peers {
-		fmt.Println(node.addr)
-	}
-
 	if runReclaimDaemon {
 		// Handle SIGINT and SIGTERM
 		ch := make(chan os.Signal)
@@ -365,5 +357,14 @@ func main() {
 		registerForNodeUpdates(c, stopCh, nodeName, peerName)
 		<-ch
 		close(stopCh)
+		return
+	}
+
+	peers, err := getKubePeers(c, false)
+	if err != nil {
+		common.Log.Fatalf("[kube-peers] Could not get peers: %v", err)
+	}
+	for _, node := range peers {
+		fmt.Println(node.addr)
 	}
 }

--- a/prog/kube-utils/peerlist_test.go
+++ b/prog/kube-utils/peerlist_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -71,6 +72,7 @@ func doConcurrentIterations(iterations, concurrency int, f func(int)) {
 }
 
 func TestPeerListFuzz(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
 	const (
 		testIters   = 1000
 		maxNodes    = 100

--- a/test/870_weave_recovers_unreachable_ips_on_relaunch_3_test.sh
+++ b/test/870_weave_recovers_unreachable_ips_on_relaunch_3_test.sh
@@ -86,7 +86,7 @@ function relaunch_weave_pod {
 # Suite
 #
 function main {
-    local IPAM_RECOVER_DELAY=90
+    local IPAM_RECOVER_DELAY=10
 
     start_suite "Test weave-net deallocates from IPAM on node failure";
 

--- a/test/870_weave_recovers_unreachable_ips_on_relaunch_3_test.sh
+++ b/test/870_weave_recovers_unreachable_ips_on_relaunch_3_test.sh
@@ -54,6 +54,8 @@ function setup_kubernetes_cluster {
 }
 
 function force_drop_node {
+    greyly echo "Shutting down Kubernetes on node $1"
+    run_on $1 "sudo kubeadm reset --force"
     greyly echo "Dropping node $1 with 'sudo kubectl delete node'"
     local target=$(echo "$1" | awk -F"." '{print $1}')
     run_on $HOST1 "$KUBECTL delete node $target"


### PR DESCRIPTION
Fixes #3690 - we should shut down Kubernetes before deleting the node otherwise Weave Net can restart.

While debugging this I found a few other things wrong with the `kube-utils` program, notably that the randomised wait would always take 3.081 seconds so we got a thundering herd every time.

And reduce the wait in the test script - now we have a callback when a node is removed and ipam broadcasts the reclaim, there should be no reason to wait 90 seconds.