### PR TITLE
Issues/3964 - added how to encrypt traffic

### DIFF
--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -426,6 +426,41 @@ For example,
               value: 10.0.0.0/16
 ```
 
+The list of variables you can set is:
+
+* `CHECKPOINT_DISABLE` - if set to 1, disable checking for new Weave Net
+  versions (default is blank, i.e. check is enabled)
+* `CONN_LIMIT` - soft limit on the number of connections between
+  peers. Defaults to 200.
+* `HAIRPIN_MODE` - Weave Net defaults to enabling hairpin on the bridge side of
+  the `veth` pair for containers attached. If you need to disable hairpin, e.g. your
+  kernel is one of those that can panic if hairpin is enabled, then you can disable it
+  by setting `HAIRPIN_MODE=false`.
+* `IPALLOC_RANGE` - the range of IP addresses used by Weave Net
+  and the subnet they are placed in (CIDR format; default `10.32.0.0/12`)
+* `EXPECT_NPC` - set to 0 to disable Network Policy Controller (default is on)
+* `KUBE_PEERS` - list of addresses of peers in the Kubernetes cluster
+  (default is to fetch the list from the api-server)
+* `IPALLOC_INIT` - set the initialization mode of the [IP Address
+  Manager](/site/operational-guide/concepts.md#ip-address-manager)
+  (defaults to consensus amongst the `KUBE_PEERS`)
+* `WEAVE_EXPOSE_IP` - set the IP address used as a gateway from the
+  Weave network to the host network - this is useful if you are
+  configuring the addon as a static pod.
+* `WEAVE_METRICS_ADDR` - address and port that the Weave Net
+  daemon will serve Prometheus-style metrics on (defaults to 0.0.0.0:6782)
+* `WEAVE_STATUS_ADDR` - address and port that the Weave Net
+  daemon will serve status requests on (defaults to disabled)
+* `WEAVE_MTU` - Weave Net defaults to 1376 bytes, but you can set a
+  smaller size if your underlying network has a tighter limit, or set
+  a larger size for better performance if your network supports jumbo
+  frames - see [here](/site/tasks/manage/fastdp.md#mtu) for more
+  details.
+* `NO_MASQ_LOCAL` - set to 0 to disable preserving the client source IP address when
+  accessing Service annotated with `service.spec.externalTrafficPolicy=Local`.
+  This feature works only with Weave IPAM (default).
+* `IPTABLES_BACKEND` - set to `nft` to use `nftables` backend for `iptables` (default is `iptables`)
+
 ## <a name="securing-the-setup"></a> Securing the Setup
 
 You must pass the `password-secret` option as noted in the previous section to enable the data plane encryption; this is a recommended option in case you cannot be sure about the security of the fabric between your nodes.

--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -449,7 +449,7 @@ The list of variables you can set is:
   configuring the addon as a static pod.
 * `WEAVE_METRICS_ADDR` - address and port that the Weave Net
   daemon will serve Prometheus-style metrics on (defaults to 0.0.0.0:6782)
-* `WEAVE_PASSWORD` - password to use during session key generation to encrypt
+* `WEAVE_PASSWORD` - shared key to use during session key generation to encrypt
 traffic between peers.
 * `WEAVE_STATUS_ADDR` - address and port that the Weave Net
   daemon will serve status requests on (defaults to disabled).

--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -465,7 +465,7 @@ traffic between peers.
 
 ## <a name="securing-the-setup"></a> Securing the Setup
 
-You should set `WEAVE_PASSWORD` in the previous section to enable the data plane encryption; 
+You should set the environment variable `WEAVE_PASSWORD` as stated in the previous section to enable the data plane encryption; 
 this is a recommended option in case you cannot be sure about the security of the fabric between your nodes.
 
 A different option is to use `trusted-subnets` and whitelist only the subnets that host your k8s nodes. Mind that depending on your circumstances that might allow a malicious container running in your cluster to access the weave dataplane, still.

--- a/site/kubernetes/kube-addon.md
+++ b/site/kubernetes/kube-addon.md
@@ -449,8 +449,10 @@ The list of variables you can set is:
   configuring the addon as a static pod.
 * `WEAVE_METRICS_ADDR` - address and port that the Weave Net
   daemon will serve Prometheus-style metrics on (defaults to 0.0.0.0:6782)
+* `WEAVE_PASSWORD` - password to use during session key generation to encrypt
+traffic between peers.
 * `WEAVE_STATUS_ADDR` - address and port that the Weave Net
-  daemon will serve status requests on (defaults to disabled)
+  daemon will serve status requests on (defaults to disabled).
 * `WEAVE_MTU` - Weave Net defaults to 1376 bytes, but you can set a
   smaller size if your underlying network has a tighter limit, or set
   a larger size for better performance if your network supports jumbo
@@ -463,7 +465,8 @@ The list of variables you can set is:
 
 ## <a name="securing-the-setup"></a> Securing the Setup
 
-You must pass the `password-secret` option as noted in the previous section to enable the data plane encryption; this is a recommended option in case you cannot be sure about the security of the fabric between your nodes.
+You should set `WEAVE_PASSWORD` in the previous section to enable the data plane encryption; 
+this is a recommended option in case you cannot be sure about the security of the fabric between your nodes.
 
 A different option is to use `trusted-subnets` and whitelist only the subnets that host your k8s nodes. Mind that depending on your circumstances that might allow a malicious container running in your cluster to access the weave dataplane, still.
 


### PR DESCRIPTION
closes: #3964 

documenting available options and adding how to encrypt traffic

tested via 


```yaml
  containers:
            - name: weave
              command:
                - /home/weave/launch.sh
              env:
                - name: INIT_CONTAINER
                  value: "true"
                - name: WEAVE_PASSWORD
                  value: "wfvAwt7sj"
                - name: EXTRA_ARGS
                  value: "--log-level=debug"
```
and logs shows traffic enctryped

```bash
✗ k logs -f weave-net-b9jk2 -n kube-system                                                                                <aws:sts>
Defaulted container "weave" out of: weave, weave-npc, weave-init (init)
DEBU: 2022/11/22 17:26:21.687729 [kube-peers] Checking peer "1a:04:b1:a3:35:b4" against list &{[]}
Peer not in list; removing persisted data
INFO: 2022/11/22 17:26:21.808174 Command line options: map[conn-limit:200 datapath:datapath db-prefix:/weavedb/weave-net docker-api: expect-npc:true http-addr:127.0.0.1:6784 ipalloc-init:consensus=2 ipalloc-range:10.32.0.0/12 log-level:debug metrics-addr:0.0.0.0:6782 name:1a:04:b1:a3:35:b4 nickname:ip-192-168-107-175.eu-north-1.compute.internal no-dns:true no-masq-local:true port:6783]
INFO: 2022/11/22 17:26:21.808343 weave  git-34de0b10a69c
INFO: 2022/11/22 17:26:22.449899 Bridge type is bridged_fastdp
INFO: 2022/11/22 17:26:22.450094 Communication between peers via untrusted networks is encrypted.
```

