### PR TITLE
Don't exit if machine has no ipv6 installed

### DIFF
--- a/net/arp.go
+++ b/net/arp.go
@@ -41,3 +41,11 @@ func sysctl(procPath, variable, value string) error {
 
 	return nil
 }
+
+func sysctlIfExists(procPath, variable, value string) error {
+	err := sysctl(procPath, variable, value)
+	if err != nil && os.IsNotExist(err) {
+		err = nil // ignore 'not found' errors
+	}
+	return err
+}

--- a/net/bridge.go
+++ b/net/bridge.go
@@ -281,7 +281,7 @@ func EnsureBridge(procPath string, config *BridgeConfig, log *logrus.Logger, ips
 		}
 	}
 	// No ipv6 router advertisments please
-	if err := sysctl(procPath, "net/ipv6/conf/"+config.WeaveBridgeName+"/accept_ra", "0"); err != nil {
+	if err := sysctlIfExists(procPath, "net/ipv6/conf/"+config.WeaveBridgeName+"/accept_ra", "0"); err != nil {
 		return bridgeType, errors.Wrap(err, "setting accept_ra to 0")
 	}
 

--- a/net/veth.go
+++ b/net/veth.go
@@ -50,10 +50,10 @@ func CreateAndAttachVeth(procPath, name, peerName, bridgeName string, mtu int, k
 		return cleanup("attaching veth %q to %q: %s", name, bridgeName, err)
 	}
 	// No ipv6 router advertisments please
-	if err := sysctl(procPath, "net/ipv6/conf/"+name+"/accept_ra", "0"); err != nil {
+	if err := sysctlIfExists(procPath, "net/ipv6/conf/"+name+"/accept_ra", "0"); err != nil {
 		return cleanup("setting accept_ra to 0: %s", err)
 	}
-	if err := sysctl(procPath, "net/ipv6/conf/"+peerName+"/accept_ra", "0"); err != nil {
+	if err := sysctlIfExists(procPath, "net/ipv6/conf/"+peerName+"/accept_ra", "0"); err != nil {
 		return cleanup("setting accept_ra to 0: %s", err)
 	}
 	if !bridgeType.IsFastdp() && !keepTXOn {


### PR DESCRIPTION
We are trying to turn off `accept_ra`, so if we get an error that the option doesn't exist we can just ignore it.

Fixes #3814