### PR TITLE
Only drop traffic to the Weave Net port on 127.0.0.1

### DIFF
--- a/prog/weaver/main.go
+++ b/prog/weaver/main.go
@@ -307,6 +307,11 @@ func main() {
 
 	bridgeConfig.Mac = name.String()
 	bridgeConfig.Port = config.Port
+	if httpAddr != "" {
+		if _, port, err := net.SplitHostPort(httpAddr); err == nil {
+			bridgeConfig.ControlPort = port
+		}
+	}
 	ips := ipset.New(common.LogLogger(), 0)
 	bridgeType, err := weavenet.EnsureBridge(procPath, &bridgeConfig, Log, ips)
 	checkFatal(err)

--- a/weave
+++ b/weave
@@ -483,7 +483,7 @@ destroy_bridge() {
 
     [ -n "$DOCKER_BRIDGE_IP" ] || DOCKER_BRIDGE_IP=$(util_op bridge-ip $DOCKER_BRIDGE)
 
-    run_iptables -t filter -D INPUT -d 127.0.0.1/32 -p tcp -m addrtype ! --src-type LOCAL -m conntrack ! --ctstate RELATED,ESTABLISHED -j DROP >/dev/null 2>&1 || true
+    run_iptables -t filter -D INPUT -d 127.0.0.1/32 -p tcp --dport 6784 -m addrtype ! --src-type LOCAL -m conntrack ! --ctstate RELATED,ESTABLISHED -m comment --comment "Block non-local access to Weave Net control port" -j DROP >/dev/null 2>&1 || true
     run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p udp --dport 53  -j ACCEPT  >/dev/null 2>&1 || true
     run_iptables -t filter -D INPUT -i $DOCKER_BRIDGE -p tcp --dport 53  -j ACCEPT  >/dev/null 2>&1 || true
 


### PR DESCRIPTION
Only block the specific port Weave Net is listening on.
Add a comment so users know what the rule is for.

Remove the rule added in v2.6.3 because it was too coarse.

Fixes #3810 
