### PR TITLE
Block non-local traffic to the Weave control port

### DIFF
--- a/net/bridge.go
+++ b/net/bridge.go
@@ -469,6 +469,11 @@ func configureIPTables(config *BridgeConfig, ips ipset.Interface) error {
 		}
 	}
 
+	// Block non-local traffic to the Weave control port
+	if err = ipt.AppendUnique("filter", "INPUT", "-p", "tcp", "--dst", "127.0.0.1", "-m", "addrtype", "!", "--src-type", "LOCAL", "-m", "conntrack", "!", "--ctstate", "RELATED,ESTABLISHED", "-j", "DROP"); err != nil {
+		return err
+	}
+
 	if config.NPC {
 		// Steer traffic via the NPC.
 

--- a/weave
+++ b/weave
@@ -483,6 +483,7 @@ destroy_bridge() {
 
     [ -n "$DOCKER_BRIDGE_IP" ] || DOCKER_BRIDGE_IP=$(util_op bridge-ip $DOCKER_BRIDGE)
 
+    run_iptables -t filter -D INPUT -d 127.0.0.1/32 -p tcp -m addrtype ! --src-type LOCAL -m conntrack ! --ctstate RELATED,ESTABLISHED -j DROP >/dev/null 2>&1 || true
     run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p udp --dport 53  -j ACCEPT  >/dev/null 2>&1 || true
     run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p tcp --dport 53  -j ACCEPT  >/dev/null 2>&1 || true
 


### PR DESCRIPTION
We expect the loopback address 127.0.0.1 to only be accessible from the local host.
However under some Linux configurations it can be accessed remotely. https://github.com/kubernetes/kubernetes/issues/90259

Add an iptables rule to block this case.
