### PR TITLE
router: tell goroutine to exit when forwarder is stopped

### DIFF
--- a/router/overlay_switch.go
+++ b/router/overlay_switch.go
@@ -452,6 +452,7 @@ func (fwd *overlaySwitchForwarder) Stop() {
 	fwd.lock.Lock()
 	defer fwd.lock.Unlock()
 	fwd.stopFrom(0)
+	close(fwd.stopChan)
 }
 
 func (fwd *overlaySwitchForwarder) ControlMessage(tag byte, msg []byte) {


### PR DESCRIPTION
Otherwise a goroutine is leaked each time a connection is closed.
Fixes #3807 
