### PR TITLE
Update daemonset manifest to mount /etc/machine-id

### DIFF
--- a/prog/weave-kube/weave-daemonset-k8s-1.11.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.11.yaml
@@ -169,6 +169,9 @@ items:
                 - name: dbus
                   mountPath: /host/var/lib/dbus
                   readOnly: true
+                - mountPath: /host/etc/machine-id
+                  name: cni-machine-id
+                  readOnly: true
                 - name: xtables-lock
                   mountPath: /run/xtables.lock
                   readOnly: false
@@ -216,6 +219,9 @@ items:
             - name: cni-conf
               hostPath:
                 path: /etc
+            - name: cni-machine-id
+              hostPath:
+                path: /etc/machine-id
             - name: dbus
               hostPath:
                 path: /var/lib/dbus

--- a/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.8.yaml
@@ -166,6 +166,9 @@ items:
                 - name: dbus
                   mountPath: /host/var/lib/dbus
                   readOnly: true
+                - mountPath: /host/etc/machine-id
+                  name: cni-machine-id
+                  readOnly: true
                 - name: xtables-lock
                   mountPath: /run/xtables.lock
                   readOnly: false
@@ -212,6 +215,9 @@ items:
             - name: cni-conf
               hostPath:
                 path: /etc
+            - name: cni-machine-id
+              hostPath:
+                path: /etc/machine-id
             - name: dbus
               hostPath:
                 path: /var/lib/dbus

--- a/prog/weave-kube/weave-daemonset-k8s-1.9.yaml
+++ b/prog/weave-kube/weave-daemonset-k8s-1.9.yaml
@@ -169,6 +169,9 @@ items:
                 - name: dbus
                   mountPath: /host/var/lib/dbus
                   readOnly: true
+                - mountPath: /host/etc/machine-id
+                  name: cni-machine-id
+                  readOnly: true
                 - name: xtables-lock
                   mountPath: /run/xtables.lock
                   readOnly: false
@@ -216,6 +219,9 @@ items:
             - name: cni-conf
               hostPath:
                 path: /etc
+            - name: cni-machine-id
+              hostPath:
+                path: /etc/machine-id
             - name: dbus
               hostPath:
                 path: /var/lib/dbus


### PR DESCRIPTION
Mounted as ReadOnly in order to minimize attack surface as in #3880

This fixes an issue I had running weave in a Kind cluster where `getOldStyleSystemUUID()` did not return any `uuid` as those files were not present inside the weave container. Because `/host/etc/machine-id` did not exist an attempt to read `/host/var/lib/dbus/machine-id` would be made but the host machine did not have a `/var/lib/dbus/machine-id` file. This would result in both `uuid` and `machineid` being "" and causing the container to exit. 

```
func getSystemUUID(hostRoot string) ([]byte, error) {
	uuid, err := getOldStyleSystemUUID()
	if err != nil && !os.IsNotExist(err) {
		return nil, err
	}
	machineid, err := ioutil.ReadFile(hostRoot + "/etc/machine-id")
	if os.IsNotExist(err) {
		machineid, err = ioutil.ReadFile(hostRoot + "/var/lib/dbus/machine-id")
	}
	if err != nil && !os.IsNotExist(err) {
		return nil, err
	}
	if len(uuid) == 0 && len(machineid) == 0 {
		return nil, errors.New("All system IDs are blank")
	}
	return append(machineid, uuid...), nil
}
```

My change attempts to maintain the spirit of #3880 by using a new hostPath volume to only mount `/etc/machine-id` from the host into the weave container. 