### PR TITLE
support Iptables 1.8 with legacy and nf_tables support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifeq ($(ARCH),amd64)
 	WEAVEEXEC_DOCKER_ARCH?=x86_64
 
 # The name of the alpine baseimage to use as the base for weave images
-	ALPINE_BASEIMAGE?=alpine:3.8
+	ALPINE_BASEIMAGE?=alpine:3.10
 
 # The extension for the made images
 # Specifying none means for example weaveworks/weave:latest

--- a/prog/weave-kube/launch.sh
+++ b/prog/weave-kube/launch.sh
@@ -28,9 +28,9 @@ setup_iptables_backend() {
       rm /sbin/iptables
       rm /sbin/iptables-save
       rm /sbin/iptables-restore
-      ln /sbin/iptables-nft /sbin/iptables
-      ln /sbin/iptables-nft-save /sbin/iptables-save
-      ln /sbin/iptables-nft-restore /sbin/iptables-restore
+      ln -s /sbin/iptables-nft /sbin/iptables
+      ln -s /sbin/iptables-nft-save /sbin/iptables-save
+      ln -s /sbin/iptables-nft-restore /sbin/iptables-restore
     fi
 }
 

--- a/prog/weave-npc/launch.sh
+++ b/prog/weave-npc/launch.sh
@@ -2,5 +2,35 @@
 
 set -e
 
+# Setup iptables backend to be legacy or nftable
+setup_iptables_backend() {
+    if [ -n "${IPTABLES_BACKEND}" ]; then
+      mode=$IPTABLES_BACKEND
+    else
+      # auto-detect if iptables backend mode to use if not specified explicitly
+      num_legacy_lines=$( (iptables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+      num_nft_lines=$( (iptables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+      if [ "${num_legacy_lines}" -ge 10 ]; then
+        mode="legacy"
+      else
+        if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+          mode="legacy"
+        else
+          mode="nft"
+        fi
+      fi
+    fi
+    if [ $mode = "nft" ]; then
+      rm /sbin/iptables
+      rm /sbin/iptables-save
+      rm /sbin/iptables-restore
+      ln /sbin/iptables-nft /sbin/iptables
+      ln /sbin/iptables-nft-save /sbin/iptables-save
+      ln /sbin/iptables-nft-restore /sbin/iptables-restore
+    fi
+}
+
+setup_iptables_backend
+
 # Start weave-npc with any flags specified in $EXTRA_ARGS as well as any flags passed to this container (for backwards compatibility)
 exec /usr/bin/weave-npc $EXTRA_ARGS $@

--- a/prog/weave-npc/launch.sh
+++ b/prog/weave-npc/launch.sh
@@ -24,9 +24,9 @@ setup_iptables_backend() {
       rm /sbin/iptables
       rm /sbin/iptables-save
       rm /sbin/iptables-restore
-      ln /sbin/iptables-nft /sbin/iptables
-      ln /sbin/iptables-nft-save /sbin/iptables-save
-      ln /sbin/iptables-nft-restore /sbin/iptables-restore
+      ln -s /sbin/iptables-nft /sbin/iptables
+      ln -s /sbin/iptables-nft-save /sbin/iptables-save
+      ln -s /sbin/iptables-nft-restore /sbin/iptables-restore
     fi
 }
 

--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -406,6 +406,7 @@ The list of variables you can set is:
 * `NO_MASQ_LOCAL` - set to 1 to preserve the client source IP address when
   accessing Service annotated with `service.spec.externalTrafficPolicy=Local`.
   The feature works only with Weave IPAM (default).
+* `IPTABLES_BACKEND` - set to `nft` to use `nftables` backend for `iptables` (default is `iptables`) 
 
 Example:
 ```


### PR DESCRIPTION

Fixes #3465

- upgrade to alpine image (for amd64 only) with iptables 1.8.3
- updated alpine image bundles both (legacy and nftable) version iptables, iptables-save, iptables-restore
- by default  iptables* commands soft linked to iptables-legacy*
- user can explicitly specify the iptable backed
- have borrowed back-end detection logic from kube-proxy

need to test with Kubernetes 1.17 which has kube-proxy in nft mode

