### PR TITLE
fix weave-kube manifests

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.11.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.11.yaml
@@ -8,7 +8,7 @@ items:
       labels:
         name: weave-net
       namespace: kube-system
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: weave-net
@@ -48,7 +48,7 @@ items:
         verbs:
         - patch
         - update
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: weave-net
@@ -62,7 +62,7 @@ items:
       - kind: ServiceAccount
         name: weave-net
         namespace: kube-system
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
       name: weave-net
@@ -85,7 +85,7 @@ items:
           - configmaps
         verbs:
           - create
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       name: weave-net
@@ -176,6 +176,7 @@ items:
                   mountPath: /run/xtables.lock
                   readOnly: false
           hostNetwork: true
+          dnsPolicy: ClusterFirstWithHostNet
           hostPID: true
           restartPolicy: Always
           securityContext:

--- a/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
@@ -8,7 +8,7 @@ items:
       labels:
         name: weave-net
       namespace: kube-system
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: weave-net
@@ -48,7 +48,7 @@ items:
         verbs:
         - patch
         - update
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: weave-net
@@ -62,7 +62,7 @@ items:
       - kind: ServiceAccount
         name: weave-net
         namespace: kube-system
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
       name: weave-net
@@ -85,7 +85,7 @@ items:
           - configmaps
         verbs:
           - create
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       name: weave-net

--- a/prog/weave-kube/weave-daemonset-k8s-1.9.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.9.yaml
@@ -8,7 +8,7 @@ items:
       labels:
         name: weave-net
       namespace: kube-system
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: weave-net
@@ -48,7 +48,7 @@ items:
         verbs:
         - patch
         - update
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: weave-net
@@ -62,7 +62,7 @@ items:
       - kind: ServiceAccount
         name: weave-net
         namespace: kube-system
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
       name: weave-net
@@ -85,7 +85,7 @@ items:
           - configmaps
         verbs:
           - create
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       name: weave-net


### PR DESCRIPTION
- add missing dnsPolicy: ClusterFirstWithHostNet in weave-daemonset-k8s-1.11.yaml
- update apiVersion from rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1

`dnsPolicy: ClusterFirstWithHostNet` was added in `weave-daemonset-k8s-1.8.yaml` but missing in `weave-daemonset-k8s-1.11.yaml`
