### PR TITLE
Raise Kubernetes CPU requests from 10m to 50m

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.11.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.11.yaml
@@ -137,7 +137,7 @@ items:
                   port: 6784
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:
@@ -168,7 +168,7 @@ items:
 #npc-args
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:

--- a/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.6.yaml
@@ -117,7 +117,7 @@ items:
                   port: 6784
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:
@@ -144,7 +144,7 @@ items:
               imagePullPolicy: Always
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
           hostNetwork: true

--- a/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.7.yaml
@@ -126,7 +126,7 @@ items:
                   port: 6784
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:
@@ -156,7 +156,7 @@ items:
               imagePullPolicy: Always
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:

--- a/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
@@ -134,7 +134,7 @@ items:
                   port: 6784
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:
@@ -165,7 +165,7 @@ items:
 #npc-args
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:

--- a/prog/weave-kube/weave-daemonset-k8s-1.9.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.9.yaml
@@ -137,7 +137,7 @@ items:
                   port: 6784
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:
@@ -168,7 +168,7 @@ items:
 #npc-args
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:

--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -89,23 +89,18 @@ Kubernetes manages
 on each node, and only schedules pods to run on nodes that have enough
 free resources.
 
-The components of a typical Kubernetes installation (with the master
-node running etcd, scheduler, api-server, etc.) take up about 95% of a
-CPU, which leaves little room to run anything else. For all of Weave
-Net's features to work, it must run on every node, including the
-master.
+In the example manifests we request 10% of a CPU, which will be enough
+for small installations, but you should monitor how much it uses in
+your production clusters and adjust the requests to suit.
 
-The best way to resolve this issue is to use machines with at least
-two CPU cores. However if you are installing Kubernetes and Weave Net
-for the first time, you may not be aware of this requirement. For this
-reason, Weave Net launches as a DaemonSet with a specification that
-reserves at least 1% CPU for each container. This enables Weave Net to
-start up seamlessly on a single-CPU node.
+We do not recommend that you set a CPU or memory _limit_ unless you
+are very experienced in such matters, because the implementation of
+limits in the Linux kernel sometimes behaves in a surprising way.
 
-Depending on the workload, Weave Net may need more than 1% of the
-CPU. The percentage set in the DaemonSet is the minimum and not a
-limit. This minimum setting allows Weave Net to take advantage of
-available CPU and "burst" above that limit if it needs to.
+On a 1-node single-CPU cluster you may find Weave Net does not install
+at all, because other Kubernetes components already take 95% of the
+CPU. The best way to resolve this issue is to use machines with at
+least two CPU cores.
 
 ## <a name="eviction"></a>Pod Eviction
 


### PR DESCRIPTION
This setting is passed by Kubelet to the Linux scheduler to ask for a share of available CPU, so we should ask for a bit more than 1% of 1 CPU. Otherwise if a CPU is contended Weave Net will get throttled frequently.

Weave Net in fastdp mode shouldn't need a lot of CPU most of the time, but at startup there is quite a lot to do.

The setting is also used by the Kubernetes scheduler to decide how much will fit on a node, so setting it much higher will reserve CPU that we shouldn't need most of the time.