### PR TITLE
Add new 'type' and 'encryption' labels to weave_connections metric

### DIFF
--- a/test/101_cross_hosts_2_test.sh
+++ b/test/101_cross_hosts_2_test.sh
@@ -24,5 +24,6 @@ weave_on  $HOST2 attach $C2/24 c2
 
 wait_for_x network_tester_status "network tester status"
 assert "echo $status" "pass"
+assert "connections_metric $HOST1 state=\\\"established\\\"" "1"
 
 end_suite

--- a/test/101_cross_hosts_2_test.sh
+++ b/test/101_cross_hosts_2_test.sh
@@ -24,6 +24,6 @@ weave_on  $HOST2 attach $C2/24 c2
 
 wait_for_x network_tester_status "network tester status"
 assert "echo $status" "pass"
-assert "connections_metric $HOST1 state=\\\"established\\\"" "1"
+assert "connections_metric $HOST1 encryption=\\\"\\\",state=\\\"established\\\"" "1"
 
 end_suite

--- a/test/110_sleeve_encryption_2_test.sh
+++ b/test/110_sleeve_encryption_2_test.sh
@@ -16,5 +16,6 @@ assert_raises "exec_on $HOST1 c1 $PING $C2"
 
 assert_raises "weave_on $HOST1 status connections | grep -P 'encrypted *sleeve'"
 assert_raises "weave_on $HOST2 status connections | grep -P 'encrypted *sleeve'"
+assert "connections_metric $HOST1 encryption=\\\"yes\\\"",state=\\\"established\\\" "1"
 
 end_suite

--- a/test/111_fastdp_encryption_2_test.sh
+++ b/test/111_fastdp_encryption_2_test.sh
@@ -44,6 +44,7 @@ weave_on $HOST2 launch --password wfvAwt7sj $HOST1
 
 assert_raises "weave_on $HOST1 status connections | grep -P 'encrypted *fastdp'"
 assert_raises "weave_on $HOST2 status connections | grep -P 'encrypted *fastdp'"
+assert "connections_metric $HOST1 encryption=\\\"yes\\\"",state=\\\"established\\\" "1"
 
 PCAP1=$(mktemp)
 PCAP2=$(mktemp)

--- a/test/115_optional_encryption_2_test.sh
+++ b/test/115_optional_encryption_2_test.sh
@@ -17,6 +17,7 @@ weave_on $HOST1 launch --password wfvAwt7sj --trusted-subnets $HOST2_CIDR
 weave_on $HOST2 launch --password wfvAwt7sj $HOST1
 assert_raises "weave_on $HOST1 status connections | grep encrypted"
 assert_raises "weave_on $HOST2 status connections | grep encrypted"
+assert "connections_metric $HOST1 encryption=\\\"yes\\\"",state=\\\"established\\\" "1"
 
 weave_on $HOST1 stop
 weave_on $HOST2 stop
@@ -26,5 +27,6 @@ weave_on $HOST1 launch --password wfvAwt7sj --trusted-subnets $HOST2_CIDR
 weave_on $HOST2 launch --password wfvAwt7sj --trusted-subnets $HOST1_CIDR $HOST1
 assert_raises "weave_on $HOST1 status connections | grep unencrypted"
 assert_raises "weave_on $HOST2 status connections | grep unencrypted"
+assert "connections_metric $HOST1 encryption=\\\"\\\"",state=\\\"established\\\" "1"
 
 end_suite

--- a/test/config.sh
+++ b/test/config.sh
@@ -267,6 +267,10 @@ wait_for_attached() {
     wait_for_x "check_attached $1 $2" "$2 on $1 to be attached"
 }
 
+connections_metric() {
+    $SSH $1 curl -sS http://127.0.0.1:6784/metrics | awk -e "/^weave_connections.*$2/ { print \$2 }"
+}
+
 # assert_dns_record <host> <container> <name> [<ip> ...]
 assert_dns_record() {
     local host=$1


### PR DESCRIPTION
Fixes #3788 

Notes:
- I don't have a good way of testing this out locally, but `make` succeeds, so that's encouraging...
- instead of limiting the `state` label's value to the values in `allConnectionStates`, the state will reflect whatever's in `conn.State` (which _may_ be out of sync with `allConnectionStates` some day? 🤷‍♂)
- I felt like maybe logging some sort of error message if the value of the `name` attribute was a non-string, but not sure if this is really necessary. Maybe removing the check and allowing a panic instead would be better somehow?

Signed-off-by: Dave Henderson <dhenderson@gmail.com>