### PR TITLE
Update Go to 1.15.6

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.6-buster
+FROM golang:1.15.6-buster
 
 # Support Raspberry Pi 2 and newer
 ENV GOARM 7


### PR DESCRIPTION
Makes the images about 5% smaller (82.6MB -> 78.7MB)
