### PR TITLE
Reload router iptables rules if they get cleared

### DIFF
--- a/net/expose.go
+++ b/net/expose.go
@@ -103,13 +103,8 @@ func addNatRule(ipt *iptables.IPTables, rulespec ...string) error {
 	// Loop until we get an exit code other than "temporarily unavailable"
 	for {
 		if err := ipt.AppendUnique("nat", "WEAVE", rulespec...); err != nil {
-			if ierr, ok := err.(*iptables.Error); ok {
-				if status, ok := ierr.ExitError.Sys().(syscall.WaitStatus); ok {
-					// (magic exit code 4 found in iptables source code; undocumented)
-					if status.ExitStatus() == 4 {
-						continue
-					}
-				}
+			if isResourceError(err) {
+				continue
 			}
 			return err
 		}

--- a/net/ipset/ipset.go
+++ b/net/ipset/ipset.go
@@ -26,7 +26,8 @@ type Interface interface {
 	Create(ipsetName Name, ipsetType Type) error
 	AddEntry(user types.UID, ipsetName Name, entry string, comment string) error
 	DelEntry(user types.UID, ipsetName Name, entry string) error
-	Exist(user types.UID, ipsetName Name, entry string) bool
+	EntryExists(user types.UID, ipsetName Name, entry string) bool
+	Exists(ipsetName Name) (bool, error)
 	Flush(ipsetName Name) error
 	Destroy(ipsetName Name) error
 
@@ -121,8 +122,22 @@ func (i *ipset) DelEntry(user types.UID, ipsetName Name, entry string) error {
 	return doExec("del", string(ipsetName), entry)
 }
 
-func (i *ipset) Exist(user types.UID, ipsetName Name, entry string) bool {
+func (i *ipset) EntryExists(user types.UID, ipsetName Name, entry string) bool {
 	return i.existUser(user, ipsetName, entry)
+}
+
+// Dummy way to check whether a given ipset exists.
+func (i *ipset) Exists(name Name) (bool, error) {
+	sets, err := i.List(string(name))
+	if err != nil {
+		return false, err
+	}
+	for _, s := range sets {
+		if s == name {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (i *ipset) Flush(ipsetName Name) error {

--- a/net/iptables.go
+++ b/net/iptables.go
@@ -130,10 +130,10 @@ const (
 	iptablesFlushPollTime = 100 * time.Millisecond
 )
 
-// Monitor periodically checks for a canary chain in iptables. If this canary chain goes missing it calls the reloadFunc.
+// MonitorForIptablesFlush periodically checks for a canary chain in iptables. If this canary chain goes missing it calls the reloadFunc.
 // This is a more efficient way of detecting whether firewalld or another process has been removing rules that we rely on.
 // The reloadFunc can then check whether other chains that should exist are still there, fix things and restore the canary.
-func Monitor(log *logrus.Logger, canary string, tables []string, reloadFunc func(), interval time.Duration, stopCh <-chan struct{}) {
+func MonitorForIptablesFlush(log *logrus.Logger, canary string, tables []string, reloadFunc func(), interval time.Duration, stopCh <-chan struct{}) {
 	ipt, err := iptables.New()
 	if err != nil {
 		log.Errorf("creating iptables object while initializing iptable Monitoring %s", err)

--- a/net/iptables.go
+++ b/net/iptables.go
@@ -130,7 +130,9 @@ const (
 	iptablesFlushPollTime = 100 * time.Millisecond
 )
 
-// Monitor is part of Interface
+// Monitor periodically checks for a canary chain in iptables. If this canary chain goes missing it calls the reloadFunc.
+// This is a more efficient way of detecting whether firewalld or another process has been removing rules that we rely on.
+// The reloadFunc can then check whether other chains that should exist are still there, fix things and restore the canary.
 func Monitor(log *logrus.Logger, canary string, tables []string, reloadFunc func(), interval time.Duration, stopCh <-chan struct{}) {
 	ipt, err := iptables.New()
 	if err != nil {

--- a/net/iptables.go
+++ b/net/iptables.go
@@ -2,9 +2,13 @@ package net
 
 import (
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 // AddChainWithRules creates a chain and appends given rules to it.
@@ -103,4 +107,118 @@ func ensureRulesAtTop(table, chain string, rulespecs [][]string, ipt *iptables.I
 	}
 
 	return nil
+}
+
+func chainExists(ipt *iptables.IPTables, table string, chain string) (bool, error) {
+	existingChains, err := ipt.ListChains(table)
+	if err != nil {
+		return false, errors.Wrapf(err, "ipt.ListChains(%s)", table)
+	}
+	chainMap := make(map[string]struct{})
+	for _, c := range existingChains {
+		chainMap[c] = struct{}{}
+	}
+
+	_, found := chainMap[chain]
+	return found, nil
+}
+
+const (
+	// Max time we wait for an iptables flush to complete after we notice it has started
+	iptablesFlushTimeout = 5 * time.Second
+	// How often we poll while waiting for an iptables flush to complete
+	iptablesFlushPollTime = 100 * time.Millisecond
+)
+
+// Monitor is part of Interface
+func Monitor(log *logrus.Logger, canary string, tables []string, reloadFunc func(), interval time.Duration, stopCh <-chan struct{}) {
+	ipt, err := iptables.New()
+	if err != nil {
+		log.Errorf("creating iptables object while initializing iptable Monitoring %s", err)
+		return
+	}
+
+	for {
+		_ = PollImmediateUntil(interval, func() (bool, error) {
+			for _, table := range tables {
+				if err := ensureChains(ipt, table, canary); err != nil {
+					log.Warningf("Could not set up iptables canary %s/%s: %v", table, canary, err)
+					return false, nil
+				}
+			}
+			return true, nil
+		}, stopCh)
+
+		// Poll until stopCh is closed or iptables is flushed
+		err = utilwait.PollUntil(interval, func() (bool, error) {
+			if exists, err := chainExists(ipt, tables[0], canary); exists {
+				return false, nil
+			} else if isResourceError(err) {
+				log.Warningf("Could not check for iptables canary %s/%s: %v", tables[0], canary, err)
+				return false, nil
+			}
+			log.Infof("iptables canary %s/%s deleted", tables[0], canary)
+
+			// Wait for the other canaries to be deleted too before returning
+			// so we don't start reloading too soon.
+			err := utilwait.PollImmediate(iptablesFlushPollTime, iptablesFlushTimeout, func() (bool, error) {
+				for i := 1; i < len(tables); i++ {
+					if exists, err := chainExists(ipt, tables[i], canary); exists || isResourceError(err) {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+			if err != nil {
+				log.Warning("Inconsistent iptables state detected.")
+			}
+			return true, nil
+		}, stopCh)
+
+		if err != nil {
+			// stopCh was closed
+			for _, table := range tables {
+				_ = ipt.DeleteChain(table, canary)
+			}
+			return
+		}
+
+		log.Infof("Reloading after iptables flush")
+		reloadFunc()
+	}
+}
+
+const iptablesStatusResourceProblem = 4
+
+// isResourceError returns true if the error indicates that iptables ran into a "resource
+// problem" and was unable to attempt the request. In particular, this will be true if it
+// times out trying to get the iptables lock.
+func isResourceError(err error) bool {
+	if ierr, ok := err.(*iptables.Error); ok {
+		if status, ok := ierr.ExitError.Sys().(syscall.WaitStatus); ok {
+			return status.ExitStatus() == iptablesStatusResourceProblem
+		}
+	}
+
+	return false
+}
+
+// PollImmediateUntil tries a condition func until it returns true, an error or stopCh is closed.
+//
+// PollImmediateUntil runs the 'condition' before waiting for the interval.
+// 'condition' will always be invoked at least once.
+func PollImmediateUntil(interval time.Duration, condition utilwait.ConditionFunc, stopCh <-chan struct{}) error {
+	done, err := condition()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	select {
+	case <-stopCh:
+		return utilwait.ErrWaitTimeout
+	default:
+		return utilwait.PollUntil(interval, condition, stopCh)
+	}
 }

--- a/npc/namespace.go
+++ b/npc/namespace.go
@@ -441,7 +441,7 @@ func (ns *ns) updateDefaultAllowIPSetEntry(oldObj, newObj *coreapi.Pod, ipsetNam
 	// Instead of iterating over all selectors we check whether old pod IP
 	// has been inserted into default-allow ipset to decide whether the IP
 	// in the ipset has to be updated.
-	if ns.ips.Exist(oldObj.ObjectMeta.UID, ipsetName, oldObj.Status.PodIP) {
+	if ns.ips.EntryExists(oldObj.ObjectMeta.UID, ipsetName, oldObj.Status.PodIP) {
 
 		if err := ns.ips.DelEntry(oldObj.ObjectMeta.UID, ipsetName, oldObj.Status.PodIP); err != nil {
 			return err

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -196,7 +196,7 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 	}
 
 	// delete `weave-local-pods` ipset which is no longer used by weave-npc
-	weaveLocalPodExist, err := ipsetExist(ips, npc.LocalIpset)
+	weaveLocalPodExist, err := ips.Exists(npc.LocalIpset)
 	if err != nil {
 		common.Log.Errorf("Failed to look if ipset '%s' exists", npc.LocalIpset)
 	} else if weaveLocalPodExist {
@@ -207,22 +207,6 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 	}
 
 	return nil
-}
-
-// Dummy way to check whether a given ipset exists.
-// TODO(brb) Use "ipset -exist create <..>" for our purpose instead (for some reasons
-// creating an ipset with -exist fails).
-func ipsetExist(ips ipset.Interface, name ipset.Name) (bool, error) {
-	sets, err := ips.List(string(name))
-	if err != nil {
-		return false, err
-	}
-	for _, s := range sets {
-		if s == name {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 func root(cmd *cobra.Command, args []string) {

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/weaveworks/common/mflagext"
 	"github.com/weaveworks/common/signals"
 	"github.com/weaveworks/mesh"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/weaveworks/weave/common"
 	"github.com/weaveworks/weave/common/docker"
@@ -529,7 +528,9 @@ func main() {
 
 			weavenet.Reexpose(&bridgeConfig, Log)
 		}
-		go weavenet.Monitor(Log, "WEAVE-CANARY", []string{"mangle", "nat", "filter"}, applyIPTables, iptablesRefresh, wait.NeverStop)
+		stopChan := make(chan struct{})
+		go weavenet.Monitor(Log, "WEAVE-CANARY", []string{"mangle", "nat", "filter"}, applyIPTables, iptablesRefresh, stopChan)
+		defer close(stopChan)
 	} else {
 		Log.Printf("Not refreshing iptables (interval: %v)", iptablesRefresh)
 	}

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -524,7 +524,7 @@ func main() {
 		weavenet.Reexpose(&bridgeConfig, Log)
 	}
 	stopChan := make(chan struct{})
-	go weavenet.Monitor(Log, "WEAVE-CANARY", []string{"mangle", "nat", "filter"}, applyIPTables, 10*time.Second, stopChan)
+	go weavenet.MonitorForIptablesFlush(Log, "WEAVE-CANARY", []string{"mangle", "nat", "filter"}, applyIPTables, 10*time.Second, stopChan)
 	defer close(stopChan)
 
 	signals.SignalHandlerLoop(common.Log, router)

--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -168,6 +168,7 @@ func main() {
 		procPath           string
 		discoveryEndpoint  string
 		token              string
+		iptablesRefresh    time.Duration
 		advertiseAddress   string
 		pluginConfig       plugin.Config
 		defaultDockerHost  = getenvOrDefault("DOCKER_HOST", "unix:///var/run/docker.sock")
@@ -216,6 +217,7 @@ func main() {
 	mflag.StringVar(&discoveryEndpoint, []string{"-peer-discovery-url"}, "https://cloud.weave.works/api/net", "url for peer discovery")
 	mflag.StringVar(&token, []string{"-token"}, "", "token for peer discovery")
 	mflag.StringVar(&advertiseAddress, []string{"-advertise-address"}, "", "address to advertise for peer discovery")
+	mflag.DurationVar(&iptablesRefresh, []string{"-iptables-refresh-interval"}, 10*time.Second, "Interval to reapply iptables. 0 to only apply on launch.")
 
 	mflag.BoolVar(&pluginConfig.Enable, []string{"-plugin"}, false, "enable Docker plugin (v1)")
 	mflag.BoolVar(&pluginConfig.EnableV2, []string{"-plugin-v2"}, false, "enable Docker plugin (v2)")
@@ -313,8 +315,11 @@ func main() {
 		}
 	}
 	ips := ipset.New(common.LogLogger(), 0)
+	err = weavenet.ResetIPTables(&bridgeConfig, ips)
+	checkFatal(err)
 	bridgeType, err := weavenet.EnsureBridge(procPath, &bridgeConfig, Log, ips)
 	checkFatal(err)
+
 	Log.Println("Bridge type is", bridgeType)
 
 	config.Password = determinePassword(password)
@@ -510,6 +515,29 @@ func main() {
 		// We remove the default route installed by the kernel,
 		// because awsvpc has installed it as well
 		go exposeForAWSVPC(allocator, defaultSubnet, bridgeConfig.WeaveBridgeName, waitReady.Add())
+	}
+
+	if iptablesRefresh > 0 {
+		Log.Printf("Entering iptable refresh loop (interval %v)", iptablesRefresh)
+		ticker := time.NewTicker(iptablesRefresh).C
+		go func() {
+			for {
+				select {
+				case <-ticker:
+					Log.Debug("Re-configuring iptables")
+					err := weavenet.ConfigureIPTables(&bridgeConfig, ips)
+					if err != nil {
+						Log.Errorf("Error configuring iptables: %s", err)
+					}
+
+					Log.Debug("Beginning re-exposure...")
+					weavenet.Reexpose(&bridgeConfig, Log)
+					Log.Debug("... re-exposure complete.")
+				}
+			}
+		}()
+	} else {
+		Log.Printf("Not refreshing iptables (interval: %v)", iptablesRefresh)
 	}
 
 	signals.SignalHandlerLoop(common.Log, router)

--- a/test/130_expose_2_test.sh
+++ b/test/130_expose_2_test.sh
@@ -27,10 +27,6 @@ exec_on1() {
     assert_raises "exec_on  $HOST1 $@"
 }
 
-wait_for_iptable_refresh() {
-    sleep 2
-}
-
 # Containers in the same subnet should be able to talk; different subnet not.
 check_container_connectivity() {
     exec_on1 "c1 $PING $C2"
@@ -43,7 +39,7 @@ check_container_connectivity() {
 
 start_suite "exposing weave network to host"
 
-weave_on $HOST1 launch --ipalloc-range $UNIVERSE --iptables-refresh-interval=1s
+weave_on $HOST1 launch --ipalloc-range $UNIVERSE
 
 start_container $HOST1 $C1/24 --name=c1
 start_container $HOST1 $C2/24 --name=c2
@@ -65,17 +61,8 @@ weave_on1 "expose $EXP/24"
 run_on1   "! $PING $C1"
 run_on1   "  $PING $C3"
 run_on1   "! $PING $C5"
-wait_for_iptable_refresh
-run_on1   "! $PING $C1"
-run_on1   "  $PING $C3"
-run_on1   "! $PING $C5"
-
 weave_on1 "expose"
 weave_on1 "expose"
-run_on1   "! $PING $C1"
-run_on1   "  $PING $C3"
-run_on1   "  $PING $C5"
-wait_for_iptable_refresh
 run_on1   "! $PING $C1"
 run_on1   "  $PING $C3"
 run_on1   "  $PING $C5"
@@ -86,14 +73,8 @@ weave_on1 "hide $EXP/24"
 weave_on1 "hide $EXP/24"
 run_on1   "! $PING $C3"
 run_on1   "  $PING $C5"
-wait_for_iptable_refresh
-run_on1   "! $PING $C3"
-run_on1   "  $PING $C5"
-
 weave_on1 "hide"
 weave_on1 "hide"
-run_on1   "! $PING $C5"
-wait_for_iptable_refresh
 run_on1   "! $PING $C5"
 
 # remote host connectivity after 'expose'

--- a/test/130_expose_2_test.sh
+++ b/test/130_expose_2_test.sh
@@ -27,6 +27,10 @@ exec_on1() {
     assert_raises "exec_on  $HOST1 $@"
 }
 
+wait_for_iptable_refresh() {
+    sleep 2
+}
+
 # Containers in the same subnet should be able to talk; different subnet not.
 check_container_connectivity() {
     exec_on1 "c1 $PING $C2"
@@ -39,7 +43,7 @@ check_container_connectivity() {
 
 start_suite "exposing weave network to host"
 
-weave_on $HOST1 launch --ipalloc-range $UNIVERSE
+weave_on $HOST1 launch --ipalloc-range $UNIVERSE --iptables-refresh-interval=1s
 
 start_container $HOST1 $C1/24 --name=c1
 start_container $HOST1 $C2/24 --name=c2
@@ -61,8 +65,17 @@ weave_on1 "expose $EXP/24"
 run_on1   "! $PING $C1"
 run_on1   "  $PING $C3"
 run_on1   "! $PING $C5"
+wait_for_iptable_refresh
+run_on1   "! $PING $C1"
+run_on1   "  $PING $C3"
+run_on1   "! $PING $C5"
+
 weave_on1 "expose"
 weave_on1 "expose"
+run_on1   "! $PING $C1"
+run_on1   "  $PING $C3"
+run_on1   "  $PING $C5"
+wait_for_iptable_refresh
 run_on1   "! $PING $C1"
 run_on1   "  $PING $C3"
 run_on1   "  $PING $C5"
@@ -73,8 +86,14 @@ weave_on1 "hide $EXP/24"
 weave_on1 "hide $EXP/24"
 run_on1   "! $PING $C3"
 run_on1   "  $PING $C5"
+wait_for_iptable_refresh
+run_on1   "! $PING $C3"
+run_on1   "  $PING $C5"
+
 weave_on1 "hide"
 weave_on1 "hide"
+run_on1   "! $PING $C5"
+wait_for_iptable_refresh
 run_on1   "! $PING $C5"
 
 # remote host connectivity after 'expose'

--- a/test/135_expose_iptables_refresh.sh
+++ b/test/135_expose_iptables_refresh.sh
@@ -29,7 +29,7 @@ start_suite "exposing weave network to host"
 ## Check no refreshing
 weave_on1 "launch --iptables-refresh-interval=0s"
 IPT_BEFORE=$(get_weave_iptable_rules)
-run_on1 "sudo iptables -t nat -D POSTROUTING -j WEAVE"
+run_on1 "sudo iptables -t nat -X WEAVE-CANARY"
 wait_for_iptable_refresh
 IPT_AFTER=$(get_weave_iptable_rules)
 assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 1
@@ -38,7 +38,7 @@ stop_weave_on1
 ## Check refreshing
 weave_on1 "launch --iptables-refresh-interval=1s"
 IPT_BEFORE=$(get_weave_iptable_rules)
-run_on1 "sudo iptables -t nat -D POSTROUTING -j WEAVE"
+run_on1 "sudo iptables -t nat -X WEAVE-CANARY"
 wait_for_iptable_refresh
 IPT_AFTER=$(get_weave_iptable_rules)
 assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 0
@@ -50,7 +50,7 @@ stop_weave_on1
 weave_on1 "launch --iptables-refresh-interval=0s"
 weave_on1 "expose"
 IPT_BEFORE=$(get_weave_iptable_rules)
-run_on1 "sudo iptables -D FORWARD -o weave -j WEAVE-EXPOSE"
+run_on1 "sudo iptables -t nat -X WEAVE-CANARY"
 wait_for_iptable_refresh
 IPT_AFTER=$(get_weave_iptable_rules)
 assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 1
@@ -60,7 +60,7 @@ stop_weave_on1
 weave_on1 "launch --iptables-refresh-interval=1s"
 weave_on1 "expose"
 IPT_BEFORE=$(get_weave_iptable_rules)
-run_on1 "sudo iptables -D FORWARD -o weave -j WEAVE-EXPOSE"
+run_on1 "sudo iptables -t nat -X WEAVE-CANARY"
 wait_for_iptable_refresh
 IPT_AFTER=$(get_weave_iptable_rules)
 assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 0

--- a/test/135_expose_iptables_refresh.sh
+++ b/test/135_expose_iptables_refresh.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+. "$(dirname "$0")/config.sh"
+
+run_on1() {
+    assert_raises "run_on $HOST1 $@"
+}
+
+weave_on1() {
+    assert_raises "weave_on $HOST1 $@"
+}
+
+stop_weave_on1() {
+    assert_raises "stop_weave_on $HOST1 $@"
+}
+
+get_weave_iptable_rules() {
+    get_command_output_on $HOST1 "sudo iptables-save | grep -i weave"
+}
+
+wait_for_iptable_refresh() {
+    sleep 2
+}
+
+start_suite "exposing weave network to host"
+
+# Launch
+
+## Check no refreshing
+weave_on1 "launch --iptables-refresh-interval=0s"
+IPT_BEFORE=$(get_weave_iptable_rules)
+run_on1 "sudo iptables -t nat -D POSTROUTING -j WEAVE"
+wait_for_iptable_refresh
+IPT_AFTER=$(get_weave_iptable_rules)
+assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 1
+stop_weave_on1
+
+## Check refreshing
+weave_on1 "launch --iptables-refresh-interval=1s"
+IPT_BEFORE=$(get_weave_iptable_rules)
+run_on1 "sudo iptables -t nat -D POSTROUTING -j WEAVE"
+wait_for_iptable_refresh
+IPT_AFTER=$(get_weave_iptable_rules)
+assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 0
+stop_weave_on1
+
+# Expose
+
+## Check no refreshing
+weave_on1 "launch --iptables-refresh-interval=0s"
+weave_on1 "expose"
+IPT_BEFORE=$(get_weave_iptable_rules)
+run_on1 "sudo iptables -D FORWARD -o weave -j WEAVE-EXPOSE"
+wait_for_iptable_refresh
+IPT_AFTER=$(get_weave_iptable_rules)
+assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 1
+stop_weave_on1
+
+## Check refreshing
+weave_on1 "launch --iptables-refresh-interval=1s"
+weave_on1 "expose"
+IPT_BEFORE=$(get_weave_iptable_rules)
+run_on1 "sudo iptables -D FORWARD -o weave -j WEAVE-EXPOSE"
+wait_for_iptable_refresh
+IPT_AFTER=$(get_weave_iptable_rules)
+assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 0
+stop_weave_on1
+
+end_suite

--- a/test/135_expose_iptables_refresh.sh
+++ b/test/135_expose_iptables_refresh.sh
@@ -19,24 +19,14 @@ get_weave_iptable_rules() {
 }
 
 wait_for_iptable_refresh() {
-    sleep 2
+    # Canary is checked every 10s
+    sleep 12
 }
 
 start_suite "exposing weave network to host"
 
 # Launch
-
-## Check no refreshing
-weave_on1 "launch --iptables-refresh-interval=0s"
-IPT_BEFORE=$(get_weave_iptable_rules)
-run_on1 "sudo iptables -t nat -X WEAVE-CANARY"
-wait_for_iptable_refresh
-IPT_AFTER=$(get_weave_iptable_rules)
-assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 1
-stop_weave_on1
-
-## Check refreshing
-weave_on1 "launch --iptables-refresh-interval=1s"
+weave_on1 "launch"
 IPT_BEFORE=$(get_weave_iptable_rules)
 run_on1 "sudo iptables -t nat -X WEAVE-CANARY"
 wait_for_iptable_refresh
@@ -44,20 +34,8 @@ IPT_AFTER=$(get_weave_iptable_rules)
 assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 0
 stop_weave_on1
 
-# Expose
-
-## Check no refreshing
-weave_on1 "launch --iptables-refresh-interval=0s"
-weave_on1 "expose"
-IPT_BEFORE=$(get_weave_iptable_rules)
-run_on1 "sudo iptables -t nat -X WEAVE-CANARY"
-wait_for_iptable_refresh
-IPT_AFTER=$(get_weave_iptable_rules)
-assert_raises "diff <(echo $IPT_BEFORE) <(echo $IPT_AFTER)" 1
-stop_weave_on1
-
-## Check refreshing
-weave_on1 "launch --iptables-refresh-interval=1s"
+# After exposing
+weave_on1 "launch"
 weave_on1 "expose"
 IPT_BEFORE=$(get_weave_iptable_rules)
 run_on1 "sudo iptables -t nat -X WEAVE-CANARY"


### PR DESCRIPTION
Adds a `CANARY` iptable chain and reloads all the weavenet iptable chains if the `CANARY` is removed by something (usually `firewalld`).

Partially addresses https://github.com/weaveworks/weave/issues/3586

### Details

- This exposes `ConfigureIPTables` and tries to make it safe to call again and again.
-  The destructive resets are pulled out into `ResetIPTables` and are called at launch so iptable state should remain mostly the same as prior to this PR.