### PR TITLE
metric for NPC errors

### DIFF
--- a/npc/metrics/metrics.go
+++ b/npc/metrics/metrics.go
@@ -22,6 +22,12 @@ var (
 		},
 		[]string{"protocol", "dport"},
 	)
+	PolicyEnforcementErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "weavenpc_policy_enforcement_errors",
+			Help: "Errors occured in enforcing the network policies.",
+		},
+	)
 )
 
 func gatherMetrics() {
@@ -93,6 +99,9 @@ func dstIP(packet gopacket.Packet) string {
 
 func Start(addr string) error {
 	if err := prometheus.Register(blockedConnections); err != nil {
+		return err
+	}
+	if err := prometheus.Register(PolicyEnforcementErrors); err != nil {
 		return err
 	}
 

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -34,7 +34,12 @@ var (
 	bridgePortName string
 )
 
-func handleError(err error) { common.CheckError(err) }
+func handleError(err error) {
+	if err != nil {
+		metrics.PolicyEnforcementErrors.Inc()
+		common.Log.Error(err)
+	}
+}
 
 func handleFatal(err error) { common.CheckFatal(err) }
 


### PR DESCRIPTION
Replacement for #3794 - this is a bit simpler and covers more errors.

Introduce `weavenpc_policy_enforcement_errors` Prometheus metric to track number of errors occured during enforcing network policies.

Fixes #3791