### PR TITLE
Move egress logging rule beside drop rule

### DIFF
--- a/prog/weave-npc/main.go
+++ b/prog/weave-npc/main.go
@@ -193,7 +193,6 @@ func createBaseRules(ipt *iptables.IPTables, ips ipset.Interface) error {
 	ruleSpecs = append(ruleSpecs, [][]string{
 		{"-m", "state", "--state", "NEW", "-j", chains.EgressDefaultChain},
 		{"-m", "state", "--state", "NEW", "-m", "mark", "!", "--mark", npc.EgressMark, "-j", chains.EgressCustomChain},
-		{"-m", "state", "--state", "NEW", "-m", "mark", "!", "--mark", npc.EgressMark, "-j", "NFLOG", "--nflog-group", "86"},
 	}...)
 	if err := net.AddChainWithRules(ipt, npc.TableFilter, chains.EgressChain, ruleSpecs); err != nil {
 		return err


### PR DESCRIPTION
Otherwise we might log a blocked connection even though the packet was not dropped.

Noticed while investigating #3829 