### PR TITLE
Workaround to fix ipset conflict with iptables

### DIFF
--- a/prog/weave-kube/init.sh
+++ b/prog/weave-kube/init.sh
@@ -21,6 +21,8 @@ xt_set_exists() {
     fi
     iptables -w -F WEAVE-KUBE-TEST
     iptables -w -X WEAVE-KUBE-TEST
+    # delay to allow kernel to clean up - see https://github.com/weaveworks/weave/issues/3847
+    sleep 1
     ipset destroy weave-kube-test
     [ -z "$NOT_EXIST" ] || (echo "\"xt_set\" does not exist" >&2 && return 1)
 }


### PR DESCRIPTION
[Rebase of #3848 because the line affected has moved to a different file]

Sleep before ipset destroy in startup, otherwise the operation can sometimes fail - see https://github.com/weaveworks/weave/issues/3847
