### PR TITLE
Fix nil pointer panic in npc/namespace.go

### DIFF
--- a/npc/controller.go
+++ b/npc/controller.go
@@ -60,9 +60,9 @@ func New(nodeName string, ipt iptables.Interface, ips ipset.Interface, clientset
 
 func (npc *controller) onNewNsSelector(selector *selector) error {
 	for _, ns := range npc.nss {
-		if ns.namespace != nil {
-			if selector.matchesNamespaceSelector(ns.namespace.ObjectMeta.Labels) {
-				if err := selector.addEntry(ns.namespace.ObjectMeta.UID, string(ns.allPods.ipsetName), namespaceComment(ns)); err != nil {
+		if ns.namespaceUID != "" {
+			if selector.matchesNamespaceSelector(ns.namespaceLabels) {
+				if err := selector.addEntry(ns.namespaceUID, string(ns.allPods.ipsetName), namespaceComment(ns)); err != nil {
 					return err
 				}
 			}
@@ -73,10 +73,10 @@ func (npc *controller) onNewNsSelector(selector *selector) error {
 
 func (npc *controller) onNewNamespacePodsSelector(selector *selector) error {
 	for _, ns := range npc.nss {
-		if ns.namespace != nil && len(ns.pods) > 0 {
+		if ns.namespaceUID != "" && len(ns.pods) > 0 {
 			for _, pod := range ns.pods {
 				if hasIP(pod) {
-					if selector.matchesNamespacedPodSelector(pod.ObjectMeta.Labels, ns.namespace.ObjectMeta.Labels) {
+					if selector.matchesNamespacedPodSelector(pod.ObjectMeta.Labels, ns.namespaceLabels) {
 						if err := selector.addEntry(pod.ObjectMeta.UID, pod.Status.PodIP, podComment(pod)); err != nil {
 							return err
 						}

--- a/npc/controller_test.go
+++ b/npc/controller_test.go
@@ -155,6 +155,7 @@ func TestRegressionPolicyNamespaceOrdering3059(t *testing.T) {
 	sourceNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "source",
+			UID:  "source",
 			Labels: map[string]string{
 				"app": "source",
 			},
@@ -164,6 +165,7 @@ func TestRegressionPolicyNamespaceOrdering3059(t *testing.T) {
 	destinationNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "destination",
+			UID:  "destination",
 		},
 	}
 
@@ -244,6 +246,7 @@ func TestDefaultAllow(t *testing.T) {
 	defaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
+			UID:  "default",
 		},
 	}
 	controller.AddNamespace(defaultNamespace)
@@ -373,6 +376,7 @@ func TestOutOfOrderPodEvents(t *testing.T) {
 	defaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
+			UID:  "default",
 		},
 	}
 	client.CoreV1().Namespaces().Create(defaultNamespace)
@@ -457,6 +461,7 @@ func TestNewTargetSelector(t *testing.T) {
 	defaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
+			UID:  "default",
 		},
 	}
 	client.CoreV1().Namespaces().Create(defaultNamespace)
@@ -535,11 +540,13 @@ func TestEgressPolicyWithIPBlock(t *testing.T) {
 	defaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
+			UID:  "default",
 		},
 	}
 	nonDefaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "non-default",
+			UID:  "non-default",
 		},
 	}
 	client.CoreV1().Namespaces().Create(defaultNamespace)
@@ -630,6 +637,7 @@ func TestIngressPolicyWithIPBlockAndPortSpecified(t *testing.T) {
 	defaultNamespace := &coreapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
+			UID:  "default",
 		},
 	}
 


### PR DESCRIPTION
Try to solve this issue #3836 .

The `*coreapi.Namespace` in struct `ns` may be set to `nil` in func [`deleteNamespace`](https://github.com/weaveworks/weave/blob/1ff09fd4d1c52bfa49222b724742f7b4bb80543a/npc/namespace.go#L538) before func [`deletePod`](https://github.com/weaveworks/weave/blob/1ff09fd4d1c52bfa49222b724742f7b4bb80543a/npc/namespace.go#L320) called，it will cause a pinic when `deletePod` use the namespace pointer.

I use a new map to store the lables of namespace, when the pointer is set to nil, it can avoid panic and work well. 


```
DEBU: 2020/07/23 11:09:37.920737 EVENT DeletePod {"metadata":{"creationTimestamp":"2020-07-23T08:30:24Z","deletionGracePeriodSeconds":0,"deletionTimestamp":"2020-07-23T11:09:31Z","generateName":"bp-s2-745c79479b-","labels":{"App":"f43f2b4120f7e4adbb88ede557c74ec35","Blueprint":"bbp-s2","Service":"bp-s2","app":"bp-s2","flowid":"57","pod-template-hash":"745c79479b","version":"v1"},"name":"bp-s2-745c79479b-kq66f","namespace":"f43f2b4120f7e4adbb88ede557c74ec35","resourceVersion":"27784263","selfLink":"/api/v1/namespaces/f43f2b4120f7e4adbb88ede557c74ec35/pods/bp-s2-745c79479b-kq66f","uid":"9eb3ec80-d600-4d07-837f-7662cd6a3e0a"},"spec":{"affinity":{},"containers":[{"image":"harbor.cloud2go.cn/cloudtogo/network-multitool","imagePullPolicy":"Always","name":"bp-s2","ports":[{"containerPort":80,"name":"p80","protocol":"TCP"}],"readinessProbe":{"failureThreshold":3,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"tcpSocket":{"port":80},"timeoutSeconds":1},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"FallbackToLogsOnError"}],"dnsConfig":{"options":[{"name":"ndots","value":"1"}]},"dnsPolicy":"ClusterFirst","nodeName":"n1.env.lab.io","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"serviceAccount":"default","serviceAccountName":"default","terminationGracePeriodSeconds":0},"status":{"conditions":[{"lastProbeTime":null,"lastTransitionTime":"2020-07-23T08:30:24Z","status":"True","type":"Initialized"},{"lastProbeTime":null,"lastTransitionTime":"2020-07-23T08:31:48Z","status":"True","type":"Ready"},{"lastProbeTime":null,"lastTransitionTime":"2020-07-23T08:31:48Z","status":"True","type":"ContainersReady"},{"lastProbeTime":null,"lastTransitionTime":"2020-07-23T08:30:24Z","status":"True","type":"PodScheduled"}],"hostIP":"10.10.13.8","phase":"Running","podIP":"10.20.192.88","qosClass":"BestEffort","startTime":"2020-07-23T08:30:24Z"}}
INFO: 2020/07/23 11:09:37.939904 deleting entry 10.20.192.88 from weave-Cz*b([u5~[;?3vXY}8w6UH?f3 of 9eb3ec80-d600-4d07-837f-7662cd6a3e0a
INFO: 2020/07/23 11:09:37.939958 deleting entry 10.20.192.88 from weave-5$otwpJo/[g4!?%N8=f+9t=Au of 9eb3ec80-d600-4d07-837f-7662cd6a3e0a
INFO: 2020/07/23 11:09:37.939981 deleting entry 10.20.192.88 from weave-vfZR:H@W@vf0XI[v.hMddEGJF of 9eb3ec80-d600-4d07-837f-7662cd6a3e0a
INFO: 2020/07/23 11:09:37.940007 deleted entry 10.20.192.88 from weave-vfZR:H@W@vf0XI[v.hMddEGJF of 9eb3ec80-d600-4d07-837f-7662cd6a3e0a
ERROR: logging before flag.Parse: E0723 11:09:37.946420    1331 runtime.go:66] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/go/src/github.com/weaveworks/weave/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:72
/go/src/github.com/weaveworks/weave/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/go/src/github.com/weaveworks/weave/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/panic.go:679
/usr/local/go/src/runtime/panic.go:199
/usr/local/go/src/runtime/signal_unix.go:394
/go/src/github.com/weaveworks/weave/npc/namespace.go:336
/go/src/github.com/weaveworks/weave/npc/controller.go:144
/go/src/github.com/weaveworks/weave/npc/controller.go:106
/go/src/github.com/weaveworks/weave/npc/controller.go:143
/go/src/github.com/weaveworks/weave/prog/weave-npc/main.go:287
/go/src/github.com/weaveworks/weave/vendor/k8s.io/client-go/tools/cache/controller.go:209
/go/src/github.com/weaveworks/weave/vendor/k8s.io/client-go/tools/cache/controller.go:320
/go/src/github.com/weaveworks/weave/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:444
/go/src/github.com/weaveworks/weave/vendor/k8s.io/client-go/tools/cache/controller.go:150
/go/src/github.com/weaveworks/weave/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
/go/src/github.com/weaveworks/weave/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134
/go/src/github.com/weaveworks/weave/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
/go/src/github.com/weaveworks/weave/vendor/k8s.io/client-go/tools/cache/controller.go:124
/usr/local/go/src/runtime/asm_amd64.s:1357
```