### PR TITLE
Disable accept_ra on Weave Net interfaces

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -279,6 +279,10 @@ func EnsureBridge(procPath string, config *BridgeConfig, log *logrus.Logger, ips
 			return bridgeType, errors.Wrap(err, "setting proxy_arp")
 		}
 	}
+	// No ipv6 router advertisments please
+	if err := sysctl(procPath, "net/ipv6/conf/"+config.WeaveBridgeName+"/accept_ra", "0"); err != nil {
+		return bridgeType, errors.Wrap(err, "setting accept_ra to 0")
+	}
 
 	if err := linkSetUpByName(config.WeaveBridgeName); err != nil {
 		return bridgeType, err

--- a/net/netns.go
+++ b/net/netns.go
@@ -55,9 +55,9 @@ func WithNetNSByPath(path string, work func() error) error {
 }
 
 func NSPathByPid(pid int) string {
-	return NSPathByPidWithRoot("/", pid)
+	return NSPathByPidWithProc("/proc", pid)
 }
 
-func NSPathByPidWithRoot(root string, pid int) string {
-	return filepath.Join(root, fmt.Sprintf("/proc/%d/ns/net", pid))
+func NSPathByPidWithProc(procPath string, pid int) string {
+	return filepath.Join(procPath, fmt.Sprint(pid), "/ns/net")
 }

--- a/net/veth.go
+++ b/net/veth.go
@@ -49,6 +49,13 @@ func CreateAndAttachVeth(procPath, name, peerName, bridgeName string, mtu int, k
 	if err := bridgeType.attach(veth); err != nil {
 		return cleanup("attaching veth %q to %q: %s", name, bridgeName, err)
 	}
+	// No ipv6 router advertisments please
+	if err := sysctl(procPath, "net/ipv6/conf/"+name+"/accept_ra", "0"); err != nil {
+		return cleanup("setting accept_ra to 0: %s", err)
+	}
+	if err := sysctl(procPath, "net/ipv6/conf/"+peerName+"/accept_ra", "0"); err != nil {
+		return cleanup("setting accept_ra to 0: %s", err)
+	}
 	if !bridgeType.IsFastdp() && !keepTXOn {
 		if err := EthtoolTXOff(veth.PeerName); err != nil {
 			return cleanup(`unable to set tx off on %q: %s`, peerName, err)

--- a/net/veth.go
+++ b/net/veth.go
@@ -236,7 +236,7 @@ func setupIface(procPath, ifaceName, newIfName string) error {
 }
 
 // configureARP is a helper for the Docker plugin which doesn't set the addresses itself
-func ConfigureARP(prefix, rootPath string) error {
+func ConfigureARP(prefix, procPath string) error {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return err
@@ -244,7 +244,7 @@ func ConfigureARP(prefix, rootPath string) error {
 	for _, link := range links {
 		ifName := link.Attrs().Name
 		if strings.HasPrefix(ifName, prefix) {
-			configureARPCache(rootPath+"/proc", ifName)
+			configureARPCache(procPath, ifName)
 			if addrs, err := netlink.AddrList(link, netlink.FAMILY_V4); err == nil {
 				for _, addr := range addrs {
 					arping.GratuitousArpOverIfaceByName(addr.IPNet.IP, ifName)

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -134,7 +134,7 @@ func (driver *driver) CreateEndpoint(create *api.CreateEndpointRequest) (*api.Cr
 
 	// create veths. note we assume endpoint IDs are unique in the first 9 chars
 	name, peerName := vethPair(create.EndpointID)
-	if _, err := weavenet.CreateAndAttachVeth(name, peerName, weavenet.WeaveBridgeName, 0, false, true, nil); err != nil {
+	if _, err := weavenet.CreateAndAttachVeth("/proc", name, peerName, weavenet.WeaveBridgeName, 0, false, true, nil); err != nil {
 		return nil, driver.error("JoinEndpoint", "%s", err)
 	}
 

--- a/plugin/net/driver.go
+++ b/plugin/net/driver.go
@@ -39,9 +39,10 @@ type driver struct {
 	// used only by plugin-v2
 	forceMulticast bool
 	networks       map[string]network
+	procPath       string
 }
 
-func New(client *docker.Client, weave *weaveapi.Client, name, scope string, dns, isPluginV2, forceMulticast bool) (skel.Driver, error) {
+func New(client *docker.Client, weave *weaveapi.Client, name, scope string, dns, isPluginV2, forceMulticast bool, procPath string) (skel.Driver, error) {
 	driver := &driver{
 		name:       name,
 		scope:      scope,
@@ -51,6 +52,7 @@ func New(client *docker.Client, weave *weaveapi.Client, name, scope string, dns,
 		// make sure that it's used only by plugin-v2
 		forceMulticast: isPluginV2 && forceMulticast,
 		networks:       make(map[string]network),
+		procPath:       procPath,
 	}
 
 	// Do not start watcher in the case of plugin v2, which prevents us from
@@ -134,7 +136,7 @@ func (driver *driver) CreateEndpoint(create *api.CreateEndpointRequest) (*api.Cr
 
 	// create veths. note we assume endpoint IDs are unique in the first 9 chars
 	name, peerName := vethPair(create.EndpointID)
-	if _, err := weavenet.CreateAndAttachVeth("/proc", name, peerName, weavenet.WeaveBridgeName, 0, false, true, nil); err != nil {
+	if _, err := weavenet.CreateAndAttachVeth(driver.procPath, name, peerName, weavenet.WeaveBridgeName, 0, false, true, nil); err != nil {
 		return nil, driver.error("JoinEndpoint", "%s", err)
 	}
 

--- a/plugin/net/watcher.go
+++ b/plugin/net/watcher.go
@@ -43,14 +43,9 @@ func (w *watcher) ContainerStarted(id string) {
 					w.driver.warn("ContainerStarted", "unable to register %s with weaveDNS: %s", id, err)
 				}
 			}
-			rootDir := "/"
-			if w.driver.isPluginV2 {
-				// We bind mount host's /proc to /host/proc for plugin-v2
-				rootDir = "/host"
-			}
-			netNSPath := weavenet.NSPathByPidWithRoot(rootDir, info.State.Pid)
+			netNSPath := weavenet.NSPathByPidWithProc(w.driver.procPath, info.State.Pid)
 			if err := weavenet.WithNetNSByPath(netNSPath, func() error {
-				return weavenet.ConfigureARP(weavenet.VethName, rootDir)
+				return weavenet.ConfigureARP(weavenet.VethName, w.driver.procPath)
 			}); err != nil {
 				w.driver.warn("ContainerStarted", "unable to configure interfaces: %s", err)
 			}

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -453,6 +453,7 @@ func main() {
 
 	pluginConfig.DNS = !noDNS
 	pluginConfig.DefaultSubnet = defaultSubnet.String()
+	pluginConfig.ProcPath = procPath
 	plugin := plugin.NewPlugin(pluginConfig)
 
 	// The weave script always waits for a status call to succeed,


### PR DESCRIPTION
To retain control over addressing and routing.

Slight refactor to keep the `/proc` path out of the weeds, and plumb through the setting to the Docker plugin rather than second-guessing it there.