### PR TITLE
Remove the need for a third host in test 320

### DIFF
--- a/test/320_claim_2_test.sh
+++ b/test/320_claim_2_test.sh
@@ -44,20 +44,8 @@ assert_raises "exec_on $HOST1 c1 $PING $C3"
 stop_weave_on $HOST1
 stop_weave_on $HOST2
 
-delete_persistence $HOST1 $HOST2
-
 # Now make host1 attempt to claim from host2, when host2 is stopped
 # the point being to check whether host1 will hang trying to talk to host2
-weave_on $HOST2 launch --ipalloc-range $UNIVERSE
-weave_on $HOST2 prime
-# Introduce host3 to remember the IPAM CRDT when we stop host2
-weave_on $HOST3 launch --ipalloc-range $UNIVERSE $HOST2
-weave_on $HOST3 prime
-stop_weave_on $HOST2
-weave_on $HOST1 launch --ipalloc-range $UNIVERSE $HOST3
-
-stop_weave_on $HOST1
-stop_weave_on $HOST3
 
 # Delete persistence data on host1, so that host1 would try to establish a ring.
 delete_persistence $HOST1


### PR DESCRIPTION
This was necessary when we didn't have ipam persistence, as the comment said "to remember the IPAM CRDT when we stop host2". 

But we have persistence to hold the CRDT so we don't need host3.

Rename the test so the test runner only gives it 2 hosts.