### PR TITLE
Add weave-daemonset-k8s-1.11.yaml to release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -93,6 +93,7 @@ build() {
     sed -i.bak -e "s/:latest/:$VERSION/" -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset-k8s-1.7.yaml
     sed -i.bak -e "s/:latest/:$VERSION/" -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset-k8s-1.8.yaml
     sed -i.bak -e "s/:latest/:$VERSION/" -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset-k8s-1.9.yaml
+    sed -i.bak -e "s/:latest/:$VERSION/" -e "/imagePullPolicy: Always/d" ./prog/weave-kube/weave-daemonset-k8s-1.11.yaml
     make SUDO=$SUDO WEAVE_VERSION=$VERSION DOCKERHUB_USER=$DOCKERHUB_USER
 
     if make tests; then
@@ -189,6 +190,13 @@ draft() {
         --name "weave-daemonset-k8s-1.9.yaml" \
         --file "./prog/weave-kube/weave-daemonset-k8s-1.9.yaml"
  
+    github-release upload \
+        --user $GITHUB_USER \
+        --repo weave \
+        --tag $LATEST_TAG \
+        --name "weave-daemonset-k8s-1.11.yaml" \
+        --file "./prog/weave-kube/weave-daemonset-k8s-1.11.yaml"
+
     echo "** Draft $TYPE $RELEASE_NAME $VERSION created at"
     echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG"
 }
@@ -303,6 +311,13 @@ publish() {
             --tag latest_release \
             --name "weave-daemonset-k8s-1.9.yaml" \
             --file "./prog/weave-kube/weave-daemonset-k8s-1.9.yaml"
+
+         github-release upload \
+            --user $GITHUB_USER \
+            --repo weave \
+            --tag latest_release \
+            --name "weave-daemonset-k8s-1.11.yaml" \
+            --file "./prog/weave-kube/weave-daemonset-k8s-1.11.yaml"
 
         echo "** Release $RELEASE_NAME $VERSION published at"
         echo -e "\thttps://github.com/$GITHUB_USER/weave/releases/$LATEST_TAG"


### PR DESCRIPTION
This is the manifest for Kubernetes 1.11 and above.
It was added to release 2.6 by hand, but this change will mean it gets included automatically next time.