### PR TITLE
Terminate NPC application if any of the watches panic

### DIFF
--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -216,17 +216,14 @@ func hCtx() context.Context {
 	return context.Background()
 }
 
-func stopOnPanicRecover(stopChan chan struct{}) {
+func stopOnPanicRecover() {
 	if r := recover(); r != nil {
 		os.Exit(1)
 	}
 }
 
 func root(cmd *cobra.Command, args []string) {
-	var (
-		npController cache.Controller
-		stopChan     chan struct{}
-	)
+	var npController cache.Controller
 
 	common.SetLogLevel(logLevel)
 	if nodeName == "" {
@@ -266,11 +263,11 @@ func root(cmd *cobra.Command, args []string) {
 	nsController := makeController(client.CoreV1().RESTClient(), "namespaces", &coreapi.Namespace{},
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				defer stopOnPanicRecover(stopChan)
+				defer stopOnPanicRecover()
 				handleError(npc.AddNamespace(hCtx(), obj.(*coreapi.Namespace)))
 			},
 			DeleteFunc: func(obj interface{}) {
-				defer stopOnPanicRecover(stopChan)
+				defer stopOnPanicRecover()
 				switch obj := obj.(type) {
 				case *coreapi.Namespace:
 					handleError(npc.DeleteNamespace(hCtx(), obj))
@@ -282,18 +279,18 @@ func root(cmd *cobra.Command, args []string) {
 				}
 			},
 			UpdateFunc: func(old, new interface{}) {
-				defer stopOnPanicRecover(stopChan)
+				defer stopOnPanicRecover()
 				handleError(npc.UpdateNamespace(hCtx(), old.(*coreapi.Namespace), new.(*coreapi.Namespace)))
 			}})
 
 	podController := makeController(client.CoreV1().RESTClient(), "pods", &coreapi.Pod{},
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				defer stopOnPanicRecover(stopChan)
+				defer stopOnPanicRecover()
 				handleError(npc.AddPod(hCtx(), obj.(*coreapi.Pod)))
 			},
 			DeleteFunc: func(obj interface{}) {
-				defer stopOnPanicRecover(stopChan)
+				defer stopOnPanicRecover()
 				switch obj := obj.(type) {
 				case *coreapi.Pod:
 					handleError(npc.DeletePod(hCtx(), obj))
@@ -305,17 +302,17 @@ func root(cmd *cobra.Command, args []string) {
 				}
 			},
 			UpdateFunc: func(old, new interface{}) {
-				defer stopOnPanicRecover(stopChan)
+				defer stopOnPanicRecover()
 				handleError(npc.UpdatePod(hCtx(), old.(*coreapi.Pod), new.(*coreapi.Pod)))
 			}})
 
 	npHandlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			defer stopOnPanicRecover(stopChan)
+			defer stopOnPanicRecover()
 			handleError(npc.AddNetworkPolicy(hCtx(), obj))
 		},
 		DeleteFunc: func(obj interface{}) {
-			defer stopOnPanicRecover(stopChan)
+			defer stopOnPanicRecover()
 			switch obj := obj.(type) {
 			case cache.DeletedFinalStateUnknown:
 				// We know this object has gone away, but its final state is no longer
@@ -327,7 +324,7 @@ func root(cmd *cobra.Command, args []string) {
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
-			defer stopOnPanicRecover(stopChan)
+			defer stopOnPanicRecover()
 			handleError(npc.UpdateNetworkPolicy(hCtx(), old, new))
 		},
 	}

--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
+	goruntime "runtime"
 	"syscall"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -218,7 +220,9 @@ func hCtx() context.Context {
 
 func stopOnPanicRecover() {
 	if r := recover(); r != nil {
-		os.Exit(1)
+		buf := make([]byte, 1<<20)
+		stacklen := goruntime.Stack(buf, false)
+		handleFatal(fmt.Errorf("panic: %v \n%s", r, buf[:stacklen]))
 	}
 }
 


### PR DESCRIPTION
This is #3792, rebased, squashed to remove back-steps, with a couple more commits to improve error reporting and remove an unnecessary variable.
Fixes #3764

Credit to @naemono

Work-around for https://github.com/kubernetes/client-go/issues/838 / https://github.com/kubernetes/kubernetes/issues/93641