### PR TITLE
Move ansible install out from every CI run

### DIFF
--- a/bin/provision_test_vms.sh
+++ b/bin/provision_test_vms.sh
@@ -13,13 +13,6 @@ function install_terraform() {
     curl -fsS https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip | gunzip >terraform && chmod +x terraform && sudo mv terraform /usr/bin
 }
 
-function install_ansible() {
-    sudo apt-get update || true
-    sudo apt-get install -qq -y python-pip python-dev libffi-dev libssl-dev \
-        && pip install --user -U setuptools cffi \
-        && pip install --user ansible
-}
-
 [ -n "$SECRET_KEY" ] || {
     echo "Cannot run smoke tests: no secret key"
     exit 1
@@ -28,7 +21,6 @@ function install_ansible() {
 source "$SRCDIR/bin/circle-env"
 
 install_terraform
-install_ansible
 
 # Only attempt to create GCP image in first container, wait for it to be created otherwise:
 [ "$CIRCLE_NODE_INDEX" != "0" ] && export CREATE_IMAGE=0

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -66,7 +66,7 @@ function print_vars() {
 }
 
 function verify_dependencies() {
-    local deps=(python terraform ansible-playbook gcloud)
+    local deps=(python terraform gcloud)
     for dep in "${deps[@]}"; do
         if [ ! "$(which "$dep")" ]; then
             echo >&2 "$dep is not installed or not in PATH."
@@ -141,9 +141,18 @@ function wait_for_image() {
     exit 1
 }
 
+function install_ansible() {
+    sudo apt-get update || true
+    sudo apt-get install -qq -y python-pip python-dev libffi-dev libssl-dev \
+        && pip install --user -U setuptools cffi \
+        && pip install --user ansible
+}
+
 # shellcheck disable=SC2155
 function create_image() {
     if [[ "$CREATE_IMAGE" == 1 ]]; then
+        install_ansible
+
         greenly echo "> Creating GCP image $IMAGE_NAME..."
         local begin_img=$(date +%s)
         local num_hosts=1


### PR DESCRIPTION
Sparked by builds failing due to some tool no longer working with Python 2.

Move Ansible install to run only where need it, when we create VM images.
Bonus: this knocks about a minute off the run time!

(The image-creating part needs updates too - see #3687)
